### PR TITLE
Generic CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# CMakeList.txt : CMake project for XbSymbolSymbolDatabase, include source and define
+# project specific logic here.
+#
+cmake_minimum_required (VERSION 3.8)
+
+project (XbSymbolDatabase)
+
+file(GLOB SOURCES "XbSymbolDatabase.c" "OOVPADatabase/*.inl")
+
+add_library (XbSymbolDatabase ${SOURCES})


### PR DESCRIPTION
By include CMakeLists.txt file, any third-party using CMake can directly include this file without a hassle.

(Part of a requirement for XbSymbolCacheGenTest project.)