### PR TITLE
Fix GNU compiler support

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -1268,7 +1268,7 @@ void HLEError(SymbolDatabaseVerifyContext *context, uint16_t buildVersion, char 
     }
 
     if (context->against != NULL && context->against_data != NULL) {
-        (void)strncat(buffer, ", comparing against ", OOVPA_TABLE_COUNT(", comparing against "));
+        (void)strcat(buffer, ", comparing against ");
 
         ret_str_count = HLEErrorString(bufferTemp, context->against_data, buildVersion, context->against_index);
         (void)strncat(buffer, bufferTemp, ret_str_count);
@@ -1281,7 +1281,7 @@ void HLEError(SymbolDatabaseVerifyContext *context, uint16_t buildVersion, char 
     va_end(args);
 
 
-    (void)strncat(buffer, " : ", 3);
+    (void)strcat(buffer, " : ");
     (void)strncat(buffer, bufferTemp, ret_str_count);
 
     if (output_func != NULL) {

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -34,6 +34,29 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdint.h>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+static inline uint32_t BitScanReverse(uint32_t value)
+{
+    uint32_t index;
+    if (!_BitScanReverse(&index, value)) {
+        return 32;
+    }
+    return index;
+}
+#elif __GNUC__
+static inline uint32_t BitScanReverse(uint32_t value)
+{
+    if (value == 0) {
+        return 32;
+    }
+    return 31 - __builtin_clz(value);
+}
+#else
+#error Unsupported platform
+#endif
 
 // ******************************************************************
 // * Xbox Symbol Database
@@ -361,8 +384,8 @@ void* XbSymbolLocateFunction(OOVPA *Oovpa,
                 uint8_t Offset;
                 uint32_t derive_index;
 
-                // Extract an index from the indices mask :
-                _BitScanReverse(&derive_index, derive_indices); // MSVC intrinsic; GCC has __builtin_clz
+                // Extract an index from the indices mask
+                derive_index = BitScanReverse(derive_indices);
                 derive_indices ^= (1 << derive_index);
 
                 // get currently registered (un)known address


### PR DESCRIPTION
This should affect GCC, and probably also Clang (not sure if the preprocessor checks are good).

Commits are self-explanatory:

- `_BitScanReverse` does not exist in the GCC world. The zero-case is never encountered, but I added it for completeness; it returns 32 (which means the first set bit is not within the lower 32 bits).
- `strncat` with `n == sizeof(src)` gives a warning (as zero included - it was still initialized and appended though). There's no good reason to use `strncat` as `strcat` behaves the same. The `strncat` using `OOVPA_TABLE_COUNT` was even worse, as there's no reason this should be done; its only job was a cryptic form of `strlen("string") + 1`.

**Please confirm I did not break Windows support.**
Ideally someone would also test on macOS or using another clang implementation.

*(I did not add myself to the copyright list as this doesn't really have anything that qualifies for that. Please tell me if I should still do it)*