### PR TITLE
HotFix: Fix Copyright Notice and API's typo

### DIFF
--- a/OOVPA.h
+++ b/OOVPA.h
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2017 PatrickvL

--- a/OOVPADatabase/D3D8/3911.inl
+++ b/OOVPADatabase/D3D8/3911.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/3925.inl
+++ b/OOVPADatabase/D3D8/3925.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/3947.inl
+++ b/OOVPADatabase/D3D8/3947.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/4034.inl
+++ b/OOVPADatabase/D3D8/4034.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/4039.inl
+++ b/OOVPADatabase/D3D8/4039.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2018 jarupxx
 // *

--- a/OOVPADatabase/D3D8/4134.inl
+++ b/OOVPADatabase/D3D8/4134.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/4242.inl
+++ b/OOVPADatabase/D3D8/4242.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/4361.inl
+++ b/OOVPADatabase/D3D8/4361.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/4432.inl
+++ b/OOVPADatabase/D3D8/4432.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/4531.inl
+++ b/OOVPADatabase/D3D8/4531.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/4627.inl
+++ b/OOVPADatabase/D3D8/4627.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/4831.inl
+++ b/OOVPADatabase/D3D8/4831.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/4928.inl
+++ b/OOVPADatabase/D3D8/4928.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/5028.inl
+++ b/OOVPADatabase/D3D8/5028.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/5120.inl
+++ b/OOVPADatabase/D3D8/5120.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/5233.inl
+++ b/OOVPADatabase/D3D8/5233.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/5344.inl
+++ b/OOVPADatabase/D3D8/5344.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/5455.inl
+++ b/OOVPADatabase/D3D8/5455.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8/5558.inl
+++ b/OOVPADatabase/D3D8/5558.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/5788.inl
+++ b/OOVPADatabase/D3D8/5788.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8/5849.inl
+++ b/OOVPADatabase/D3D8/5849.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/D3D8LTCG/3911.inl
+++ b/OOVPADatabase/D3D8LTCG/3911.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/4039.inl
+++ b/OOVPADatabase/D3D8LTCG/4039.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/4432.inl
+++ b/OOVPADatabase/D3D8LTCG/4432.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/4531.inl
+++ b/OOVPADatabase/D3D8LTCG/4531.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/4627.inl
+++ b/OOVPADatabase/D3D8LTCG/4627.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/4721.inl
+++ b/OOVPADatabase/D3D8LTCG/4721.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/4928.inl
+++ b/OOVPADatabase/D3D8LTCG/4928.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5028.inl
+++ b/OOVPADatabase/D3D8LTCG/5028.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5120.inl
+++ b/OOVPADatabase/D3D8LTCG/5120.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5233.inl
+++ b/OOVPADatabase/D3D8LTCG/5233.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5344.inl
+++ b/OOVPADatabase/D3D8LTCG/5344.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5455.inl
+++ b/OOVPADatabase/D3D8LTCG/5455.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5788.inl
+++ b/OOVPADatabase/D3D8LTCG/5788.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG/5849.inl
+++ b/OOVPADatabase/D3D8LTCG/5849.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/D3D8_OOVPA.inl
+++ b/OOVPADatabase/D3D8_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/DSound/3911.inl
+++ b/OOVPADatabase/DSound/3911.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017-2019 RadWolfie
 // *

--- a/OOVPADatabase/DSound/3936.inl
+++ b/OOVPADatabase/DSound/3936.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/DSound/4039.inl
+++ b/OOVPADatabase/DSound/4039.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017-2019 RadWolfie
 // *

--- a/OOVPADatabase/DSound/4134.inl
+++ b/OOVPADatabase/DSound/4134.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2018-2019 RadWolfie

--- a/OOVPADatabase/DSound/4242.inl
+++ b/OOVPADatabase/DSound/4242.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017-2019 RadWolfie
 // *

--- a/OOVPADatabase/DSound/4361.inl
+++ b/OOVPADatabase/DSound/4361.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/DSound/4432.inl
+++ b/OOVPADatabase/DSound/4432.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/DSound/4531.inl
+++ b/OOVPADatabase/DSound/4531.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/DSound/4627.inl
+++ b/OOVPADatabase/DSound/4627.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2019 RadWolfie

--- a/OOVPADatabase/DSound/4721.inl
+++ b/OOVPADatabase/DSound/4721.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *  (c) 2019 RadWolfie

--- a/OOVPADatabase/DSound/4831.inl
+++ b/OOVPADatabase/DSound/4831.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *  (c) 2019 RadWolfie

--- a/OOVPADatabase/DSound/5028.inl
+++ b/OOVPADatabase/DSound/5028.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2019 RadWolfie

--- a/OOVPADatabase/DSound/5344.inl
+++ b/OOVPADatabase/DSound/5344.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2019 RadWolfie

--- a/OOVPADatabase/DSound/5455.inl
+++ b/OOVPADatabase/DSound/5455.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017-2019 RadWolfie
 // *

--- a/OOVPADatabase/DSound/5558.inl
+++ b/OOVPADatabase/DSound/5558.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *  (c) 2017 PatrickvL

--- a/OOVPADatabase/DSound_OOVPA.inl
+++ b/OOVPADatabase/DSound_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017-2019 RadWolfie
 // *  (c) 2017 jarupxx

--- a/OOVPADatabase/JVS/4831.inl
+++ b/OOVPADatabase/JVS/4831.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2019 Luke Usher
 // *

--- a/OOVPADatabase/JVS_OOVPA.inl
+++ b/OOVPADatabase/JVS_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2019 Luke Usher
 // *

