### PR TITLE
Add symbol for D3D_DestroyResource

### DIFF
--- a/OOVPADatabase/D3D8/3911.inl
+++ b/OOVPADatabase/D3D8/3911.inl
@@ -418,6 +418,35 @@ OOVPA_NO_XREF(D3DDevice_GetGammaRamp, 3911, 14)
 OOVPA_END;
 
 // ******************************************************************
+// * D3D_DestroyResource
+// ******************************************************************
+// Generic OOVPA as of 3911 and newer.
+OOVPA_NO_XREF(D3D_DestroyResource, 3911, 38)
+    // push edi 
+    // push eda
+    // mov edi [esp + $0C]
+    // mov eax, [edi]
+    // mov esi, eax
+    OV_MATCH(0x00, 0x56, 0x57, 0x8B, 0x7C, 0x24, 0x0C, 0x8B, 0x07, 0x8B, 0xF0),
+
+    // and esi, $70000
+    // cmp esi, $50000
+    OV_MATCH(0x0A, 0x81, 0xE6, 0x00, 0x00, 0x07, 0x00, 0x81, 0xFE, 0x00, 0x00, 0x05, 0x00),
+    
+    // jne eip + $04
+    // test eax, eax
+    // jne eip + $06
+    // push edi
+    OV_MATCH(0x16, 0x75, 0x04, 0x85, 0xC0, 0x79, 0x06, 0x57),
+
+    // cmp esi, $50000
+    OV_MATCH(0x28, 0x81, 0xFE, 0x00, 0x00, 0x05, 0x00),
+
+    // mov eax, [edi + $04]
+    OV_MATCH(0x35, 0x8B, 0x47, 0x04),
+OOVPA_END;
+
+// ******************************************************************
 // * D3D_SetPushBufferSize
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.

--- a/OOVPADatabase/D3D8_OOVPA.inl
+++ b/OOVPADatabase/D3D8_OOVPA.inl
@@ -403,6 +403,7 @@ OOVPATable D3D8_OOVPA[] = {
     REGISTER_OOVPAS(D3D_ClearStateBlockFlags, 3911),
     REGISTER_OOVPAS(D3D_CommonSetRenderTarget, 4627, 5028), // Used between 4627 to 5233 (from 5344's comment)
     REGISTER_OOVPAS(D3D_CreateStandAloneSurface, 4034),
+    REGISTER_OOVPAS(D3D_DestroyResource, 3911),
     REGISTER_OOVPAS(D3D_EnumAdapterModes, 3911),
     REGISTER_OOVPAS(D3D_GetAdapterDisplayMode, 3911, 4627),
     REGISTER_OOVPAS(D3D_GetAdapterIdentifier, 3911),


### PR DESCRIPTION
This pattern works for all known XDK versions, from 3911-5933

Fix #82 