### PR TITLE
Implement Specific Detected Selection Scan for OOVPA

### DIFF
--- a/OOVPA.h
+++ b/OOVPA.h
@@ -60,6 +60,10 @@ typedef struct _OOVPA
     // no XREF_* enum defined for this OOVPA.
     unsigned short XRefSaveIndex;
 
+    unsigned char DetectSelect;
+
+    unsigned char Padding[3];
+
     // Define LOVP here to reduce type definition complexity.
     // (Otherwise, if defined in the template classes, that would mean
     // that for each template instance, the type is redefined. Let's
@@ -88,18 +92,22 @@ typedef struct _LOVP
     };
 } LOVP;
 
+// Set variable's padding to 0.
+#define VARPADSET 0
+
 // This XRefZero constant, when set in the OOVPA.XRefCount field,
 // indicates there are no {offset, XREF_*-enum} present in the OOVPA.
-#define XRefZero 0x00
+#define XRefZero    0
 
 // This XRefOne constant, when set in the OOVPA.XRefCount field,
 // indicates the OOVPA contains one (1) {offset, XREF_* enum} pair.
-#define XRefOne 0x01
+#define XRefOne     1
 
 // Sometimes, there can be more than one {Offset, XREF_*-enum}
 // pair at the start of the OOVPA's.
-#define XRefTwo 0x02
-#define XRefThree 0x03
+#define XRefTwo     2
+#define XRefThree   3
+#define XRefFour    4
 
 // This XRefNoSaveIndex constant, when set in the OOVPA.XRefSaveIndex
 // field, functions as a marker indicating there's no XREF_* enum
@@ -118,6 +126,12 @@ typedef struct _LOVP
 // TODO: Remove above line, then uncomment the line below for easy swap after OOVPA database has been fixed.
 //  { Offset, { .unused = 0, .value = Value } } 
 
+// Macro for determine how the OOVPA scan will process for detection.
+#define DetectDefault 0
+#define DetectFirst   1
+#define DetectSecond  2
+#define DetectThird   3
+#define DetectFourth  4
 
 // ******************************************************************
 // * Large Optimized (Offset,Value)-Pair Array
@@ -133,11 +147,17 @@ typedef struct _LOOVPA
 } LOOVPA;
 #pragma warning(pop)
 
-#define OOVPA_XREF(Name, Version, Count, XRefSaveIndex, XRefCount)    \
-LOOVPA Name##_##Version = { Count, XRefCount, (unsigned short)XRefSaveIndex, {
+#define OOVPA_XREF_EXTEND(Name, Version, Count, XRefSaveIndex, XRefCount, DetectSelect) \
+LOOVPA Name##_##Version = { Count, XRefCount, XRefSaveIndex, DetectSelect, VARPADSET, VARPADSET, VARPADSET, {
+
+#define OOVPA_NO_XREF_DETECT(Name, Version, Count, DetectSelect) \
+OOVPA_XREF_EXTEND(Name, Version, Count, XRefNoSaveIndex, XRefZero, DetectSelect)
+
+#define OOVPA_XREF(Name, Version, Count, XRefSaveIndex, XRefCount) \
+OOVPA_XREF_EXTEND(Name, Version, Count, XRefSaveIndex, XRefCount, DetectDefault)
 
 #define OOVPA_NO_XREF(Name, Version, Count) \
-OOVPA_XREF(Name, Version, Count, XRefNoSaveIndex, XRefZero)
+OOVPA_XREF_EXTEND(Name, Version, Count, XRefNoSaveIndex, XRefZero, DetectDefault)
 
 #define OOVPA_END } }
 

--- a/OOVPADatabase/D3D8/3911.inl
+++ b/OOVPADatabase/D3D8/3911.inl
@@ -31,10 +31,11 @@
 //       Currently, this is the best method without rely on
 //       D3DDevice_BlockUntilVerticalBlank detection.
 //       Also, it is not a symbol.