--- a/OOVPADatabase/XActEng/4627.inl
+++ b/OOVPADatabase/XActEng/4627.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XActEng/4928.inl
+++ b/OOVPADatabase/XActEng/4928.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XActEng/5120.inl
+++ b/OOVPADatabase/XActEng/5120.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XActEng/5233.inl
+++ b/OOVPADatabase/XActEng/5233.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XActEng/5344.inl
+++ b/OOVPADatabase/XActEng/5344.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XActEng/5558.inl
+++ b/OOVPADatabase/XActEng/5558.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XActEng_OOVPA.inl
+++ b/OOVPADatabase/XActEng_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XGraphic/3911.inl
+++ b/OOVPADatabase/XGraphic/3911.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XGraphic/4134.inl
+++ b/OOVPADatabase/XGraphic/4134.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XGraphic/4361.inl
+++ b/OOVPADatabase/XGraphic/4361.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XGraphic_OOVPA.inl
+++ b/OOVPADatabase/XGraphic_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XNet/3911.inl
+++ b/OOVPADatabase/XNet/3911.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XNet/4361.inl
+++ b/OOVPADatabase/XNet/4361.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XNet/4627.inl
+++ b/OOVPADatabase/XNet/4627.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XNet/5120.inl
+++ b/OOVPADatabase/XNet/5120.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XNet/5455.inl
+++ b/OOVPADatabase/XNet/5455.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XNet_OOVPA.inl
+++ b/OOVPADatabase/XNet_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XOnline/4361.inl
+++ b/OOVPADatabase/XOnline/4361.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XOnline/4627.inl
+++ b/OOVPADatabase/XOnline/4627.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XOnline/4831.inl
+++ b/OOVPADatabase/XOnline/4831.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XOnline/5028.inl
+++ b/OOVPADatabase/XOnline/5028.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XOnline/5455.inl
+++ b/OOVPADatabase/XOnline/5455.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XOnline/5558.inl
+++ b/OOVPADatabase/XOnline/5558.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XOnline/5659.inl
+++ b/OOVPADatabase/XOnline/5659.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/XOnline/5788.inl
+++ b/OOVPADatabase/XOnline/5788.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XOnline/5849.inl
+++ b/OOVPADatabase/XOnline/5849.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/XOnline_OOVPA.inl
+++ b/OOVPADatabase/XOnline_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/3911.inl
+++ b/OOVPADatabase/Xapi/3911.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/3950.inl
+++ b/OOVPADatabase/Xapi/3950.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/4039.inl
+++ b/OOVPADatabase/Xapi/4039.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/4134.inl
+++ b/OOVPADatabase/Xapi/4134.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/4242.inl
+++ b/OOVPADatabase/Xapi/4242.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/4361.inl
+++ b/OOVPADatabase/Xapi/4361.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/4432.inl
+++ b/OOVPADatabase/Xapi/4432.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/4721.inl
+++ b/OOVPADatabase/Xapi/4721.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/4831.inl
+++ b/OOVPADatabase/Xapi/4831.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/5028.inl
+++ b/OOVPADatabase/Xapi/5028.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/5120.inl
+++ b/OOVPADatabase/Xapi/5120.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/5344.inl
+++ b/OOVPADatabase/Xapi/5344.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi/5455.inl
+++ b/OOVPADatabase/Xapi/5455.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/OOVPADatabase/Xapi/5788.inl
+++ b/OOVPADatabase/Xapi/5788.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *

--- a/OOVPADatabase/Xapi_OOVPA.inl
+++ b/OOVPADatabase/Xapi_OOVPA.inl
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2017 jarupxx
 // *

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -322,7 +322,7 @@ const char* XbSymbolLibraryToString(uint32_t library_flag)
 
 // NOTE: Library string must return only one specific flag, cannot make a mix combo flags.
 //       Otherwise, internal scan and XbSymbolLibraryToString will not function correctly.
-uint32_t XbSymbolLibrayToFlag(const char* library_name)
+uint32_t XbSymbolLibraryToFlag(const char* library_name)
 {
     if (strncmp(library_name, Lib_D3D8, 8) == 0) {
         return XbSymbolLib_D3D8;
@@ -1485,7 +1485,7 @@ bool XbSymbolScan(const void* xb_header_addr,
             }
 
             const char* LibraryStr = pLibraryVersion[lv].szName;
-            uint32_t LibraryFlag = XbSymbolLibrayToFlag(LibraryStr);
+            uint32_t LibraryFlag = XbSymbolLibraryToFlag(LibraryStr);
 
             do {
 

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -17,7 +17,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2016-2018 Luke Usher

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -515,7 +515,7 @@ bool XbSymbolScanSection(uint32_t xbe_base_address, uint32_t xbe_size, const cha
 /// </summary>
 /// <param name="library_name">Input library name string.</param>
 /// <returns>Return 0 if does not in the database. Otherwise will return flag value.</returns>
-uint32_t XbSymbolLibrayToFlag(const char* library_name);
+uint32_t XbSymbolLibraryToFlag(const char* library_name);
 
 /// <summary>
 /// (Debug feature) By calling it will perform a self test for duplicate OOVPAs. (May will change at any time.)

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2016-2017 PatrickvL

--- a/Xbe.h
+++ b/Xbe.h
@@ -15,7 +15,7 @@
 // *  You should have recieved a copy of the GNU General Public License
 // *  along with this program; see the file COPYING.
 // *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 // *
 // *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
 // *  (c) 2018 RadWolfie


### PR DESCRIPTION
Very minor fixes:
* Thanks to @LukeUsher discovery, copyright notice has **Bostom** instead of **Boston** is fixed.
* I had discover a typo for `XbSymbolLibraryToFlag` name, was `XbSymbolLibrayToFlag`.
  * **NOTE:** This typo fix does require third-party to correct their end.