### PR TITLE
Some Debug Updates

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -1170,6 +1170,8 @@ bool XbSymbolScan(const void* xb_header_addr,
                                 if (SymbolDBList[d2].LibSec.section[d3] != NULL && strncmp(SectionName, SymbolDBList[d2].LibSec.section[d3], 8) == 0) {
                                     pSectionScan = pSectionHeaders + s;
 
+                                    XbSymbolOutputMessageFormat(XB_OUTPUT_MESSAGE_DEBUG, "Scanning %.8s library in %.8s section", LibraryStr, SectionName);
+
                                     XbSymbolScanOOVPA(SymbolDBList[d2].OovpaTable, SymbolDBList[d2].OovpaTableCount, LibraryStr, SymbolDBList[d2].LibSec.library,
                                                         pSectionScan, BuildVersion, register_func, xb_start_virt_addr);
                                     break;

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -387,6 +387,7 @@ void* XbSymbolLocateFunction(OOVPA *Oovpa,
         return 0;
 
     uint32_t derive_indices = 0;
+
     // Check all XRefs are known (if not, don't do a useless scan) :
     for (unsigned int v = 0; v < Oovpa->XRefCount; v++) {
         uint32_t XRef;
@@ -419,7 +420,7 @@ void* XbSymbolLocateFunction(OOVPA *Oovpa,
     }
 
     // search all of the image memory
-    for (memptr_t cur = lower; cur < upper; cur++)
+    for (memptr_t cur = lower; cur < upper; cur++) {
         if (CompareOOVPAToAddress(Oovpa, cur, xb_start_virtual_addr)) {
 
             while (derive_indices > 0) {
@@ -455,6 +456,7 @@ void* XbSymbolLocateFunction(OOVPA *Oovpa,
 
             return cur - xb_start_virtual_addr;
         }
+    }
 
     // found nothing
     return 0;
@@ -528,8 +530,9 @@ void XbSymbolScanOOVPA(OOVPATable *OovpaTable,
 
         // Search for each function's location using the OOVPA
         xbaddr pFunc = (xbaddr)(uintptr_t)XbSymbolLocateFunction(pLoop->Oovpa, lower, upper, (uintptr_t)xb_start_virt_addr);
-        if (pFunc == 0)
+        if (pFunc == 0) {
             continue;
+        }
 
         if (pFunc == pLastKnownFunc && pLastKnownSymbol == pLoop - 1) {
             //if (g_SymbolAddresses[pLastKnownSymbol->szFuncName] == 0) {
@@ -544,6 +547,7 @@ void XbSymbolScanOOVPA(OOVPATable *OovpaTable,
         pLastKnownFunc = pFunc;
         pLastKnownSymbol = pLoop;
     }
+
     if (pLastKnownSymbol != NULL) {
         XbSymbolRegisterSymbol(pLastKnownSymbol, LibraryName, LibraryFlag, pLastKnownFunc, register_func);
     }
@@ -848,7 +852,7 @@ void XbSymbolDX8SectionScan(uint32_t LibraryFlag,
         if (BuildVersion < 3911) {
             // Not supported, currently ignored.
         }
-        if (BuildVersion < 4034) {
+        else if (BuildVersion < 4034) {
             pFunc = XbSymbolLocateFunctionCast(&D3DDevice_SetRenderState_CullMode_3911, lower, upper, xb_start_virt_addr);
         }
         else {

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -469,6 +469,7 @@ void XbSymbolScanOOVPA(OOVPATable *OovpaTable,
     OOVPATable *pLastKnownSymbol = NULL;
     uint32_t pLastKnownFunc = 0;
     const char *SymbolName = NULL;
+    char output[2048];
     for (; pLoop < pLoopEnd; pLoop++) {
 
         if (SymbolName == NULL) {
@@ -494,10 +495,14 @@ void XbSymbolScanOOVPA(OOVPATable *OovpaTable,
 
         if (pFunc == pLastKnownFunc && pLastKnownSymbol == pLoop - 1) {
             //if (g_SymbolAddresses[pLastKnownSymbol->szFuncName] == 0) {
-                char output[2048];
                 sprintf(output, "Duplicate OOVPA signature found for %s, %hd vs %hd!", pLastKnownSymbol->szFuncName, pLastKnownSymbol->Version, pLoop->Version);
                 XbSymbolOutputMessage(XB_OUTPUT_MESSAGE_WARN, output);
             //}
+        }
+
+        if (buildVersion < pLoop->Version) {
+            sprintf(output, "OOVPA signature is too high for [%hd] %s!", pLoop->Version, pLoop->szFuncName);
+            XbSymbolOutputMessage(XB_OUTPUT_MESSAGE_WARN, output);
         }
 
         pLastKnownFunc = pFunc;

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -158,6 +158,11 @@ xbaddr XRefDataBase[XREF_COUNT] = { 0 }; // Reset and populated by EmuHLEInterce
 bool bXRefFirstPass; // For search speed optimization, set in XbSymbolScan, read in XbSymbolLocateFunction
 unsigned int UnResolvedXRefs = XREF_COUNT;
 bool bStrictBuildVersionLimit = false;
+#if _DEBUG
+xb_output_message output_verbose_level = XB_OUTPUT_MESSAGE_DEBUG;
+#else
+xb_output_message output_verbose_level = XB_OUTPUT_MESSAGE_INFO;
+#endif
 
 
 // ******************************************************************
@@ -182,6 +187,16 @@ void XbSymbolSetOutputMessage(xb_output_message_t message_func)
     output_func = message_func;
 }
 
+bool XbSymbolSetOutputVerbosity(xb_output_message verbose_level)
+{
+    if (verbose_level < XB_OUTPUT_MESSAGE_MAX) {
+        output_verbose_level = verbose_level;
+        return true;
+    }
+    // Return false only when requested level is invalid.
+    return false;
+}
+
 void XbSymbolBypassBuildVersionLimit(bool bypass_limit)
 {
     bStrictBuildVersionLimit = !bypass_limit;
@@ -193,7 +208,8 @@ void XbSymbolBypassBuildVersionLimit(bool bypass_limit)
 void XbSymbolOutputMessage(xb_output_message mLevel, const char* message)
 {
     // Check if output function is set.
-    if (output_func != NULL) {
+    // Plus if pass minimum verbose level to output.
+    if (output_func != NULL && mLevel >= output_verbose_level) {
         output_func(mLevel, message);
     }
 }
@@ -204,7 +220,8 @@ void XbSymbolOutputMessageFormat(xb_output_message mLevel, const char* format, .
     char bufferTemp[2048];
 
     // Check if output function is set.
-    if (output_func != NULL) {
+    // Plus if pass minimum verbose level to output.
+    if (output_func != NULL && mLevel >= output_verbose_level) {
         va_list args;
         va_start(args, format);
         (void)vsprintf(bufferTemp, format, args);

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -395,10 +395,12 @@ typedef enum _XRefDataBaseOffset
 #define XREF_ADDR_DERIVE 1
 
 typedef enum _xb_output_message {
-    XB_OUTPUT_MESSAGE_INFO=0,
+    XB_OUTPUT_MESSAGE_DEBUG=0,
+    XB_OUTPUT_MESSAGE_INFO,
     XB_OUTPUT_MESSAGE_WARN,
     XB_OUTPUT_MESSAGE_ERROR,
-    XB_OUTPUT_MESSAGE_DEBUG
+    // Only for internal usage.
+    XB_OUTPUT_MESSAGE_MAX
 } xb_output_message;
 
 #ifndef xbaddr
@@ -488,6 +490,13 @@ unsigned int XbSymbolDataBaseTestOOVPAs();
 /// </summary>
 /// <param name="bypass_limit">Input boolean to either bypass or enable the build version limit.</param>
 void XbSymbolBypassBuildVersionLimit(bool bypass_limit);
+
+/// <summary>
+/// To set verbose level can be output message.
+/// By default, release build is set to info+ level and debug build is set to debug+ level.
+/// </summary>
+/// <param name="verbose_level">See xb_output_message enum for list of options.</param>
+bool XbSymbolSetOutputVerbosity(xb_output_message verbose_level);
 
 #ifdef __cplusplus
 }

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -479,7 +479,7 @@ bool XbSymbolScanSection(uint32_t xbe_base_address, uint32_t xbe_size, const cha
 uint32_t XbSymbolLibrayToFlag(const char* library_name);
 
 /// <summary>
-/// By calling it will perform a self test for duplicate OOVPAs. (May will change at any time.)
+/// (Debug feature) By calling it will perform a self test for duplicate OOVPAs. (May will change at any time.)
 /// </summary>
 /// <returns>Return total count of errors.</returns>
 unsigned int XbSymbolDataBaseTestOOVPAs();

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -423,7 +423,7 @@ unsigned int XbSymbolLibraryVersion();
 bool XbSymbolRegisterLibrary(uint32_t library_flag);
 
 /// <summary>
-/// To register any detected symbol name with address and revision back to third-party program.
+/// To register any detected symbol name with address and build version back to third-party program.
 /// NOTE: Be aware of library name will be varity since some libraries are detecting in other sections as well.
 /// </summary>
 /// <param name="library_str">Name of the library in string.</param>
@@ -436,15 +436,15 @@ typedef void(*xb_output_message_t)(xb_output_message message_flag, const char* m
 void XbSymbolSetOutputMessage(xb_output_message_t message_func);
 
 /// <summary>
-/// To register any detected symbol name with address and revision back to third-party program.
+/// To register any detected symbol name with address and build version back to third-party program.
 /// NOTE: Be aware of library name will be varity since some libraries are detecting in other sections as well.
 /// </summary>
 /// <param name="library_str">Name of the library in string.</param>
 /// <param name="library_flag">Name of the library in flag.</param>
 /// <param name="symbol_str">Name of the library in symbol string.</param>
 /// <param name="address">Return xbox's virtual address.</param>
-/// <param name="revision">Found with specific revision.</param>
-typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_flag, const char* symbol_str, xbaddr address, uint32_t revision);
+/// <param name="build_verison">Found with specific build verison.</param>
+typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_flag, const char* symbol_str, xbaddr address, uint32_t build_verison);
 
 /// <summary>
 /// To scan symbols in memory of raw xbe or host's virtual xbox environment.
@@ -466,7 +466,7 @@ bool XbSymbolScan(const void* xb_header_addr, xb_symbol_register_t register_func
 /// <param name="upper_bound">Ending point of relative address base on xbeData.</param>
 /// <param name="register_func">Callback register function to be call for any detected symbols.</param>
 /// <returns>Only return true if a section name is in the database.</returns>
-bool XbSymbolScanSection(uint32_t xbe_base_address, uint32_t xbe_size, const char* section_name, uint32_t section_virtual_address, uint32_t section_size, uint16_t revision, xb_symbol_register_t register_func);
+bool XbSymbolScanSection(uint32_t xbe_base_address, uint32_t xbe_size, const char* section_name, uint32_t section_virtual_address, uint32_t section_size, uint16_t build_verison, xb_symbol_register_t register_func);
 */
 
 /// <summary>
@@ -481,6 +481,13 @@ uint32_t XbSymbolLibrayToFlag(const char* library_name);
 /// </summary>
 /// <returns>Return total count of errors.</returns>
 unsigned int XbSymbolDataBaseTestOOVPAs();
+
+/// <summary>
+/// (Debug feature) Set to true will perform full range of OOVPAs registered in current database.
+/// Or stop at xbe's build version detected.
+/// </summary>
+/// <param name="bypass_limit">Input boolean to either bypass or enable the build version limit.</param>
+void XbSymbolBypassBuildVersionLimit(bool bypass_limit);
 
 #ifdef __cplusplus
 }

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -498,6 +498,19 @@ void XbSymbolBypassBuildVersionLimit(bool bypass_limit);
 /// <param name="verbose_level">See xb_output_message enum for list of options.</param>
 bool XbSymbolSetOutputVerbosity(xb_output_message verbose_level);
 
+/// <summary>
+/// (Debug feature) Set to true will continue the same signature scan after first detected.
+/// </summary>
+/// <param name="enable">Input boolean to either continue with the signature scan after first symbol found or not.</param>
+void XbSymbolContinuousSigScan(bool enable);
+
+/// <summary>
+/// (Debug feature) Set to true will register first detected address only.
+/// This function can be used if XbSymbolContinuousSigScan is set to true.
+/// </summary>
+/// <param name="enable">Input boolean to use first symbol address only or not.</param>
+void XbSymbolFirstDetectAddressOnly(bool enable);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added:
  * XbSymbolBypassBuildVersionLimit to API usage. (See API for details.)
    * Is a requirement in order to perform a depth testing internally.
  * XbSymbolSetOutputVerbosity to API usage. (See API for details.)
    * By include this function, the process will run faster internal by skip certain verbose message with string formats provided.
  * XbSymbolOutputMessageFormat to reduce unnecessary buffer size holder in any functions.
  * Output debug message of what library and section are being scanned.
  * **NEW** XbSymbolContinuousSigScan to API usage. (See API for details.)
    * Is a requirement in order to perform a depth testing internally.
  * **NEW** XbSymbolFirstDetectAddressOnly to API usage. (See API for details.)
    * Is a requirement in order to perform a depth testing internally.