### PR TITLE
Add 2 D3D8 Signatures

### DIFF
--- a/OOVPA.h
+++ b/OOVPA.h
@@ -150,6 +150,9 @@ typedef struct _LOOVPA
 #define OOVPA_XREF_EXTEND(Name, Version, Count, XRefSaveIndex, XRefCount, DetectSelect) \
 LOOVPA Name##_##Version = { Count, XRefCount, XRefSaveIndex, DetectSelect, VARPADSET, VARPADSET, VARPADSET, {
 
+#define OOVPA_XREF_DETECT(Name, Version, Count, XRefSaveIndex, XRefCount, DetectSelect) \
+OOVPA_XREF_EXTEND(Name, Version, Count, XRefSaveIndex, XRefCount, DetectSelect)
+
 #define OOVPA_NO_XREF_DETECT(Name, Version, Count, DetectSelect) \
 OOVPA_XREF_EXTEND(Name, Version, Count, XRefNoSaveIndex, XRefZero, DetectSelect)
 

--- a/OOVPADatabase/D3D8/3911.inl
+++ b/OOVPADatabase/D3D8/3911.inl
@@ -2302,7 +2302,9 @@ OOVPA_END;
 // * D3DDevice_SetRenderState_Simple
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3DDevice_SetRenderState_Simple, 3911, 12)
+OOVPA_XREF(D3DDevice_SetRenderState_Simple, 3911, 12,
+    XREF_D3DDevice_SetRenderState_Simple,
+    XRefZero)
 
         // D3DDevice_SetRenderState_Simple+0x00 : mov eax, [D3D__DEVICE]
         OV_MATCH(0x00, 0xA1),
@@ -5135,5 +5137,79 @@ OOVPA_XREF(CDevice_MakeSpace, 3911, 13,
 
         // CDevice::MakeSpace_4+0x32 : ret
         OV_MATCH(0x32, 0xC3),
+
+OOVPA_END;
+
+// ******************************************************************
+// * D3DDevice::SetRenderStateNotInline
+// ******************************************************************
+// Generic OOVPA as of 3911 and newer.
+OOVPA_XREF(D3DDevice_SetRenderStateNotInline, 3911, 1+6,
+    XREF_D3DDevice_SetRenderStateNotInline,
+    XRefOne)
+
+        // D3DDevice::SetRenderStateNotInline+0x18 : call D3DDevice_SetRenderState_Simple
+        XREF_ENTRY(0x19, XREF_D3DDevice_SetRenderState_Simple),
+
+        // D3DDevice::SetRenderStateNotInline+0x00 : push esi
+        OV_MATCH(0x00, 0x56),
+
+        // D3DDevice::SetRenderStateNotInline+0x06 : jge +0x__ (0x1F vs LTCG 0x21)
+        OV_MATCH(0x08, 0x7D),
+
+        // D3DDevice::SetRenderStateNotInline+0x0A : ecx,[addr]
+        OV_MATCH(0x0A, 0x8B, 0x0C, 0xB5),
+
+        // D3DDevice::SetRenderStateNotInline+0x18 : call D3DDevice_SetRenderState_Simple
+        OV_MATCH(0x18, 0xE8),
+
+        // After offset 0x24 has various instruction changes
+
+OOVPA_END;
+
+// ******************************************************************
+// * D3DDevice::SetRenderState
+// ******************************************************************
+// Generic OOVPA as of 3911 and newer.
+OOVPA_XREF_DETECT(D3DDevice_SetRenderState, 3911, 1+4,
+    XRefNoSaveIndex,
+    XRefOne,
+    DetectFirst)
+
+        // D3DDevice::SetRenderState+0x02 : call D3DDevice_SetRenderStateNotInline
+        XREF_ENTRY(0x03, XREF_D3DDevice_SetRenderStateNotInline),
+
+        // D3DDevice::SetRenderState+0x00 : push eax; push ecx
+        OV_MATCH(0x00, 0x50, 0x51),
+
+        // D3DDevice::SetRenderState+0x02 : call D3DDevice_SetRenderStateNotInline
+        OV_MATCH(0x02, 0xE8),
+
+        // D3DDevice::SetRenderState+0x07 : ret
+        OV_MATCH(0x07, 0xC3),
+
+OOVPA_END;
+
+// ******************************************************************
+// * D3DDevice::SetRenderState (duplicate)
+// ******************************************************************
+// Generic OOVPA as of 3911 and newer.
+// TODO: Add another macro to accept duplicates.
+OOVPA_XREF_DETECT(D3DDevice_SetRenderState2, 3911, 1+4,
+    XRefNoSaveIndex,
+    XRefOne,
+    DetectSecond)
+
+        // D3DDevice::SetRenderState+0x02 : call D3DDevice_SetRenderStateNotInline
+        XREF_ENTRY(0x03, XREF_D3DDevice_SetRenderStateNotInline),
+
+        // D3DDevice::SetRenderState+0x00 : push eax; push ecx
+        OV_MATCH(0x00, 0x50, 0x51),
+
+        // D3DDevice::SetRenderState+0x02 : call D3DDevice_SetRenderStateNotInline
+        OV_MATCH(0x02, 0xE8),
+
+        // D3DDevice::SetRenderState+0x07 : ret
+        OV_MATCH(0x07, 0xC3),
 
 OOVPA_END;

--- a/OOVPADatabase/D3D8LTCG/4627.inl
+++ b/OOVPADatabase/D3D8LTCG/4627.inl
@@ -1042,24 +1042,6 @@ OOVPA_NO_XREF(D3DDevice_SetRenderStateNotInline_0, 2048, 13)
 OOVPA_END;
 
 // ******************************************************************
-// * D3DDevice_SetRenderStateNotInline
-// ******************************************************************
-//578B7C24108BD7E8
-OOVPA_NO_XREF(D3DDevice_SetRenderStateNotInline, 1024, 9)
-
-        { 0x00, 0x56 },
-
-        { 0x11, 0x57 },
-        { 0x12, 0x8B },
-        { 0x13, 0x7C },
-        { 0x14, 0x24 },
-        { 0x15, 0x10 },
-        { 0x16, 0x8B },
-        { 0x17, 0xD7 },
-        { 0x18, 0xE8 },
-OOVPA_END;
-
-// ******************************************************************
 // * D3DDevice_SetTextureStageStateNotInline
 // ******************************************************************
 //1BC981E1F1BFFFFF81C1

--- a/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -144,7 +144,6 @@ OOVPATable D3D8LTCG_OOVPA[] = {
     REGISTER_OOVPAS(D3DDevice_SetPixelShaderConstant_4, 2024),
     REGISTER_OOVPAS(D3DDevice_SetPixelShaderProgram, 1024),
     REGISTER_OOVPAS(D3DDevice_SetPixelShader_0, 2024, 2036, 2048, 2060, 2072),
-    REGISTER_OOVPAS(D3DDevice_SetRenderStateNotInline, 1024),
     REGISTER_OOVPAS(D3DDevice_SetRenderStateNotInline_0, 2048),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_BackFillMode, 1024, 1036),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_CullMode, 1045, 1049, 1052, 1053),

