### PR TITLE
Cleanup for non-Windows platfoms and non-MSVC compilers

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -203,7 +203,7 @@ const char* XbSymbolLibraryToString(uint32_t library_flag)
     }
 }
 
-inline uint32_t XbSymbolLibrayToFlag(const char* library_name)
+uint32_t XbSymbolLibrayToFlag(const char* library_name)
 {
     if (strncmp(library_name, Lib_D3D8, 8) == 0) {
         return XbSymbolLib_D3D8;
@@ -246,14 +246,14 @@ inline uint32_t XbSymbolLibrayToFlag(const char* library_name)
 
 // NOTE: PatrickvL state the arguments are named differently and the function does something that has another meaning,
 //       the implementation could be changed if the need ever arises.
-inline void GetXRefEntry(OOVPA *oovpa, int index, uint32_t* xref_out, uint8_t* offset_out) 
+static inline void GetXRefEntry(OOVPA *oovpa, int index, uint32_t* xref_out, uint8_t* offset_out) 
 {
     // Note : These are stored swapped by the XREF_ENTRY macro, hence this difference from GetOovpaEntry :
     *xref_out = (unsigned int)((LOOVPA*)oovpa)->Lovp[index].Offset;
     *offset_out = ((LOOVPA*)oovpa)->Lovp[index].Value;
 }
 
-inline void GetOovpaEntry(OOVPA *oovpa, int index, uint32_t* offset_out, uint8_t* value_out)
+static inline void GetOovpaEntry(OOVPA *oovpa, int index, uint32_t* offset_out, uint8_t* value_out)
 {
     *offset_out = (unsigned int)((LOOVPA*)oovpa)->Lovp[index].Offset;
     *value_out = ((LOOVPA*)oovpa)->Lovp[index].Value;

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -37,7 +37,7 @@
 // * Xbox Symbol Database
 // ******************************************************************
 
-#include "xbSymbolDatabase.h"
+#include "XbSymbolDatabase.h"
 #include "Xbe.h"
 
 // ******************************************************************
@@ -49,7 +49,7 @@
 #include "OOVPADatabase/D3D8LTCG.OOVPA.inl"
 #include "OOVPADatabase/DSound.OOVPA.inl"
 #include "OOVPADatabase/XG.OOVPA.inl"
-#include "OOVPADatabase/XNET.OOVPA.inl"
+#include "OOVPADatabase/XNet.OOVPA.inl"
 #include "OOVPADatabase/XOnline.OOVPA.inl"
 #include "OOVPADatabase/XactEng.OOVPA.inl"
 

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -445,7 +445,7 @@ bool XbSymbolScanSection(uint32_t xbe_base_address, uint32_t xbe_size, const cha
 /// </summary>
 /// <param name="library_name">Input library name string.</param>
 /// <returns>Return 0 if does not in the database. Otherwise will return flag value.</returns>
-inline uint32_t XbSymbolLibrayToFlag(const char* library_name);
+uint32_t XbSymbolLibrayToFlag(const char* library_name);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Fix case-sensitive include-path: Unlike Windows, some platforms are case-sensitive. So the include path must be written properly
- Fix use of the `inline` keyword: The inline keyword has a different meaning in different versions of C. I turned the functions which are only in one compilation unit into `static inline`. The function which isn't accessible from elsewhere isn't `inline` anymore.

The code is untested, because there's many other issues in the codebase, and I don't have 32 bit compatibility to test XbSymbolDatabase at all (See issue 25 about x64 support).