### PR TITLE
Fix GitHub linguist detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,3 +34,7 @@
 *.h filter=enforceTabSpace
 *.inl filter=enforceTabSpace
 *.c filter=enforceTabSpace
+
+# Github's linguist thinks these files are C++, even rename to h extension thinks it is Objective-C.
+# Since it is not compiler dependent for .inl extension. Let's ignore what language it is in.
+OOVPADatabase/* linguist-vendored


### PR DESCRIPTION
Resolve #5.
However there is some codes causing linguist to still think is C++. Eventually we will have the functions reformat to meet our requirement to work with Cxbx-Reloaded. At this state, it is shown as main C.