### PR TITLE
Relocate JVS into Separate Section

### DIFF
--- a/OOVPADatabase/JVS/4831.inl
+++ b/OOVPADatabase/JVS/4831.inl
@@ -28,19 +28,17 @@ OOVPA_XREF(JVS_SendCommand_String, 4831, 13,
     XRefZero)
     
     // JVS_STATUS_ERROR_DEVICE_NOT_CONNECTED2 from JVS_SendCommand
-    { 0x00, 'J' },
-    { 0x01, 'V' },
-    { 0x02, 'S' },
-    { 0x04, 'S' },
-    { 0x0B, 'E' },
-    { 0x11, 'D' },
-    { 0x18, 'N' },
-    { 0x1C, 'C' },
-    { 0x25, '2' },
-    { 0x27, 'f' },
-    { 0x2C, 'J' },
-    { 0x30, 'S' },
-    { 0x34, 'C' },
+    OV_MATCH(0x00, 'J', 'V', 'S'),
+    OV_MATCH(0x04, 'S'),
+    OV_MATCH(0x0B, 'E'),
+    OV_MATCH(0x11, 'D'),
+    OV_MATCH(0x18, 'N'),
+    OV_MATCH(0x1C, 'C'),
+    OV_MATCH(0x25, '2'),
+    OV_MATCH(0x27, 'f'),
+    OV_MATCH(0x2C, 'J'),
+    OV_MATCH(0x30, 'S'),
+    OV_MATCH(0x34, 'C'),
 OOVPA_END;
 
 
@@ -49,19 +47,13 @@ OOVPA_XREF(JvsBACKUP_Read_String, 4831, 13,
     XRefZero)
 
     // Status error <JvsBACKUP_Read>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0D, '<' },