-OOVPA_XREF(D3DDevice__ManualFindEventHandleGeneric, 3911, 2+14,
+OOVPA_XREF_EXTEND(D3DDevice__ManualFindEventHandleGeneric, 3911, 2+14,
 
     XRefNoSaveIndex,
-    XRefTwo)
+    XRefTwo,
+    DetectFirst)
 
         // D3DDevice__ManualFindEventHandleGeneric+0x00 : mov eax, [D3D__PDEVICE]
         XREF_ENTRY(0x01, XREF_D3DDEVICE),

--- a/OOVPADatabase/DSound/3911.inl
+++ b/OOVPADatabase/DSound/3911.inl
@@ -5018,10 +5018,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetVolume
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetVolume has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetVolume, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetVolume, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetVolume+0x0C : call [CMcpxVoiceClient_SetVolume]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetVolume ),
@@ -5046,10 +5047,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetVolume
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetVolume has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetVolume, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetVolume, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetVolume+0x0C : call [CMcpxVoiceClient_SetVolume]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetVolume ),
@@ -5074,10 +5076,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetPitch
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetPitch has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetPitch, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetPitch, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetPitch+0x0C : call [CMcpxVoiceClient_SetPitch]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetPitch ),
@@ -5102,10 +5105,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetPitch
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetPitch has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetPitch, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetPitch, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetPitch+0x0C : call [CMcpxVoiceClient_SetPitch]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetPitch ),
@@ -5130,10 +5134,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetLFO
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetLFO has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetLFO, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetLFO, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetLFO+0x0C : call [CMcpxVoiceClient_SetLFO]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetLFO ),
@@ -5158,10 +5163,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetLFO
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetLFO has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetLFO, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetLFO, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetLFO+0x0C : call [CMcpxVoiceClient_SetLFO]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetLFO ),
@@ -5186,10 +5192,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetEG
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetEG has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetEG, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetEG, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetEG+0x0C : call [CMcpxVoiceClient_SetEG]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetEG ),
@@ -5214,10 +5221,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetEG
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetEG has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetEG, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetEG, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetEG+0x0C : call [CMcpxVoiceClient_SetEG]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetEG ),
@@ -5242,10 +5250,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetFilter
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetFilter has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetFilter, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetFilter, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetFilter+0x0C : call [CMcpxVoiceClient_SetFilter]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetFilter ),
@@ -5269,10 +5278,11 @@ OOVPA_END;
 // ******************************************************************
 // * IDirectSoundStream_SetFilter
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetFilter, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetFilter, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetFilter+0x0C : call [CMcpxVoiceClient_SetFilter]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetFilter ),
@@ -5297,10 +5307,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetHeadroom
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetHeadroom has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetHeadroom, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetHeadroom, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetHeadroom+0x0C : call [CDirectSoundVoice_SetHeadroom]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetHeadroom ),
@@ -5325,10 +5336,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetHeadroom
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetHeadroom has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetHeadroom, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetHeadroom, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetHeadroom+0x0C : call [CDirectSoundVoice_SetHeadroom]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetHeadroom ),
@@ -5353,10 +5365,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetFrequency
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetFrequency has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetFrequency, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetFrequency, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetFrequency+0x0C : call [CDirectSoundVoice_SetFrequency]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetFrequency ),
@@ -5381,10 +5394,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetFrequency
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetFrequency has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetFrequency, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetFrequency, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetFrequency+0x0C : call [CDirectSoundVoice_SetFrequency]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetFrequency ),
@@ -5409,10 +5423,11 @@ OOVPA_END;
 // * CDirectSoundStream_SetMixBins
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetMixBins has the same asm code as this function.
-OOVPA_XREF(CDirectSoundStream_SetMixBins, 3911, 1+9,
+OOVPA_XREF_EXTEND(CDirectSoundStream_SetMixBins, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectFirst)
 
         // CDirectSoundStream_SetMixBins+0x0C : call [CDirectSoundVoice_SetMixBins]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetMixBins ),
@@ -5437,10 +5452,11 @@ OOVPA_END;
 // * IDirectSoundStream_SetMixBins
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetMixBins has the same asm code as this function.
-OOVPA_XREF(IDirectSoundStream_SetMixBins, 3911, 1+9,
+OOVPA_XREF_EXTEND(IDirectSoundStream_SetMixBins, 3911, 1+9,
 
     XRefNoSaveIndex,
-    XRefOne)
+    XRefOne,
+    DetectSecond)
 
         // IDirectSoundStream_SetMixBins+0x0C : call [CDirectSoundVoice_SetMixBins]
         XREF_ENTRY( 0x0D, XREF_CDirectSoundVoice_SetMixBins ),

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -468,9 +468,16 @@ void* XbSymbolLocateFunction(const char* szFuncName,
         upper -= Offset;
     }
 
-    // search all of the image memory
+    // 
+    unsigned int detect_selection = Oovpa->DetectSelect;
+    unsigned int counter = 0;
+
+    // search all of the buffer memory range
     for (memptr_t cur = lower; cur < upper; cur++) {
         if (CompareOOVPAToAddress(Oovpa, cur, xb_start_virtual_addr)) {
+
+            // Increase the counter whenever detected address is found.
+            counter++;
 
             while (derive_indices > 0) {
                 uint32_t XRef;
@@ -501,23 +508,55 @@ void* XbSymbolLocateFunction(const char* szFuncName,
                     XRefDataBase[XRef] = XRefAddr;
                 }*/
 
-                if (!bScanFirstDetect || (bScanFirstDetect && symbol_address == NULL)) {
-                    XRefDataBase[XRef] = XRefAddr;
+                // Check if selection is default (zero) then perform the standard procedure.
+                if (detect_selection == 0) {
+                    if (!bScanFirstDetect || (bScanFirstDetect && symbol_address == NULL)) {
+                        XRefDataBase[XRef] = XRefAddr;
+                    }
+                }
+                // Otherwise, perform a detected selection procedure.
+                else {
+                    // If counter match the target selection, then save the ref address.
+                    if (detect_selection == counter) {
+                        XRefDataBase[XRef] = XRefAddr;
+                    }
                 }
             }
 
-            if (symbol_address != NULL) {
-                XbSymbolOutputMessageFormat(XB_OUTPUT_MESSAGE_WARN,
-                    "Duplicate symbol detection found for %s (%hu), 0x%08x vs 0x%08x",
-                    szFuncName, version, symbol_address, cur - xb_start_virtual_addr);
-            }
+            // Check if selection is default (zero) then perform the standard procedure.
+            if (detect_selection == 0) {
 
-            if (!bScanFirstDetect || (bScanFirstDetect && symbol_address == NULL)) {
-                symbol_address = cur - xb_start_virtual_addr;
-            }
+                if (symbol_address != NULL) {
+                    XbSymbolOutputMessageFormat(XB_OUTPUT_MESSAGE_WARN,
+                        "Duplicate symbol detection found for %s (%hu), 0x%08x vs 0x%08x",
+                        szFuncName, version, symbol_address, cur - xb_start_virtual_addr);
+                }
 
-            if (bOneTimeScan) {
-                break;
+                if (!bScanFirstDetect || (bScanFirstDetect && symbol_address == NULL)) {
+                    symbol_address = cur - xb_start_virtual_addr;
+                }
+
+                if (bOneTimeScan) {
+                    break;
+                }
+            }
+            // Otherwise, perform a detected selection procedure.
+            else {
+                // If counter match the detected selection, then perform a force break here
+                // with address set.
+                if (detect_selection == counter) {
+                    symbol_address = cur - xb_start_virtual_addr;
+
+                    if (bOneTimeScan) {
+                        break;
+                    }
+                }
+                // Otherwise, let's log debug info about what is skipped address detection.
+                else {
+                    XbSymbolOutputMessageFormat(XB_OUTPUT_MESSAGE_DEBUG,
+                        "Skipped symbol detection found for %s (%hu), 0x%08x",
+                        szFuncName, version, cur - xb_start_virtual_addr);
+                }
             }
         }
     }
@@ -1689,6 +1728,7 @@ unsigned int XbSymbolDataBaseVerifyDataBaseList(SymbolDatabaseVerifyContext *con
 unsigned int XbSymbolDataBaseVerifyOOVPA(SymbolDatabaseVerifyContext *context, OOVPA *oovpa)
 {
     unsigned int error_count = 0;
+
     if (context->against == NULL) {
         // TODO : verify XRefSaveIndex and XRef's (how?)
 
@@ -1699,6 +1739,7 @@ unsigned int XbSymbolDataBaseVerifyOOVPA(SymbolDatabaseVerifyContext *context, O
         for (int p = oovpa->XRefCount + 1; p < oovpa->Count; p++) {
             uint32_t curr_offset;
             GetOovpaEntry(oovpa, p, &curr_offset, &dummy_value);
+
             if (!(curr_offset > prev_offset)) {
                 error_count++;
                 OOVPAError(context, "Lovp[%2u] : Offset (0x%03x) must be larger then previous offset (0x%03x)",
@@ -1730,6 +1771,7 @@ unsigned int XbSymbolDataBaseVerifyOOVPA(SymbolDatabaseVerifyContext *context, O
     int unique_offset_right = 0;
     int equal_offset_value = 0;
     int equal_offset_different_value = 0;
+
     while (true) {
         bool left_next = true;
         bool right_next = true;
@@ -1771,25 +1813,43 @@ unsigned int XbSymbolDataBaseVerifyOOVPA(SymbolDatabaseVerifyContext *context, O
         }
     }
 
+    bool unique_detect_select;
+    // First, let's make sure DetectSelect is the same
+    if ((left->DetectSelect == right->DetectSelect) ||
+        // Or left OOVPA is set to default detect and is different than right detect select.
+        (left->DetectSelect == 0 && left->DetectSelect != right->DetectSelect) ||
+        // Or right OOVPA is set to default detect and is different than left detect select.
+        (right->DetectSelect == 0 && left->DetectSelect != right->DetectSelect)) {
+        unique_detect_select = false;
+    }
+    // When above checks are not found, then we know the detected selection is unique.
+    // Therefore ignore the OOVPA identical error.
+    else {
+        unique_detect_select = true;
+    }
+
     // no mismatching values on identical offsets?
     if (equal_offset_different_value == 0) {
         // enough matching OV-pairs?
         if (equal_offset_value > 4) {
             // no unique OV-pairs on either side?
             if (unique_offset_left + unique_offset_right == 0) {
-                error_count++;
-                OOVPAError(context, "OOVPA's are identical",
-                         unique_offset_left,
-                         unique_offset_right);
+                // If detect selection is not unique, then make an error report.
+                if (!unique_detect_select) {
+                    error_count++;
+                    OOVPAError(context, "OOVPA's are identical",
+                               unique_offset_left,
+                               unique_offset_right);
+                }
             } else {
                 // not too many new OV-pairs on the left side?
                 if (unique_offset_left < 6) {
-                    // not too many new OV-parirs on the right side?
+                    // not too many new OV-pairs on the right side?
                     if (unique_offset_right < 6) {
                         error_count++;
                         OOVPAError(context, "OOVPA's are expanded (left +%d, right +%d)",
-                                 unique_offset_left,
-                                 unique_offset_right);
+                                   unique_offset_left,
+                                   unique_offset_right);
                     }
                 }
             }


### PR DESCRIPTION
With specific detected selection scan for OOVPA, it is become possible to have 2+ identical OOVPAs with a different symbol name.

Using this method will also reduce false warnings and errors as well.