### PR TITLE
Register D3DRS_CullMode

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -723,6 +723,9 @@ bool XbSymbolScan(void* xbeData, xb_symbol_register_t register_func)
 
                                         XRefDataBase[XREF_D3DRS_CULLMODE] = DerivedAddr_D3DRS_CULLMODE;
                                     }
+
+									// Register the offset of D3DRS_CULLMODE, this can be used to programatically locate other render-states in the calling program
+									register_func(LibraryStr, LibraryFlag, "D3DRS_CULLMODE", DerivedAddr_D3DRS_CULLMODE, 0);
                                 }
 
                                 // Derive address of EmuD3DDeferredRenderState from D3DRS_CULLMODE


### PR DESCRIPTION
I came up with a solution to auto-detect and fix an incorrect detection of EmuD3DDeferredRenderState within Cxbx-Reloaded, however, it requires that the offset of the derived D3DRS_CULLMODE symbol is passed to the emulator.

This PR makes that happen.

The Cxbx-R side will be pushed shortly: Just note that Cxbx-R uses this information to automatically correct a broken EmuD3DDeferredRenderState, as well as show a notification to submit an issue to fix it upstream in XbSymbolDatabase: This is beneficial for everyone.