### PR TITLE
Fix warnings part 1

### DIFF
--- a/OOVPA.h
+++ b/OOVPA.h
@@ -75,21 +75,21 @@ typedef struct _LOVP
 
 // This XRefZero constant, when set in the OOVPA.XRefCount field,
 // indicates there are no {offset, XREF_*-enum} present in the OOVPA.
-#define XRefZero 0U
+#define XRefZero 0x00
 
 // This XRefOne constant, when set in the OOVPA.XRefCount field,
 // indicates the OOVPA contains one (1) {offset, XREF_* enum} pair.
-#define XRefOne 1U
+#define XRefOne 0x01
 
 // Sometimes, there can be more than one {Offset, XREF_*-enum}
 // pair at the start of the OOVPA's.
-#define XRefTwo 2U
-#define XRefThree 3U
+#define XRefTwo 0x02
+#define XRefThree 0x03
 
 // This XRefNoSaveIndex constant, when set in the OOVPA.XRefSaveIndex
 // field, functions as a marker indicating there's no XREF_* enum
 // defined for the OOVPA.
-#define XRefNoSaveIndex 0xFFFF
+#define XRefNoSaveIndex 0xFF
 
 // Macro used for storing an XRef {Offset, XREF}-Pair.
 //
@@ -118,7 +118,7 @@ typedef struct _LOOVPA
 } LOOVPA;
 
 #define OOVPA_XREF(Name, Version, Count, XRefSaveIndex, XRefCount)    \
-LOOVPA Name##_##Version = { Count, XRefCount, XRefSaveIndex, {
+LOOVPA Name##_##Version = { Count, XRefCount, (unsigned char)XRefSaveIndex, {
 
 #define OOVPA_NO_XREF(Name, Version, Count) \
 OOVPA_XREF(Name, Version, Count, XRefNoSaveIndex, XRefZero)

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -369,7 +369,7 @@ typedef enum _XRefDataBaseOffset
 	XREF_XAPI_GetTypeInformation,
 
 	XREF_COUNT // XREF_COUNT must always be last.
-	// Also, if XREF_COUNT > sizeof(uint16), enlarge struct OOVPA.XRefSaveIndex (and Value somehow)
+	// Also, if XREF_COUNT > sizeof(uint8), enlarge struct OOVPA.XRefSaveIndex (and Value somehow)
 } XRefDataBaseOffset;
 
 #define XREF_ADDR_UNDETERMINED -1


### PR DESCRIPTION
Enum is default to int, in C we can't force it to use different size. Type-cast is a requirement.

I already have a part 2 fix for remaining warnings. However, it is conflict with PR #12.

This resolve partial warning issues for issue #7.

It can be safely merge into master.