### PR TITLE
Support 64-bit program and outside hardcode xbox base memory range

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -308,9 +308,9 @@ bool CompareOOVPAToAddress(OOVPA *Oovpa, memptr_t cur, uintptr_t xb_start_virt_a
 
 // locate the given function, searching within lower and upper bounds
 void* XbSymbolLocateFunction(OOVPA *Oovpa,
-                                memptr_t lower,
-                                memptr_t upper,
-                                uintptr_t xb_start_virtual_addr)
+                             memptr_t lower,
+                             memptr_t upper,
+                             uintptr_t xb_start_virtual_addr)
 {
 
     // skip out if this is an unnecessary search
@@ -548,7 +548,8 @@ bool XbSymbolScanSection(uint32_t xbe_base_address,
 
 bool XbSymbolInit(const void* xb_header_addr,
                   xb_symbol_register_t register_func,
-                  bool* pbDSoundLibHeader) {
+                  bool* pbDSoundLibHeader)
+{
     if (xb_header_addr == (void*)0 || register_func == 0) {
         return 0;
     }

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -1140,8 +1140,8 @@ bool XbSymbolScanInternal(const void* xbeData,
     return 1;
 }
 
-bool XbSymbolScanRunTime(const void* xbeData,
-                         xb_symbol_register_t register_func)
+bool XbSymbolScanRunTimeMemory(const void* xbeData,
+                               xb_symbol_register_t register_func)
 {
     return XbSymbolScanInternal(xbeData, register_func, true);
 }

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -1072,7 +1072,7 @@ bool XbSymbolScanInternal(const void* xbeData,
                             if (strncmp(SectionName, Sec_D3D, 8) == 0) {
 
                                 if (isRunTime) {
-                                    // if an emulator did not load a section, then skip the section scan.
+                                    // if an xbe executable did not load a section, then skip the section scan.
                                     if (pSectionHeaders[s].dwSectionRefCount == 0) {
                                         continue;
                                     }

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -1145,7 +1145,7 @@ bool XbSymbolScanRunTime(const void* xbeData,
 {
     return XbSymbolScanInternal(xbeData, register_func, true);
 }
-bool XbSymbolScanFileImage(const void* xbeData,
+bool XbSymbolScanRawFileMemory(const void* xbeData,
                   xb_symbol_register_t register_func)
 {
     return XbSymbolScanInternal(xbeData, register_func, false);

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -429,8 +429,8 @@ typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_f
 /// <param name="xbeData">Starting point of xbe memory address.</param>
 /// <param name="register_func">Callback register function to be call for any detected symbols.</param>
 /// <returns>Only return false if something is not valid.</returns>
-bool XbSymbolScanRunTime(const void* xbeData, xb_symbol_register_t register_func);
-#define XbSymbolScan XbSymbolScanRunTime
+bool XbSymbolScanRunTimeMemory(const void* xbeData, xb_symbol_register_t register_func);
+#define XbSymbolScan XbSymbolScanRunTimeMemory
 
 /// <summary>
 /// To scan symbols in Xbe's file image.

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -424,21 +424,13 @@ void XbSymbolSetOutputMessage(xb_output_message_t message_func);
 typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_flag, const char* symbol_str, xbaddr address, uint32_t revision);
 
 /// <summary>
-/// To scan symbols in runtime xbe usage.
+/// To scan symbols in memory of raw xbe or host's virtual xbox environment.
 /// </summary>
-/// <param name="xbeData">Starting point of xbe memory address.</param>
+/// <param name="xb_header_addr">Starting point of xbox header address.</param>
 /// <param name="register_func">Callback register function to be call for any detected symbols.</param>
+/// <param name="is_raw">True: Full scan of raw xbe; False: Scan only loaded sections.</param>
 /// <returns>Only return false if something is not valid.</returns>
-bool XbSymbolScanRunTimeMemory(const void* xbeData, xb_symbol_register_t register_func);
-#define XbSymbolScan XbSymbolScanRunTimeMemory
-
-/// <summary>
-/// To scan symbols in Xbe's file image.
-/// </summary>
-/// <param name="xbeData">Starting point of xbe memory address.</param>
-/// <param name="register_func">Callback register function to be call for any detected symbols.</param>
-/// <returns>Only return false if something is not valid.</returns>
-bool XbSymbolScanRawFileMemory(const void* xbeData, xb_symbol_register_t register_func);
+bool XbSymbolScan(const void* xb_header_addr, xb_symbol_register_t register_func, bool is_raw);
 
 /* NOTE: Do not use this function, It is currently not functional and optimized at the moment.
 /// <summary>

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -438,7 +438,7 @@ bool XbSymbolScanRunTime(const void* xbeData, xb_symbol_register_t register_func
 /// <param name="xbeData">Starting point of xbe memory address.</param>
 /// <param name="register_func">Callback register function to be call for any detected symbols.</param>
 /// <returns>Only return false if something is not valid.</returns>
-bool XbSymbolScanFileImage(const void* xbeData, xb_symbol_register_t register_func);
+bool XbSymbolScanRawFileMemory(const void* xbeData, xb_symbol_register_t register_func);
 
 /* NOTE: Do not use this function, It is currently not functional and optimized at the moment.
 /// <summary>

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -420,12 +420,21 @@ void XbSymbolSetOutputMessage(xb_output_message_t message_func);
 typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_flag, const char* symbol_str, uint32_t address, uint32_t revision);
 
 /// <summary>
-/// To scan symbols for Xbe's file.
+/// To scan symbols in runtime xbe usage.
 /// </summary>
 /// <param name="xbeData">Starting point of xbe memory address.</param>
 /// <param name="register_func">Callback register function to be call for any detected symbols.</param>
 /// <returns>Only return false if something is not valid.</returns>
-bool XbSymbolScan(const void* xbeData, xb_symbol_register_t register_func);
+bool XbSymbolScanRunTime(const void* xbeData, xb_symbol_register_t register_func);
+#define XbSymbolScan XbSymbolScanRunTime
+
+/// <summary>
+/// To scan symbols in Xbe's file image.
+/// </summary>
+/// <param name="xbeData">Starting point of xbe memory address.</param>
+/// <param name="register_func">Callback register function to be call for any detected symbols.</param>
+/// <returns>Only return false if something is not valid.</returns>
+bool XbSymbolScanFileImage(const void* xbeData, xb_symbol_register_t register_func);
 
 /* NOTE: Do not use this function, It is currently not functional and optimized at the moment.
 /// <summary>

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -378,6 +378,10 @@ typedef enum _xb_output_message {
     XB_OUTPUT_MESSAGE_DEBUG
 } xb_output_message;
 
+#ifndef xbaddr
+typedef uint32_t xbaddr;
+#endif
+
 // ******************************************************************
 // * API functions to use with other projects.
 // ******************************************************************
@@ -415,9 +419,9 @@ void XbSymbolSetOutputMessage(xb_output_message_t message_func);
 /// <param name="library_str">Name of the library in string.</param>
 /// <param name="library_flag">Name of the library in flag.</param>
 /// <param name="symbol_str">Name of the library in symbol string.</param>
-/// <param name="address">TBD.</param>
+/// <param name="address">Return xbox's virtual address.</param>
 /// <param name="revision">Found with specific revision.</param>
-typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_flag, const char* symbol_str, uint32_t address, uint32_t revision);
+typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_flag, const char* symbol_str, xbaddr address, uint32_t revision);
 
 /// <summary>
 /// To scan symbols in runtime xbe usage.


### PR DESCRIPTION
Finally, 64-bit program and no restriction on memory range are supported.

using XbSymbolScan function is deprecated. Recommendation are:
* XbSymbolScanFileImage (full file image scan purpose)
* XbSymbolScanRunTime (scan runtime xbe by an emulator or the like)

resolve #25

P.S. Any extended concern or found something off (anything really). Feel free to comment below.