### PR TITLE
Merge XONLINE and XNET into Two Databases

### DIFF
--- a/OOVPADatabase/XNet_OOVPA.inl
+++ b/OOVPADatabase/XNet_OOVPA.inl
@@ -59,7 +59,7 @@ OOVPATable XNET_OOVPA[] = {
     REGISTER_OOVPAS(XnInit, 3911, 4361), // 3911 is only XNETS library, XNET library is different OOVPA.
     REGISTER_OOVPAS(WSAStartup, 3911, 4361),
     REGISTER_OOVPAS(XNetStartup, 3911, 4361),
-    REGISTER_OOVPAS(XNetGetEthernetLinkStatus, 3911, 4627),
+    REGISTER_OOVPAS(XNetGetEthernetLinkStatus, 3911, 4627), //NOTE: Found in .text section, confirmed it is correct.
     REGISTER_OOVPAS(bind, 3911, 4627),
     REGISTER_OOVPAS(connect, 3911, 5120),
     REGISTER_OOVPAS(ioctlsocket, 3911, 4627),

--- a/OOVPADatabase/XOnline_OOVPA.inl
+++ b/OOVPADatabase/XOnline_OOVPA.inl
@@ -60,32 +60,19 @@
 #include "XOnline/5849.inl"
 
 // ******************************************************************
-// * XONLINES_OOVPA
+// * XONLINE_OOVPA
 // ******************************************************************
-OOVPATable XONLINES_OOVPA[] = {
+OOVPATable XONLINE_OOVPA[] = {
 
     // XOnline section
     REGISTER_OOVPAS(CXo_XOnlineLogon, 4361, 4627, 4831, 5455, 5558, 5849),
     REGISTER_OOVPAS(XOnlineLogon, 4361),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
-    
-    // XNet section
-    REGISTER_OOVPAS(XnInit, 4361),
-    REGISTER_OOVPAS(WSAStartup, 4361),
-    REGISTER_OOVPAS(XNetStartup, 4361),
-    REGISTER_OOVPAS(XNetGetEthernetLinkStatus, 3911, 4627), //NOTE: Found in .text section, confirmed it is correct.
-    REGISTER_OOVPAS(bind, 3911, 4627),
-    REGISTER_OOVPAS(connect, 3911, 5120),
-    REGISTER_OOVPAS(ioctlsocket, 3911, 4627),
-    REGISTER_OOVPAS(listen, 3911, 4627),
-    REGISTER_OOVPAS(recv, 3911),
-    REGISTER_OOVPAS(send, 3911),
-    REGISTER_OOVPAS(socket, 3911, 4627, 5455),
 };
 
 // ******************************************************************
-// * XONLINES_OOVPA_COUNT
+// * XONLINE_OOVPA_COUNT
 // ******************************************************************
-#define XONLINES_OOVPA_COUNT XBSDB_ARRAY_SIZE(XONLINES_OOVPA)
+#define XONLINE_OOVPA_COUNT XBSDB_ARRAY_SIZE(XONLINE_OOVPA)
 
 #endif

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -142,21 +142,17 @@ SymbolDatabaseList SymbolDBList[] = {
     //{ XbSymbolLib_XGRAPHCL ,{ Sec_XGRPH }, XGRAPHCL_OOVPA, XGRAPHCL_OOVPA_COUNT },
 
     // Added Sec_text and Sec_XNET just in case.
+    // TODO: Do we need to keep Sec_XNET in here?
     // TODO: Need to find out which function is only part of XOnlines.
-    { XbSymbolLib_XONLINE,{ Sec_text, Sec_XONLINE, Sec_XNET, Sec_FLASHROM }, XONLINES_OOVPA, XONLINES_OOVPA_COUNT },
-
     // Fun fact, XONLINES are split into 2 header sections.
-    { XbSymbolLib_XONLINES,{ Sec_text, Sec_XONLINE, Sec_XNET, Sec_FLASHROM }, XONLINES_OOVPA, XONLINES_OOVPA_COUNT },
+    { XbSymbolLib_XONLINE | XbSymbolLib_XONLINES, { Sec_text, Sec_XONLINE, Sec_XNET, Sec_FLASHROM }, XONLINE_OOVPA, XONLINE_OOVPA_COUNT },
 
     // Added Sec_text just in case.
     // TODO: Need to find out which function is only part of XNets.
-    { XbSymbolLib_XNET,{ Sec_text, Sec_XNET, Sec_FLASHROM }, XNET_OOVPA, XNET_OOVPA_COUNT },
-
     // XNETS only has XNET, might be true.
-    { XbSymbolLib_XNETS,{ Sec_text, Sec_XNET, Sec_FLASHROM }, XNET_OOVPA, XNET_OOVPA_COUNT },
-
-    // test case: Stake
-    { XbSymbolLib_XNETN,{ Sec_text, Sec_XNET, Sec_FLASHROM }, XNET_OOVPA, XNET_OOVPA_COUNT },
+    // XNETN's test case: Stake
+    { XbSymbolLib_XNET | XbSymbolLib_XNETS | XbSymbolLib_XNETN | XbSymbolLib_XONLINE | XbSymbolLib_XONLINES,
+        { Sec_text, Sec_XNET, Sec_FLASHROM }, XNET_OOVPA, XNET_OOVPA_COUNT },
 };
 
 // ******************************************************************


### PR DESCRIPTION
* migrate xonlines to xonline filter list
* migrate xnet(s|n) and xonline(s) to xnet filter list
* removed XNET symbols from XONLINE list

Tested with Xbox Live xbe file which has XONLINES library, contain XONLINE and XNET sections, with no issues.

With a bonus, the errors has been reduce from 522 to 154.