### PR TITLE
Fix NXDK support

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -41,7 +41,7 @@
 #include <intrin.h>
 static inline uint32_t BitScanReverse(uint32_t value)
 {
-    uint32_t index;
+    unsigned long index;
     if (!_BitScanReverse(&index, value)) {
         return 32;
     }


### PR DESCRIPTION
* nxdk declares `wchar_t` in stddef, so we need to include it.
* Fixes a bug (with warning) introduced in #54 where https://docs.microsoft.com/en-us/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=vs-2019 takes `unsigned long` pointer as first argument.