--- a/OOVPADatabase/D3D8_OOVPA.inl
+++ b/OOVPADatabase/D3D8_OOVPA.inl
@@ -307,6 +307,11 @@ OOVPATable D3D8_OOVPA[] = {
     REGISTER_OOVPAS(D3DDevice_SetPixelShader, 3911, 4034, 4627),
     REGISTER_OOVPAS(D3DDevice_SetPixelShaderConstant, 3911, 4831),
     REGISTER_OOVPAS(D3DDevice_SetPixelShaderProgram, 3911),
+    REGISTER_OOVPAS(D3DDevice_SetRenderState_Simple, 3911), // Final generic OOVPA: 3911; Removed: 0
+    REGISTER_OOVPAS(D3DDevice_SetRenderStateNotInline, 3911), // Final generic OOVPA: 3911; Removed: 0 // NOTE: Must be after D3DDevice_SetRenderState_Simple.
+    // NOTE: Some or most of render state signatures below must be after D3DDevice_SetRenderStateNotInline.
+    REGISTER_OOVPAS(D3DDevice_SetRenderState, 3911), // Final generic OOVPA: 3911; Removed: 0
+    REGISTER_OOVPAS(D3DDevice_SetRenderState2, 3911), // Final generic OOVPA: 3911; Removed: 0 // NOTE: There is a verified duplicate function.
     REGISTER_OOVPAS(D3DDevice_SetRenderState_BackFillMode, 3911, 4034),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_CullMode, 3911, 4034),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_Deferred, 3911),
@@ -329,7 +334,6 @@ OOVPATable D3D8_OOVPA[] = {
     REGISTER_OOVPAS(D3DDevice_SetRenderState_RopZRead, 3911),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_SampleAlpha, 4627),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_ShadowFunc, 3911, 4034),
-    REGISTER_OOVPAS(D3DDevice_SetRenderState_Simple, 3911), // Final generic OOVPA: 3911; Removed: 0
     REGISTER_OOVPAS(D3DDevice_SetRenderState_StencilCullEnable, 3911, 4034), // Final generic OOVPA: 4034; Removed: 0
     REGISTER_OOVPAS(D3DDevice_SetRenderState_StencilEnable, 3911, 4034, 5849),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_StencilFail, 3911, 4034, 5849),

--- a/XbSymbolDatabase.h
+++ b/XbSymbolDatabase.h
@@ -540,6 +540,8 @@ typedef enum _XRefDatabaseOffset
     XREF_D3DDevice_GetRenderTarget2,
     XREF_D3DDevice_SetRenderTarget,
     XREF_D3DDevice_MakeSpace,
+    XREF_D3DDevice_SetRenderState_Simple,
+    XREF_D3DDevice_SetRenderStateNotInline,
     XREF_D3DDevice_SetVertexShaderConstant1,
     XREF_D3DDevice_SetVertexShaderConstant4,
     XREF_D3DResource_AddRef,


### PR DESCRIPTION
Close #85

OOVPA changelog:

Removed:
- D3DDevice_SetRenderStateNotInline (1024, was in 4627)

Added:
- D3DDevice_SetRenderStateNotInline (3911)
  - Can be detected in LTCG titles
- D3DDevice_SetRenderState (3911)
- D3DDevice_SetRenderState2 (3911)
  - Confirmed duplicate functions found in some titles.

Plus added detect macro to able use with xref.

Tested with custom Cxbx-Reloaded from verify symbol cache file with no issue.