### PR TITLE
Fix DSound VTable Not Found

### DIFF
--- a/OOVPADatabase/DSound_OOVPA.inl
+++ b/OOVPADatabase/DSound_OOVPA.inl
@@ -161,6 +161,13 @@
 #include "DSound/5455.inl"
 #include "DSound/5558.inl"
 
+// ******************************************************************
+// * DSOUND_OOVPA_manual
+// ******************************************************************
+OOVPATable DSound_OOVPA_manual[] = {
+    REGISTER_OOVPAS(CDirectSoundStream_Constructor, 3911), // NOTE: Does not need to be register in db. Using manual work instead, like D3D8 did.
+};
+#define DSound_OOVPA_manual_COUNT 0 // We're forcing it to be a dummy db slot to extend section scans. // XBSDB_ARRAY_SIZE(DSound_OOVPA_manual)
 
 // ******************************************************************
 // * DSOUND_OOVPA
@@ -311,7 +318,7 @@ OOVPATable DSound_OOVPA[] = {
     REGISTER_OOVPAS(CDirectSoundBuffer_Stop, 3911, 4039, 4134), // Final generic OOVPA: 4134; Removed: 0 // NOTE: Must be after CDirectSoundBuffer_StopEx for one time scan.
     REGISTER_OOVPAS(CDirectSoundBuffer_Use3DVoiceData, 5558), // Final generic OOVPA: 5558; Removed: 0 (introduced in 5558)
 
-    REGISTER_OOVPAS(CDirectSoundStream_Constructor, 3911), // NOTE: Does not need to be register in db. Using manual work instead, like D3D8 did.
+    // REGISTER_OOVPAS(CDirectSoundStream_Constructor, 3911), // NOTE: Does not need to be register in db. Using manual work instead, like D3D8 did.
 #if 0 // These signatures are no longer in use, yet preserved as documented signatures for future research usage.
       // Instead of these signatures below, using CDirectSoundStream_Constructor signature plus manual work allow us to reduce the scan process.
     REGISTER_OOVPAS(CDirectSoundStream_AddRef, 3911, 4039, 4134), // Final generic OOVPA: 4134; Removed: 0 // NOTE: The function and CAc97MediaObject::AddRef are the same asm code.

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -157,6 +157,10 @@ SymbolDatabaseList SymbolDBList[] = {
     // Jarupxx mention this is not a requirement?
     //{ Lib_D3DX8,{ Sec_D3DX }, _OOVPA, _OOVPA_COUNT },
 
+    // Only used for manual scan purpose as a workaround since both FLASHROM
+    // and text section will lead to false detection for non-manual signatures, see comment below.
+    { XbSymbolLib_DSOUND,{ Sec_DSOUND, Sec_rdata, Sec_FLASHROM, Sec_text }, DSound_OOVPA_manual, DSound_OOVPA_manual_COUNT },
+
     // NOTE: By adding FLASHROM to scan section may will lead false detection.
     // Since some symbols has very short asm codes.
     { XbSymbolLib_DSOUND,{ Sec_DSOUND, Sec_rdata, Sec_FLASHROM }, DSound_OOVPA, DSound_OOVPA_COUNT },

--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -1963,10 +1963,15 @@ unsigned int XbSymbolContext_ScanLibrary(XbSymbolContextHandle pHandle,
                     }
                 }
             }
+
+            // NOTE: Do not use break since database entry can have multiple same library entries even doesn't have 2+ bit flags.
+            // Affected case: DSound's manual scan required more sections.
+#if 0
             // Use the break if there are 2+ bit flags set such as include LTCG flag in std flag's oovpa database like D3D8.
             if ((SymbolDBList[d2].LibSec.library & ~pLibrary->flag) == 0) {
                 break;
             }
+#endif
         }
     }
 


### PR DESCRIPTION
Close #88 

Xbox Live now does register missing references using Cxbx-Reloaded's custom develop build link to this pull request.

2nd commit is a discovery which were preventing DSound's 2nd (actual) OOVPA database to scan.