-    { 0x0E, 'J' },
-    { 0x11, 'B' },
-    { 0x18, 'R' },
-    { 0x1B, 'd' },
-    { 0x1C, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0D, '<', 'J'),
+    OV_MATCH(0x11, 'B'),
+    OV_MATCH(0x18, 'R'),
+    OV_MATCH(0x1B, 'd'),
+    OV_MATCH(0x1C, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsBACKUP_Write_String, 4831, 13,
@@ -69,19 +61,13 @@ OOVPA_XREF(JvsBACKUP_Write_String, 4831, 13,
     XRefZero)
 
     // Status error <JvsBACKUP_Write>
-    { 0x00, 'S'    },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0D, '<' },
-    { 0x0E, 'J' },
-    { 0x11, 'B' },
-    { 0x18, 'W' },
-    { 0x1C, 'e' },
-    { 0x1D, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0D, '<', 'J'),
+    OV_MATCH(0x11, 'B'),
+    OV_MATCH(0x18, 'W'),
+    OV_MATCH(0x1C, 'e'),
+    OV_MATCH(0x1D, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsEEPROM_Read_String, 4831, 13,
@@ -89,19 +75,13 @@ OOVPA_XREF(JvsEEPROM_Read_String, 4831, 13,
     XRefZero)
 
     // Status error <JvsEEPROM_Read>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0D, '<' },
-    { 0x0E, 'J' },
-    { 0x11, 'E' },
-    { 0x18, 'R' },
-    { 0x1B, 'd' },
-    { 0x1C, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0D, '<', 'J'),
+    OV_MATCH(0x11, 'E'),
+    OV_MATCH(0x18, 'R'),
+    OV_MATCH(0x1B, 'd'),
+    OV_MATCH(0x1C, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsEEPROM_Write_String, 4831, 13,
@@ -109,19 +89,13 @@ OOVPA_XREF(JvsEEPROM_Write_String, 4831, 13,
     XRefZero)
 
     // Status error <JvsEEPROM_Write>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0D, '<' },
-    { 0x0E, 'J' },
-    { 0x11, 'E' },
-    { 0x18, 'W' },
-    { 0x1C, 'e' },
-    { 0x1D, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0D, '<', 'J'),
+    OV_MATCH(0x11, 'E'),
+    OV_MATCH(0x18, 'W'),
+    OV_MATCH(0x1C, 'e'),
+    OV_MATCH(0x1D, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsFirmwareDownload_String, 4831, 14,
@@ -129,20 +103,14 @@ OOVPA_XREF(JvsFirmwareDownload_String, 4831, 14,
     XRefZero)
 
     // Status error1 <JvsFirmwareDownload>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0C, '1' },
-    { 0x0E, '<' },
-    { 0x0F, 'J' },
-    { 0x12, 'F' },
-    { 0x1A, 'D' },
-    { 0x21, 'd' },
-    { 0x22, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0C, '1'),
+    OV_MATCH(0x0E, '<', 'J'),
+    OV_MATCH(0x12, 'F'),
+    OV_MATCH(0x1A, 'D'),
+    OV_MATCH(0x21, 'd'),
+    OV_MATCH(0x22, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsNodeReceivePacket_String, 4831, 13,
@@ -150,19 +118,13 @@ OOVPA_XREF(JvsNodeReceivePacket_String, 4831, 13,
     XRefZero)
 
     // Status waiting <JvsNodeReceivePacket>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0F, '<' },
-    { 0x10, 'J' },
-    { 0x13, 'N' },
-    { 0x17, 'R' },
-    { 0x1E, 'P' },
-    { 0x24, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0F, '<', 'J'),
+    OV_MATCH(0x13, 'N'),
+    OV_MATCH(0x17, 'R'),
+    OV_MATCH(0x1E, 'P'),
+    OV_MATCH(0x24, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsRTC_Read_String, 4831, 12,
@@ -170,18 +132,12 @@ OOVPA_XREF(JvsRTC_Read_String, 4831, 12,
     XRefZero)
 
     // Status wait <JvsRTC_Read>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0C, '<' },
-    { 0x0D, 'J' },
-    { 0x10, 'R' },
-    { 0x14, 'R' },
-    { 0x18, '>' }
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0C, '<', 'J'),
+    OV_MATCH(0x10, 'R'),
+    OV_MATCH(0x14, 'R'),
+    OV_MATCH(0x18, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsRTC_Write_String, 4831, 12,
@@ -189,18 +145,12 @@ OOVPA_XREF(JvsRTC_Write_String, 4831, 12,
     XRefZero)
 
     // Status wait <JvsRTC_Write>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0C, '<' },
-    { 0x0D, 'J' },
-    { 0x10, 'R' },
-    { 0x14, 'W' },
-    { 0x19, '>' }
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0C, '<', 'J'),
+    OV_MATCH(0x10, 'R'),
+    OV_MATCH(0x14, 'W'),
+    OV_MATCH(0x19, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsNodeSendPacket_String, 4831, 13,
@@ -208,19 +158,13 @@ OOVPA_XREF(JvsNodeSendPacket_String, 4831, 13,
     XRefZero)
 
     // Status waiting <JvsNodeSendPacket>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0F, '<' },
-    { 0x10, 'J' },
-    { 0x13, 'N' },
-    { 0x17, 'S' },
-    { 0x1B, 'P' },
-    { 0x21, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0F, '<', 'J'),
+    OV_MATCH(0x13, 'N'),
+    OV_MATCH(0x17, 'S'),
+    OV_MATCH(0x1B, 'P'),
+    OV_MATCH(0x21, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsFirmwareUpload_String, 4831, 14,
@@ -228,20 +172,14 @@ OOVPA_XREF(JvsFirmwareUpload_String, 4831, 14,
     XRefZero)
 
     // Status error1 <JvsFirmwareUpload>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0C, '1' },
-    { 0x0E, '<' },
-    { 0x0F, 'J' },
-    { 0x12, 'F' },
-    { 0x1A, 'U' },
-    { 0x1F, 'd' },
-    { 0x20, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0C, '1'),
+    OV_MATCH(0x0E, '<', 'J'),
+    OV_MATCH(0x12, 'F'),
+    OV_MATCH(0x1A, 'U'),
+    OV_MATCH(0x1F, 'd'),
+    OV_MATCH(0x20, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsScFirmwareDownload_String, 4831, 15,
@@ -249,21 +187,15 @@ OOVPA_XREF(JvsScFirmwareDownload_String, 4831, 15,
     XRefZero)
 
     // Status error1 <JvsScFirmwareDownload>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0C, '1' },
-    { 0x0E, '<' },
-    { 0x0F, 'J' },
-    { 0x12, 'S' },
-    { 0x14, 'F' },
-    { 0x1C, 'D' },
-    { 0x23, 'd' },
-    { 0x24, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0C, '1'),
+    OV_MATCH(0x0E, '<', 'J'),
+    OV_MATCH(0x12, 'S'),
+    OV_MATCH(0x14, 'F'),
+    OV_MATCH(0x1C, 'D'),
+    OV_MATCH(0x23, 'd'),
+    OV_MATCH(0x24, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsScFirmwareUpload_String, 4831, 14,
@@ -271,20 +203,14 @@ OOVPA_XREF(JvsScFirmwareUpload_String, 4831, 14,
     XRefZero)
 
     // Status waiting <JvsScFirmwareUpload>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0F, '<' },
-    { 0x10, 'J' },
-    { 0x13, 'S' },
-    { 0x15, 'F' },
-    { 0x1D, 'U' },
-    { 0x22, 'd' },
-    { 0x23, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0F, '<', 'J'),
+    OV_MATCH(0x13, 'S'),
+    OV_MATCH(0x15, 'F'),
+    OV_MATCH(0x1D, 'U'),
+    OV_MATCH(0x22, 'd'),
+    OV_MATCH(0x23, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsScReceiveMidi_String, 4831, 13,
@@ -292,19 +218,13 @@ OOVPA_XREF(JvsScReceiveMidi_String, 4831, 13,
     XRefZero)
 
     // Status waiting <JvsScReceiveMidi>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0F, '<' },
-    { 0x10, 'J' },
-    { 0x13, 'S' },
-    { 0x15, 'R' },
-    { 0x1C, 'M' },
-    { 0x20, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0F, '<', 'J'),
+    OV_MATCH(0x13, 'S'),
+    OV_MATCH(0x15, 'R'),
+    OV_MATCH(0x1C, 'M'),
+    OV_MATCH(0x20, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsScReceiveRs323c_String, 4831, 13,
@@ -312,19 +232,13 @@ OOVPA_XREF(JvsScReceiveRs323c_String, 4831, 13,
     XRefZero)
 
     // Status error <JvsScReceiveRs323c>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0D, '<' },
-    { 0x0E, 'J' },
-    { 0x11, 'S' },
-    { 0x13, 'R' },
-    { 0x1A, 'R' },
-    { 0x20, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0D, '<', 'J'),
+    OV_MATCH(0x11, 'S'),
+    OV_MATCH(0x13, 'R'),
+    OV_MATCH(0x1A, 'R'),
+    OV_MATCH(0x20, '>'),
 OOVPA_END;
 
 OOVPA_XREF(JvsScSendMidi_String, 4831, 13,
@@ -332,19 +246,13 @@ OOVPA_XREF(JvsScSendMidi_String, 4831, 13,
     XRefZero)
 
     // Status waiting <JvsScSendMidi>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'w' },
-    { 0x0F, '<' },
-    { 0x10, 'J' },
-    { 0x13, 'S' },
-    { 0x15, 'S' },
-    { 0x19, 'M' },
-    { 0x1D, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'w'),
+    OV_MATCH(0x0F, '<', 'J'),
+    OV_MATCH(0x13, 'S'),
+    OV_MATCH(0x15, 'S'),
+    OV_MATCH(0x19, 'M'),
+    OV_MATCH(0x1D, '>'),
 OOVPA_END;
 
 
@@ -353,103 +261,83 @@ OOVPA_XREF(JvsScSendRs323c_String, 4831, 13,
     XRefZero)
 
     // Status error <JvsScSendRs323c>
-    { 0x00, 'S' },
-    { 0x01, 't' },
-    { 0x02, 'a' },
-    { 0x03, 't' },
-    { 0x04, 'u' },
-    { 0x05, 's' },
-    { 0x07, 'e' },
-    { 0x0D, '<' },
-    { 0x0E, 'J' },
-    { 0x11, 'S' },
-    { 0x13, 'S' },
-    { 0x17, 'R' },
-    { 0x1D, '>' },
+    OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
+    OV_MATCH(0x07, 'e'),
+    OV_MATCH(0x0D, '<', 'J'),
+    OV_MATCH(0x11, 'S'),
+    OV_MATCH(0x13, 'S'),
+    OV_MATCH(0x17, 'R'),
+    OV_MATCH(0x1D, '>'),
 OOVPA_END;
 
 // ******************************************************************
 // * JVS_SendCommand
 // ******************************************************************
-OOVPA_XREF(JVS_SendCommand, 4831, 12,
+OOVPA_XREF(JVS_SendCommand, 4831, 1+12,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x250, XREF_JVS_SendCommand_String),
 
-    { 0x00, 0x81 },
-    { 0x01, 0xEC },
+    OV_MATCH(0x00, 0x81, 0xEC),
 
-    { 0x0A, 0xB4 },
-    { 0x0B, 0x00 },
+    OV_MATCH(0x0A, 0xB4, 0x00),
 
-    { 0x0E, 0x85 },
-    { 0x0F, 0xED },
+    OV_MATCH(0x0E, 0x85, 0xED),
 
-    { 0x10, 0x56 },
-    { 0x11, 0x57 },
+    OV_MATCH(0x10, 0x56, 0x57),
 
-    { 0x31, 0x8B },
-    { 0x32, 0xB4 },
+    OV_MATCH(0x31, 0x8B, 0xB4),
 
-    { 0x90, 0x0F },
-    { 0x96, 0xA8 }
+    OV_MATCH(0x90, 0x0F),
+
+    OV_MATCH(0x96, 0xA8),
 OOVPA_END;
 
 // ******************************************************************
 // * JVS_SendCommand2
 // * Variation of JVS_SendCommand
 // ******************************************************************
-OOVPA_XREF(JVS_SendCommand2, 4831, 8,
+OOVPA_XREF(JVS_SendCommand2, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x2C0, XREF_JVS_SendCommand_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x58 },
-    { 0x03, 0x53 },
-    { 0x86, 0x88 },
-    { 0x87, 0x44 },
-    { 0x88, 0x24 },
-    { 0x89, 0x70 },
+    OV_MATCH(0x00, 0x83, 0xEC, 0x58, 0x53),
+
+    OV_MATCH(0x86, 0x88, 0x44, 0x24, 0x70),
 OOVPA_END;
 
 // ******************************************************************
 // * JVS_SendCommand3
 // * Variation of JVS_SendCommand
 // ******************************************************************
-OOVPA_XREF(JVS_SendCommand3, 4831, 8,
+OOVPA_XREF(JVS_SendCommand3, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x28B, XREF_JVS_SendCommand_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x58 },
-    { 0x03, 0x53 },
-    { 0x86, 0x88 },
-    { 0x87, 0x44 },
-    { 0x88, 0x24 },
-    { 0x89, 0x70 },
+    OV_MATCH(0x00, 0x83, 0xEC, 0x58, 0x53),
+
+    OV_MATCH(0x86, 0x88, 0x44, 0x24, 0x70),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsBACKUP_Read
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Read, 4831, 9,
+OOVPA_XREF(JvsBACKUP_Read, 4831, 1+9,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x6E, XREF_JvsBACKUP_Read_String),
 
-    { 0x00, 0x8B },
-    { 0x11, 0x8D },
-    { 0x12, 0x54 },
-    { 0x13, 0x24 },
-    { 0x17, 0x18 },
-    { 0x43, 0xBE },
-    { 0x44, 0x00 },
-    { 0x4C, 0x05 },
-    { 0x4D, 0x00 },
+    OV_MATCH(0x00, 0x8B),
+
+    OV_MATCH(0x11, 0x8D, 0x54, 0x24),
+
+    OV_MATCH(0x17, 0x18),
+
+    OV_MATCH(0x43, 0xBE, 0x00),
+
+    OV_MATCH(0x4C, 0x05, 0x00),
 OOVPA_END;
 
 // ******************************************************************
@@ -457,700 +345,614 @@ OOVPA_END;
 // * Seems to be specfic to Crazy Taxi: Same function as above
 // * Very different code structure, needs different signature
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Read2, 4831, 9,
+OOVPA_XREF(JvsBACKUP_Read2, 4831, 1+9,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x6F, XREF_JvsBACKUP_Read_String),
 
-    { 0x00, 0x53 },
-    { 0x10, 0x6A },
-    { 0x12, 0x0F },
-    { 0x13, 0x83 },
-    { 0x18, 0x8B },
-    { 0x43, 0x55 },
-    { 0x44, 0x52 },
-    { 0x4C, 0x8D },
-    { 0x4D, 0x87 },
+    OV_MATCH(0x00, 0x53),
+
+    OV_MATCH(0x10, 0x6A),
+
+    OV_MATCH(0x12, 0x0F, 0x83),
+
+    OV_MATCH(0x18, 0x8B),
+
+    OV_MATCH(0x43, 0x55, 0x52),
+
+    OV_MATCH(0x4C, 0x8D, 0x87),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsBACKUP_Read3
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Read3, 4831, 5,
+OOVPA_XREF(JvsBACKUP_Read3, 4831, 1+5,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x5E, XREF_JvsBACKUP_Read_String),
 
-    { 0x00, 0x8B },
-    { 0x43, 0xBE },
-    { 0x44, 0x00 },
-    { 0x4C, 0x05 },
-    { 0x4D, 0x00 },
+    OV_MATCH(0x00, 0x8B),
+
+    OV_MATCH(0x43, 0xBE, 0x00),
+
+    OV_MATCH(0x4C, 0x05, 0x00),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsBACKUP_Write
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Write, 4831, 15,
+OOVPA_XREF(JvsBACKUP_Write, 4831, 1+15,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x6E, XREF_JvsBACKUP_Write_String),
 
-    { 0x00, 0x8B },
-    { 0x01, 0x44 },
-    { 0x02, 0x24 },
-    { 0x03, 0x04 },
+    OV_MATCH(0x00, 0x8B, 0x44, 0x24, 0x04),
 
-    { 0x0A, 0x55 },
-    { 0x0B, 0x56 },
+    OV_MATCH(0x0A, 0x55, 0x56),
 
-    { 0x0E, 0x00 },
-    { 0x0F, 0x6A },
+    OV_MATCH(0x0E, 0x00, 0x6A),
 
-    { 0x11, 0x8D },
-    { 0x12, 0x54 },
+    OV_MATCH(0x11, 0x8D, 0x54),
 
-    { 0x17, 0x1F },
+    OV_MATCH(0x17, 0x1F),
 
-    { 0x31, 0x51 },
-    { 0x32, 0x6A },
+    OV_MATCH(0x31, 0x51, 0x6A),
 
-    { 0x90, 0x0C },
-    { 0x91, 0x2E }
+    OV_MATCH(0x90, 0x0C, 0x2E),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsBACKUP_Write2
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Write2, 4831, 5,
+OOVPA_XREF(JvsBACKUP_Write2, 4831, 1+5,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x5E, XREF_JvsBACKUP_Write_String),
 
-    { 0x00, 0x8B },
-    { 0x43, 0xBE },
-    { 0x44, 0x00 },
-    { 0x4C, 0x05 },
-    { 0x4D, 0x00 },
+    OV_MATCH(0x00, 0x8B),
+
+    OV_MATCH(0x43, 0xBE, 0x00),
+
+    OV_MATCH(0x4C, 0x05, 0x00),
 OOVPA_END;
 
 
 // ******************************************************************
 // * JvsEEPROM_Read
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Read, 4831, 9,
+OOVPA_XREF(JvsEEPROM_Read, 4831, 1+9,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x188, XREF_JvsEEPROM_Read_String),
 
-    { 0x00, 0x51 },
-    { 0x13, 0x40 },
-    { 0x21, 0x74 },
-    { 0x22, 0x24 },
-    { 0x23, 0x18 },
-    { 0x43, 0x6A },
-    { 0x44, 0x17 },
-    { 0x4C, 0x6A },
-    { 0x4D, 0x40 },
+    OV_MATCH(0x00, 0x51),
+
+    OV_MATCH(0x13, 0x40),
+
+    OV_MATCH(0x21, 0x74, 0x24, 0x18),
+
+    OV_MATCH(0x43, 0x6A, 0x17),
+
+    OV_MATCH(0x4C, 0x6A, 0x40),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsEEPROM_Read2
 // * Almost identical to JvsEEPROM_Read, but some bytes are shifted
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Read2, 4831, 9,
+OOVPA_XREF(JvsEEPROM_Read2, 4831, 1+9,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x1B0, XREF_JvsEEPROM_Read_String),
 
-    { 0x00, 0x51 },
-    { 0x12, 0x40 },
-    { 0x21, 0x74 },
-    { 0x22, 0x24 },
-    { 0x23, 0x18 },
-    { 0x43, 0x6A },
-    { 0x44, 0x17 },
-    { 0x4C, 0x6A },
-    { 0x4D, 0x40 },
+    OV_MATCH(0x00, 0x51),
+
+    OV_MATCH(0x12, 0x40),
+
+    OV_MATCH(0x21, 0x74, 0x24, 0x18),
+
+    OV_MATCH(0x43, 0x6A, 0x17),
+
+    OV_MATCH(0x4C, 0x6A, 0x40),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsEEPROM_Read3
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Read3, 4831, 5,
+OOVPA_XREF(JvsEEPROM_Read3, 4831, 1+5,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x199, XREF_JvsEEPROM_Read_String),
 
-    { 0x00, 0x83 },
-    { 0x14, 0x40 },
-    { 0x46, 0x6A },
-    { 0x48, 0x6A },
-    { 0x4A, 0x8D },
+    OV_MATCH(0x00, 0x83),
+
+    OV_MATCH(0x14, 0x40),
+
+    OV_MATCH(0x46, 0x6A),
+
+    OV_MATCH(0x48, 0x6A),
+
+    OV_MATCH(0x4A, 0x8D),
 OOVPA_END;
 
 
 // ******************************************************************
 // * JvsEEPROM_Write
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Write, 4831, 10,
+OOVPA_XREF(JvsEEPROM_Write, 4831, 1+10,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x18E, XREF_JvsEEPROM_Write_String),
 
-    { 0x13, 0x08 },
-    { 0x3E, 0x8D },
-    { 0x3F, 0x44 },
-    { 0x40, 0x24 },
-    { 0x42, 0x50 },
-    { 0x43, 0x6A },
-    { 0x6B, 0xE1 },
-    { 0x6C, 0xFF },
-    { 0x70, 0x81 },
-    { 0x71, 0xFA },
+    OV_MATCH(0x13, 0x08),
+
+    OV_MATCH(0x3E, 0x8D, 0x44, 0x24),
+
+    OV_MATCH(0x42, 0x50, 0x6A),
+
+    OV_MATCH(0x6B, 0xE1, 0xFF),
+
+    OV_MATCH(0x70, 0x81, 0xFA),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsEEPROM_Write2
 // * Almost identical to JvsEEPROM_Write2, but some bytes are shifted
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Write2, 4831, 10,
+OOVPA_XREF(JvsEEPROM_Write2, 4831, 1+10,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x1B6, XREF_JvsEEPROM_Write_String),
-    { 0x12, 0x08 },
+    OV_MATCH(0x12, 0x08),
 
-    { 0x3E, 0x8D },
-    { 0x3F, 0x44 },
-    { 0x40, 0x24 },
-    { 0x42, 0x50 },
-    { 0x43, 0x6A },
-    { 0x6B, 0xE1 },
-    { 0x6C, 0xFF },
-    { 0x70, 0x81 },
-    { 0x71, 0xFA },
+    OV_MATCH(0x3E, 0x8D, 0x44, 0x24),
+
+    OV_MATCH(0x42, 0x50, 0x6A),
+
+    OV_MATCH(0x6B, 0xE1, 0xFF),
+
+    OV_MATCH(0x70, 0x81, 0xFA),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsEEPROM_Write3
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Write3, 4831, 3,
+OOVPA_XREF(JvsEEPROM_Write3, 4831, 1+3,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x199, XREF_JvsEEPROM_Write_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x34, 0x8B }
+    OV_MATCH(0x00, 0x83, 0xEC),
+
+    OV_MATCH(0x34, 0x8B),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsFirmwareDownload
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload, 4831, 8,
+OOVPA_XREF(JvsFirmwareDownload, 4831, 1+8,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1D4, XREF_JvsFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x4C },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 },
-    { 0x0F, 0x83 },
-    { 0x58, 0x6A },
-    { 0x59, 0x20 },
+    OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
+
+    OV_MATCH(0x0F, 0x83),
+
+    OV_MATCH(0x58, 0x6A, 0x20),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsFirmwareDownload2
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload2, 4831, 8,
+OOVPA_XREF(JvsFirmwareDownload2, 4831, 1+8,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x203, XREF_JvsFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x4C },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 },
-    { 0x0F, 0x83 },
-    { 0x58, 0x6A },
-    { 0x59, 0x20 },
+    OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
+
+    OV_MATCH(0x0F, 0x83),
+
+    OV_MATCH(0x58, 0x6A, 0x20),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsFirmwareDownload3
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload3, 4831, 5,
+OOVPA_XREF(JvsFirmwareDownload3, 4831, 1+5,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1E3, XREF_JvsFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x44 },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 }
+    OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
 OOVPA_END;
 
 
 // ******************************************************************
 // * JvsFirmwareDownload4
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload4, 4831, 5,
+OOVPA_XREF(JvsFirmwareDownload4, 4831, 1+5,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1CF, XREF_JvsFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x44 },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 }
+    OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsFirmwareUpload
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload, 4831, 8,
+OOVPA_XREF(JvsFirmwareUpload, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x1B7, XREF_JvsFirmwareUpload_String),
 
-    { 0x00, 0x83 },
-    { 0x12, 0x83 },
-    { 0x13, 0xF9 },
-    { 0x14, 0x20 },
-    { 0x40, 0x8D },
-    { 0x41, 0x44 },
-    { 0x42, 0x24 },
-    { 0x43, 0x4C },
+    OV_MATCH(0x00, 0x83),
+
+    OV_MATCH(0x12, 0x83, 0xF9, 0x20),
+
+    OV_MATCH(0x40, 0x8D, 0x44, 0x24, 0x4C),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsFirmwareUpload2
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload2, 4831, 8,
+OOVPA_XREF(JvsFirmwareUpload2, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x1DE, XREF_JvsFirmwareUpload_String),
 
-    { 0x00, 0x83 },
-    { 0x12, 0x83 },
-    { 0x13, 0xF9 },
-    { 0x14, 0x20 },
-    { 0x40, 0x8D },
-    { 0x41, 0x44 },
-    { 0x42, 0x24 },
-    { 0x43, 0x4C },
+    OV_MATCH(0x00, 0x83),
+
+    OV_MATCH(0x12, 0x83, 0xF9, 0x20),
+
+    OV_MATCH(0x40, 0x8D, 0x44, 0x24, 0x4C),
 OOVPA_END;
 
 
 // ******************************************************************
 // * JvsFirmwareUpload3
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload3, 4831, 5,
+OOVPA_XREF(JvsFirmwareUpload3, 4831, 1+5,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1DA, XREF_JvsFirmwareUpload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x44 },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 }
+    OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
 OOVPA_END;
 
 
 // ******************************************************************
 // * JvsFirmwareUpload4
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload4, 4831, 5,
+OOVPA_XREF(JvsFirmwareUpload4, 4831, 1+5,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1BF, XREF_JvsFirmwareUpload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x44 },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 }
+    OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsNodeReceivePacket
 // ******************************************************************
-OOVPA_XREF(JvsNodeReceivePacket, 4831, 8,
+OOVPA_XREF(JvsNodeReceivePacket, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x6D, XREF_JvsNodeReceivePacket_String),
 
-    { 0x28, 0x6A },
-    { 0x29, 0x19 },
-    { 0x2B, 0x6A },
-    { 0x2C, 0x03 },
-    { 0x54, 0xF6 },
-    { 0x55, 0xC3 },
-    { 0x56, 0x01 },
-    { 0xC9, 0xC2 },
+    OV_MATCH(0x28, 0x6A, 0x19),
+
+    OV_MATCH(0x2B, 0x6A, 0x03),
+
+    OV_MATCH(0x54, 0xF6),
+
+    OV_MATCH(0x55, 0xC3, 0x01),
+
+    OV_MATCH(0xC9, 0xC2),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsNodeReceivePacket2
 // ******************************************************************
-OOVPA_XREF(JvsNodeReceivePacket2, 4831, 4,
+OOVPA_XREF(JvsNodeReceivePacket2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x55, XREF_JvsNodeReceivePacket_String),
 
-    { 0x00, 0x53 },
-    { 0x01, 0x55 },
-    { 0x02, 0x56 },
-    { 0x03, 0x57 },
+    OV_MATCH(0x00, 0x53, 0x55, 0x56, 0x57),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsNodeSendPacket
 // ******************************************************************
-OOVPA_XREF(JvsNodeSendPacket, 4831, 8,
+OOVPA_XREF(JvsNodeSendPacket, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x6D, XREF_JvsNodeSendPacket_String),
 
-    { 0x23, 0x6A },
-    { 0x24, 0x20 },
-    { 0x26, 0x6A },
-    { 0x27, 0x0B },
-    { 0x54, 0xF6 },
-    { 0x55, 0xC3 },
-    { 0x56, 0x01 },
-    { 0xC9, 0xC2 },
+    OV_MATCH(0x23, 0x6A, 0x20),
+
+    OV_MATCH(0x26, 0x6A, 0x0B),
+
+    OV_MATCH(0x54, 0xF6, 0xC3, 0x01),
+
+    OV_MATCH(0xC9, 0xC2),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsNodeSendPacket2
 // ******************************************************************
-OOVPA_XREF(JvsNodeSendPacket2, 4831, 4,
+OOVPA_XREF(JvsNodeSendPacket2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x55, XREF_JvsNodeSendPacket_String),
 
-    { 0x00, 0x53 },
-    { 0x01, 0x55 },
-    { 0x02, 0x56 },
-    { 0x03, 0x57 },
+    OV_MATCH(0x00, 0x53, 0x55, 0x56, 0x57),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsRTC_Read
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Read, 4831, 8,
+OOVPA_XREF(JvsRTC_Read, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x81, XREF_JvsRTC_Read_String),
 
-    { 0x05, 0x00 },
-    { 0x06, 0x53 },
-    { 0x10, 0x1C },
-    { 0x11, 0x8B },
-    { 0x12, 0x6C },
-    { 0x13, 0x24 },
-    { 0x2B, 0x55 },
-    { 0x2C, 0xE8 },
+    OV_MATCH(0x05, 0x00, 0x53),
+
+    OV_MATCH(0x10, 0x1C, 0x8B, 0x6C, 0x24),
+
+    OV_MATCH(0x2B, 0x55, 0xE8),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsRTC_Read2
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Read2, 4831, 8,
+OOVPA_XREF(JvsRTC_Read2, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x96, XREF_JvsRTC_Read_String),
 
-    { 0x05, 0x00 },
-    { 0x06, 0x53 },
-    { 0x10, 0x1C },
-    { 0x11, 0x8B },
-    { 0x12, 0x6C },
-    { 0x13, 0x24 },
-    { 0x2B, 0x55 },
-    { 0x2C, 0xE8 },
+    OV_MATCH(0x05, 0x00, 0x53),
+
+    OV_MATCH(0x10, 0x1C, 0x8B, 0x6C, 0x24),
+
+    OV_MATCH(0x2B, 0x55, 0xE8),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsRTC_Read3
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Read3, 4831, 4,
+OOVPA_XREF(JvsRTC_Read3, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x68, XREF_JvsRTC_Read_String),
 
-    { 0x00, 0x8B },
-    { 0x10, 0x8B },
-    { 0x14, 0x56 },
-    { 0x15, 0x57 },
+    OV_MATCH(0x00, 0x8B),
+
+    OV_MATCH(0x10, 0x8B),
+
+    OV_MATCH(0x14, 0x56, 0x57),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareDownload
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload, 4831, 8,
+OOVPA_XREF(JvsScFirmwareDownload, 4831, 1+8,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1D4, XREF_JvsScFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x4C },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 },
-    { 0x0F, 0x83 },
-    { 0x58, 0x6A },
-    { 0x59, 0x20 },
+    OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
+
+    OV_MATCH(0x0F, 0x83),
+
+    OV_MATCH(0x58, 0x6A, 0x20),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsRTC_Write
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Write, 4831, 8,
+OOVPA_XREF(JvsRTC_Write, 4831, 1+8,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x96, XREF_JvsRTC_Write_String),
 
-    { 0x05, 0x00 },
-    { 0x06, 0x53 },
-    { 0x10, 0x1C },
-    { 0x11, 0x8B },
-    { 0x12, 0x6C },
-    { 0x13, 0x24 },
-    { 0x2B, 0x55 },
-    { 0x2C, 0xE8 },
+    OV_MATCH(0x05, 0x00, 0x53),
+
+    OV_MATCH(0x10, 0x1C, 0x8B, 0x6C, 0x24),
+
+    OV_MATCH(0x2B, 0x55, 0xE8),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsRTC_Write2
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Write2, 4831, 4,
+OOVPA_XREF(JvsRTC_Write2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x68, XREF_JvsRTC_Write_String),
 
-    { 0x00, 0x8B },
-    { 0x10, 0x8B },
-    { 0x14, 0x56 },
-    { 0x15, 0x57 },
+    OV_MATCH(0x00, 0x8B),
+
+    OV_MATCH(0x10, 0x8B),
+
+    OV_MATCH(0x14, 0x56, 0x57),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareDownload2
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload2, 4831, 8,
+OOVPA_XREF(JvsScFirmwareDownload2, 4831, 1+8,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x203, XREF_JvsScFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x4C },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 },
-    { 0x0F, 0x83 },
-    { 0x58, 0x6A },
-    { 0x59, 0x20 },
+    OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
+
+    OV_MATCH(0x0F, 0x83),
+
+    OV_MATCH(0x58, 0x6A, 0x20),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareDownload3
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload3, 4831, 5,
+OOVPA_XREF(JvsScFirmwareDownload3, 4831, 1+5,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1E3, XREF_JvsScFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x44 },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 }
+    OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareDownload4
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload4, 4831, 5,
+OOVPA_XREF(JvsScFirmwareDownload4, 4831, 1+5,
     XRefNoSaveIndex,
     XRefOne)
 
     XREF_ENTRY(0x1CF, XREF_JvsScFirmwareDownload_String),
 
-    { 0x03, 0x8B },
-    { 0x04, 0x44 },
-    { 0x05, 0x24 },
-    { 0x06, 0x30 },
-    { 0x07, 0x53 }
+    OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareUpload
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareUpload, 4831, 4,
+OOVPA_XREF(JvsScFirmwareUpload, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0xA9, XREF_JvsScFirmwareUpload_String),
 
-    { 0x00, 0x51 },
-    { 0x01, 0x8B },
-    { 0x05, 0x53 },
-    { 0x06, 0x8B }
+    OV_MATCH(0x00, 0x51, 0x8B),
+    OV_MATCH(0x05, 0x53, 0x8B),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareUpload2
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareUpload2, 4831, 4,
+OOVPA_XREF(JvsScFirmwareUpload2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0xBE, XREF_JvsScFirmwareUpload_String),
 
-    { 0x00, 0x51 },
-    { 0x01, 0x8B },
-    { 0x05, 0x53 },
-    { 0x06, 0x8B }
+    OV_MATCH(0x00, 0x51, 0x8B),
+
+    OV_MATCH(0x05, 0x53, 0x8B),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScFirmwareUpload3
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareUpload3, 4831, 4,
+OOVPA_XREF(JvsScFirmwareUpload3, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x9E, XREF_JvsScFirmwareUpload_String),
 
-    { 0x00, 0x83 },
-    { 0x03, 0x8B },
-    { 0x07, 0x53 },
-    { 0x08, 0x55 }
+    OV_MATCH(0x00, 0x83),
+
+    OV_MATCH(0x03, 0x8B),
+
+    OV_MATCH(0x07, 0x53, 0x55),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScReceiveMidi
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveMidi, 4831, 4,
+OOVPA_XREF(JvsScReceiveMidi, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x7D, XREF_JvsScReceiveMidi_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x53 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScReceiveMidi2
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveMidi2, 4831, 4,
+OOVPA_XREF(JvsScReceiveMidi2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x65, XREF_JvsScReceiveMidi_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x53 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScReceiveRs323c
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveRs323c, 4831, 4,
+OOVPA_XREF(JvsScReceiveRs323c, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x63, XREF_JvsScReceiveRs323c_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x56 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x56),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScReceiveRs323c2
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveRs323c2, 4831, 4,
+OOVPA_XREF(JvsScReceiveRs323c2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x4F, XREF_JvsScReceiveRs323c_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x56 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x56),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScSendMidi
 // ******************************************************************
-OOVPA_XREF(JvsScSendMidi, 4831, 4,
+OOVPA_XREF(JvsScSendMidi, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x7D, XREF_JvsScSendMidi_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x53 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScSendMidi2
 // ******************************************************************
-OOVPA_XREF(JvsScSendMidi2, 4831, 4,
+OOVPA_XREF(JvsScSendMidi2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x5D, XREF_JvsScSendMidi_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x53 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScReceiveRs323c
 // ******************************************************************
-OOVPA_XREF(JvsScSendRs323c, 4831, 4,
+OOVPA_XREF(JvsScSendRs323c, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x5E, XREF_JvsScSendRs323c_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0xC7 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0xC7),
 OOVPA_END;
 
 // ******************************************************************
 // * JvsScReceiveRs323c2
 // ******************************************************************
-OOVPA_XREF(JvsScSendRs323c2, 4831, 4,
+OOVPA_XREF(JvsScSendRs323c2, 4831, 1+4,
     XRefNoSaveIndex, XRefOne)
 
     XREF_ENTRY(0x4D, XREF_JvsScSendRs323c_String),
 
-    { 0x00, 0x83 },
-    { 0x01, 0xEC },
-    { 0x02, 0x08 },
-    { 0x03, 0x56 }
+    OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x56),
 OOVPA_END;

--- a/OOVPADatabase/JVS_OOVPA.inl
+++ b/OOVPADatabase/JVS_OOVPA.inl
@@ -1,0 +1,130 @@
+// ******************************************************************
+// *
+// *   OOVPADatabase->JVS_OOVPA.inl
+// *
+// *  XbSymbolDatabase is free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *
+// *  (c) 2019 Luke Usher
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+// Titles which did compiled with full library
+//   [LibV] Title Name                       |  Verify   |  Comments
+//-------------------------------------------------------------------
+// * [4831] House of The Dead 3              |   100%    | Contain full library.
+// * [4831] Crazy Taxi 3                     |   100%    | Contain full library.
+// * [5028] SegaBoot v2.00.0                 |   100%    | Contain full library.
+// * [5028] SegaBoot v2.13.0                 |   100%    | Contain full library.
+// * [5028] Virtua Cop 3                     |   100%    | Contain full library.
+// * [5455] Ollie King                       |   100%    | Contain full library.
+// * [5558] Outrun 2                         |   100%    | Contain full library.
+// * [5659] Outrun 2 SP                      |   100%    | Contain full library.
+// * [5788] Ghost Squad                      |   100%    | Contain full library.
+// * [5849] Sega Golf 2006                   |   100%    | Contain full library.
+
+// NOTES:
+//  * JVSSendCommand1/2/3 sometime changes even when the library version
+//    is the same except the functions are quite different in layout, etc
+//    and some offsets are different within them too.
+
+#ifndef JVS_OOVPA_INL
+#define JVS_OOVPA_INL
+
+#include "../OOVPA.h"
+
+#include "JVS/4831.inl"
+
+// ******************************************************************
+// * JVSLIB_OOVPA
+// ******************************************************************
+OOVPATable JVSLIB_OOVPA[] = {
+
+    // Chihiro/JVS (XRef strings)
+    REGISTER_OOVPAS(JVS_SendCommand_String, 4831),
+    REGISTER_OOVPAS(JvsBACKUP_Read_String, 4831),
+    REGISTER_OOVPAS(JvsBACKUP_Write_String, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Read_String, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Write_String, 4831),
+    REGISTER_OOVPAS(JvsFirmwareDownload_String, 4831),
+    REGISTER_OOVPAS(JvsFirmwareUpload_String, 4831),
+    REGISTER_OOVPAS(JvsNodeReceivePacket_String, 4831),
+    REGISTER_OOVPAS(JvsNodeSendPacket_String, 4831),
+    REGISTER_OOVPAS(JvsRTC_Read_String, 4831),
+    REGISTER_OOVPAS(JvsRTC_Write_String, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareDownload_String, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareUpload_String, 4831),
+    REGISTER_OOVPAS(JvsScReceiveMidi_String, 4831),
+    REGISTER_OOVPAS(JvsScReceiveRs323c_String, 4831),
+    REGISTER_OOVPAS(JvsScSendMidi_String, 4831),
+    REGISTER_OOVPAS(JvsScSendRs323c_String, 4831),
+
+    // Chihiro/JVS (Functions)
+    REGISTER_OOVPAS(JVS_SendCommand, 4831),
+    REGISTER_OOVPAS(JVS_SendCommand2, 4831),
+    REGISTER_OOVPAS(JVS_SendCommand3, 4831),
+    REGISTER_OOVPAS(JvsBACKUP_Read, 4831),
+    REGISTER_OOVPAS(JvsBACKUP_Read2, 4831), 
+    REGISTER_OOVPAS(JvsBACKUP_Read3, 4831),
+    REGISTER_OOVPAS(JvsBACKUP_Write, 4831),
+    REGISTER_OOVPAS(JvsBACKUP_Write2, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Read, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Read2, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Read3, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Write, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Write2, 4831),
+    REGISTER_OOVPAS(JvsEEPROM_Write3, 4831),
+    REGISTER_OOVPAS(JvsFirmwareDownload, 4831),
+    REGISTER_OOVPAS(JvsFirmwareDownload2, 4831),
+    REGISTER_OOVPAS(JvsFirmwareDownload3, 4831),
+    REGISTER_OOVPAS(JvsFirmwareDownload4, 4831),
+    REGISTER_OOVPAS(JvsFirmwareUpload, 4831),
+    REGISTER_OOVPAS(JvsFirmwareUpload2, 4831),
+    REGISTER_OOVPAS(JvsFirmwareUpload3, 4831),
+    REGISTER_OOVPAS(JvsFirmwareUpload4, 4831),
+    REGISTER_OOVPAS(JvsNodeReceivePacket, 4831),
+    REGISTER_OOVPAS(JvsNodeReceivePacket2, 4831),
+    REGISTER_OOVPAS(JvsNodeSendPacket, 4831),
+    REGISTER_OOVPAS(JvsNodeSendPacket2, 4831),
+    REGISTER_OOVPAS(JvsRTC_Read, 4831),
+    REGISTER_OOVPAS(JvsRTC_Read2, 4831),
+    REGISTER_OOVPAS(JvsRTC_Read3, 4831),
+    REGISTER_OOVPAS(JvsRTC_Write, 4831),
+    REGISTER_OOVPAS(JvsRTC_Write2, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareDownload, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareDownload2, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareDownload3, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareDownload4, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareUpload, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareUpload2, 4831),
+    REGISTER_OOVPAS(JvsScFirmwareUpload3, 4831),
+    REGISTER_OOVPAS(JvsScReceiveMidi, 4831),
+    REGISTER_OOVPAS(JvsScReceiveMidi2, 4831),
+    REGISTER_OOVPAS(JvsScReceiveRs323c, 4831),
+    REGISTER_OOVPAS(JvsScReceiveRs323c2, 4831),
+    REGISTER_OOVPAS(JvsScSendMidi, 4831),
+    REGISTER_OOVPAS(JvsScSendMidi2, 4831),
+    REGISTER_OOVPAS(JvsScSendRs323c, 4831),
+    REGISTER_OOVPAS(JvsScSendRs323c2, 4831),
+};
+
+// ******************************************************************
+// * JVSLIB_OOVPA_COUNT
+// ******************************************************************
+#define JVSLIB_OOVPA_COUNT XBSDB_ARRAY_SIZE(JVSLIB_OOVPA)
+
+#endif

--- a/OOVPADatabase/Xapi_OOVPA.inl
+++ b/OOVPADatabase/Xapi_OOVPA.inl
@@ -119,9 +119,6 @@
 #include "Xapi/5455.inl"
 #include "Xapi/5788.inl"
 
-// Note: JVS Libraries are linked in the same sections as XAPILIB, so we define them here
-#include "JVS/4831.inl"
-
 // ******************************************************************
 // * XAPILIB_OOVPA
 // ******************************************************************
@@ -179,72 +176,6 @@ OOVPATable XAPILIB_OOVPAV2[] = {
     REGISTER_OOVPAS(timeKillEvent, 3911),
     REGISTER_OOVPAS(timeSetEvent, 3911),
 
-    // Chihiro/JVS (XRef strings)
-    REGISTER_OOVPAS(JVS_SendCommand_String, 4831),
-    REGISTER_OOVPAS(JvsBACKUP_Read_String, 4831),
-    REGISTER_OOVPAS(JvsBACKUP_Write_String, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Read_String, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Write_String, 4831),
-    REGISTER_OOVPAS(JvsFirmwareDownload_String, 4831),
-    REGISTER_OOVPAS(JvsFirmwareUpload_String, 4831),
-    REGISTER_OOVPAS(JvsNodeReceivePacket_String, 4831),
-    REGISTER_OOVPAS(JvsNodeSendPacket_String, 4831),
-    REGISTER_OOVPAS(JvsRTC_Read_String, 4831),
-    REGISTER_OOVPAS(JvsRTC_Write_String, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareDownload_String, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareUpload_String, 4831),
-    REGISTER_OOVPAS(JvsScReceiveMidi_String, 4831),
-    REGISTER_OOVPAS(JvsScReceiveRs323c_String, 4831),
-    REGISTER_OOVPAS(JvsScSendMidi_String, 4831),
-    REGISTER_OOVPAS(JvsScSendRs323c_String, 4831),
-
-    // Chihiro/JVS (Functions)
-    REGISTER_OOVPAS(JVS_SendCommand, 4831),
-    REGISTER_OOVPAS(JVS_SendCommand2, 4831),
-    REGISTER_OOVPAS(JVS_SendCommand3, 4831),
-    REGISTER_OOVPAS(JvsBACKUP_Read, 4831),
-    REGISTER_OOVPAS(JvsBACKUP_Read2, 4831), 
-    REGISTER_OOVPAS(JvsBACKUP_Read3, 4831),
-    REGISTER_OOVPAS(JvsBACKUP_Write, 4831),
-    REGISTER_OOVPAS(JvsBACKUP_Write2, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Read, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Read2, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Read3, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Write, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Write2, 4831),
-    REGISTER_OOVPAS(JvsEEPROM_Write3, 4831),
-    REGISTER_OOVPAS(JvsFirmwareDownload, 4831),
-    REGISTER_OOVPAS(JvsFirmwareDownload2, 4831),
-    REGISTER_OOVPAS(JvsFirmwareDownload3, 4831),
-    REGISTER_OOVPAS(JvsFirmwareDownload4, 4831),
-    REGISTER_OOVPAS(JvsFirmwareUpload, 4831),
-    REGISTER_OOVPAS(JvsFirmwareUpload2, 4831),
-    REGISTER_OOVPAS(JvsFirmwareUpload3, 4831),
-    REGISTER_OOVPAS(JvsFirmwareUpload4, 4831),
-    REGISTER_OOVPAS(JvsNodeReceivePacket, 4831),
-    REGISTER_OOVPAS(JvsNodeReceivePacket2, 4831),
-    REGISTER_OOVPAS(JvsNodeSendPacket, 4831),
-    REGISTER_OOVPAS(JvsNodeSendPacket2, 4831),
-    REGISTER_OOVPAS(JvsRTC_Read, 4831),
-    REGISTER_OOVPAS(JvsRTC_Read2, 4831),
-    REGISTER_OOVPAS(JvsRTC_Read3, 4831),
-    REGISTER_OOVPAS(JvsRTC_Write, 4831),
-    REGISTER_OOVPAS(JvsRTC_Write2, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareDownload, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareDownload2, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareDownload3, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareDownload4, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareUpload, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareUpload2, 4831),
-    REGISTER_OOVPAS(JvsScFirmwareUpload3, 4831),
-    REGISTER_OOVPAS(JvsScReceiveMidi, 4831),
-    REGISTER_OOVPAS(JvsScReceiveMidi2, 4831),
-    REGISTER_OOVPAS(JvsScReceiveRs323c, 4831),
-    REGISTER_OOVPAS(JvsScReceiveRs323c2, 4831),
-    REGISTER_OOVPAS(JvsScSendMidi, 4831),
-    REGISTER_OOVPAS(JvsScSendMidi2, 4831),
-    REGISTER_OOVPAS(JvsScSendRs323c, 4831),
-    REGISTER_OOVPAS(JvsScSendRs323c2, 4831),
 };
 
 // ******************************************************************

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -74,6 +74,7 @@ static inline uint32_t BitScanReverse(uint32_t value)
 #include "OOVPADatabase/D3D8_OOVPA.inl"
 #include "OOVPADatabase/D3D8LTCG_OOVPA.inl"
 #include "OOVPADatabase/DSound_OOVPA.inl"
+#include "OOVPADatabase/JVS_OOVPA.inl"
 #include "OOVPADatabase/XGraphic_OOVPA.inl"
 #include "OOVPADatabase/XNet_OOVPA.inl"
 #include "OOVPADatabase/XOnline_OOVPA.inl"
@@ -119,6 +120,9 @@ SymbolDatabaseList SymbolDBList[] = {
 
     // DSOUNDH is just meant to define hot fix, there is no separate section
     //{ XbSymbolLib_DSOUNDH,{ Sec_DSOUND }, &DSound_OOVPAV2, DSound_OOVPA_COUNT },
+
+    // Only used in Chihiro applications
+    { XbSymbolLib_JVS,{ Sec_text, Sec_XPP, Sec_FLASHROM }, JVSLIB_OOVPA, JVSLIB_OOVPA_COUNT },
 
     //
     { XbSymbolLib_XACTENG, { Sec_XACTENG, Sec_FLASHROM }, XACTENG_OOVPAV2, XACTENG_OOVPA_COUNT },
@@ -1359,6 +1363,7 @@ bool XbSymbolScan(const void* xb_header_addr,
 
     bool bDSoundLibHeader;
     xb_xbe_type xbe_type;
+    bool bCheckJVS = false;
 
     if (!XbSymbolInit(xb_header_addr, register_func, &xbe_type, &bDSoundLibHeader)) {
         return 0;
@@ -1504,6 +1509,16 @@ bool XbSymbolScan(const void* xb_header_addr,
                         LibraryFlag = XbSymbolLib_DSOUND;
                         BuildVersion = preserveVersion;
                         bDSoundLibSection = true; // In case if third-party application exclude scan for DSOUND library.
+                        continue;
+                    }
+
+                    // Verify if xbe type is not a retail for Chihiro applications.
+                    // NOTE: segaboots does report as Chihiro except others report as debug.
+                    if (xbe_type != XB_XBE_TYPE_RETAIL && bCheckJVS == false) {
+                        LibraryStr = Lib_JVS;
+                        LibraryFlag = XbSymbolLib_JVS;
+                        BuildVersion = preserveVersion;
+                        bCheckJVS = true;
                         continue;
                     }
                 }

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -56,6 +56,7 @@ extern "C" {
 #define Sec_D3DX        "D3DX"
 #define Lib_DSOUND      "DSOUND"
 #define Sec_DSOUND      Lib_DSOUND
+#define Lib_JVS         "JVS"
 #define Lib_XACTENG     "XACTENG"
 #define Sec_XACTENG     Lib_XACTENG
 #define Lib_XAPILIB     "XAPILIB"
@@ -74,18 +75,20 @@ extern "C" {
 #define XbSymbolLib_D3D8LTCG    (1 << 1)
 #define XbSymbolLib_D3DX8       (1 << 2)
 #define XbSymbolLib_DSOUND      (1 << 3)
-#define XbSymbolLib_XACTENG     (1 << 4)
-#define XbSymbolLib_XAPILIB     (1 << 5)
-#define XbSymbolLib_XGRAPHC     (1 << 6)
-#define XbSymbolLib_XNET        (1 << 7)
-#define XbSymbolLib_XNETN       (1 << 8)
-#define XbSymbolLib_XNETS       (1 << 9)
-#define XbSymbolLib_XONLINE     (1 << 10)
-#define XbSymbolLib_XONLINES    (1 << 11)
+#define XbSymbolLib_JVS         (1 << 4)
+#define XbSymbolLib_XACTENG     (1 << 5)
+#define XbSymbolLib_XAPILIB     (1 << 6)
+#define XbSymbolLib_XGRAPHC     (1 << 7)
+#define XbSymbolLib_XNET        (1 << 8)
+#define XbSymbolLib_XNETN       (1 << 9)
+#define XbSymbolLib_XNETS       (1 << 10)
+#define XbSymbolLib_XONLINE     (1 << 11)
+#define XbSymbolLib_XONLINES    (1 << 12)
 
 #define XbSymbolLib_ALL ( XbSymbolLib_D3D8| XbSymbolLib_D3D8LTCG| XbSymbolLib_D3DX8| XbSymbolLib_DSOUND \
-                        | XbSymbolLib_XACTENG| XbSymbolLib_XAPILIB| XbSymbolLib_XGRAPHC| XbSymbolLib_XNET \
-                        | XbSymbolLib_XNETN| XbSymbolLib_XNETS| XbSymbolLib_XONLINE| XbSymbolLib_XONLINES)
+                        | XbSymbolLib_JVS| XbSymbolLib_XACTENG| XbSymbolLib_XAPILIB| XbSymbolLib_XGRAPHC \
+                        | XbSymbolLib_XNET| XbSymbolLib_XNETN| XbSymbolLib_XNETS| XbSymbolLib_XONLINE \
+                        | XbSymbolLib_XONLINES)
 
 // ******************************************************************
 // * XRefDataBaseOffset


### PR DESCRIPTION
Separate JVS symbols from XAPI library into its own library. Plus nothing had been changed in OOVPAs except for replace default array to OV_MATCH macro.

The documentation in JVS notes are used by @LukeUsher record:
![image](https://user-images.githubusercontent.com/740003/52278149-43037a00-294e-11e9-8815-cac4eb65b97c.png)