### PR TITLE
Add some XONLINE signatures

### DIFF
--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -770,6 +770,7 @@ typedef enum _XRefDatabaseOffset
     // +s
     XREF_XoUpdateLaunchNewImageInternal,
     XREF_CXo_XOnlineLogon,
+    XREF_CXo_XOnlineMatchSearch,
 
     // XAPI
     XREF_XAPI_GetTypeInformation,
@@ -792,7 +793,7 @@ typedef enum _XRefDatabaseOffset
     XREF_JvsScReceiveRs323c_String,
     XREF_JvsScSendMidi_String,
     XREF_JvsScSendRs323c_String,
-    
+
     XREF_COUNT // XREF_COUNT must always be last.
     // Also, if XREF_COUNT > sizeof(uint16), enlarge struct OOVPA.XRefSaveIndex (and Value somehow)
 } XRefDatabaseOffset;

--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -771,6 +771,7 @@ typedef enum _XRefDatabaseOffset
     XREF_XoUpdateLaunchNewImageInternal,
     XREF_CXo_XOnlineLogon,
     XREF_CXo_XOnlineMatchSearch,
+    XREF_CXo_XOnlineMatchSearchResultsLen,
 
     // XAPI
     XREF_XAPI_GetTypeInformation,

--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -774,6 +774,7 @@ typedef enum _XRefDatabaseOffset
     XREF_CXo_XOnlineMatchSearchResultsLen,
     XREF_CXo_XOnlineMatchSearchGetResults,
     XREF_CXo_XOnlineMatchSessionUpdate,
+    XREF_CXo_XOnlineMatchSessionCreate,
 
     // XAPI
     XREF_XAPI_GetTypeInformation,

--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -773,6 +773,7 @@ typedef enum _XRefDatabaseOffset
     XREF_CXo_XOnlineMatchSearch,
     XREF_CXo_XOnlineMatchSearchResultsLen,
     XREF_CXo_XOnlineMatchSearchGetResults,
+    XREF_CXo_XOnlineMatchSessionUpdate,
 
     // XAPI
     XREF_XAPI_GetTypeInformation,

--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -772,6 +772,7 @@ typedef enum _XRefDatabaseOffset
     XREF_CXo_XOnlineLogon,
     XREF_CXo_XOnlineMatchSearch,
     XREF_CXo_XOnlineMatchSearchResultsLen,
+    XREF_CXo_XOnlineMatchSearchGetResults,
 
     // XAPI
     XREF_XAPI_GetTypeInformation,

--- a/src/OOVPADatabase/XOnline/4831.inl
+++ b/src/OOVPADatabase/XOnline/4831.inl
@@ -88,3 +88,44 @@ OOVPA_XREF(XOnlineMatchSearch, 4831, 1+4,
         // jmp ...
         OV_MATCH(0x0A, 0xE9),
 OOVPA_END;
+
+// ******************************************************************
+// * CXo_XOnlineMatchSearchResultsLen
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSearchResultsLen, 4831, 14,
+
+    XREF_CXo_XOnlineMatchSearchResultsLen,
+    XRefZero)
+
+        // test ecx, ecx
+        // jnz ...
+        OV_MATCH(0x00, 0x85, 0xC9, 0x75),
+
+        // mov eax, ...
+        OV_MATCH(0x04, 0xB8),
+        // jmp ...
+        OV_MATCH(0x09, 0xEB),
+        // push esi
+        // mov esi, dword ptr [esp + param_2]
+        OV_MATCH(0x0B, 0x56, 0x8B, 0x74, 0x24, 0x0C),
+        // test esi, esi
+        // push 54h
+        OV_MATCH(0x10, 0x85, 0xF6, 0x6A, 0x54),
+OOVPA_END;
+
+// ******************************************************************
+// * XOnlineMatchSearchResultsLen
+// ******************************************************************
+OOVPA_XREF(XOnlineMatchSearchResultsLen, 4831, 1+3,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x07, XREF_CXo_XOnlineMatchSearchResultsLen),
+
+        // mov ecx, ...
+        OV_MATCH(0x00, 0x8B, 0x0D),
+
+        // jmp ...
+        OV_MATCH(0x06, 0xE9),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline/4831.inl
+++ b/src/OOVPADatabase/XOnline/4831.inl
@@ -49,3 +49,42 @@ OOVPA_XREF(CXo_XOnlineLogon, 4831, 15,
         { 0x2B, 0x80 },
         { 0x2C, 0xE9 },
 OOVPA_END;
+
+// ******************************************************************
+// * CXo::XOnlineMatchSearch
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSearch, 4831, 13,
+
+    XREF_CXo_XOnlineMatchSearch,
+    XRefZero)
+
+        // push ebp
+        // mov ebp, esp
+        // test ecx, ecx
+        // jnz eip + $09h
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0x85, 0xC9, 0x75, 0x09),
+
+        // pop ebp
+        // ret $1Ch
+        // pop ebp
+        // jmp ...
+        OV_MATCH(0x0C, 0x5D, 0xC2, 0x1C, 0x00, 0x5D, 0xE9),
+OOVPA_END;
+
+// ******************************************************************
+// * XOnlineMatchSearch
+// ******************************************************************
+OOVPA_XREF(XOnlineMatchSearch, 4831, 1+4,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x0B, XREF_CXo_XOnlineMatchSearch),
+
+        // push ebp
+        // mov ebp, esp
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+        // jmp ...
+        OV_MATCH(0x0A, 0xE9),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline/4831.inl
+++ b/src/OOVPADatabase/XOnline/4831.inl
@@ -166,3 +166,47 @@ OOVPA_XREF(XOnlineMatchSearchGetResults, 4831, 1+3,
         // jmp ...
         OV_MATCH(0x06, 0xE9),
 OOVPA_END;
+
+// ******************************************************************
+// * CXo::XOnlineMatchSessionUpdate
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSessionUpdate, 4831, 22,
+
+    XREF_CXo_XOnlineMatchSessionUpdate,
+    XRefZero)
+
+        // push ebp
+        // mov ebp, esp
+        // test ecx, ecx
+        // jnz eip + $07h
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0x85, 0xC9, 0x75, 0x07),
+
+        // push dword ptr [ebp + param_10]
+        // push dword ptr [ebp + param_9]
+        OV_MATCH(0x0E, 0xFF, 0x75, 0x2C, 0xFF, 0x75, 0x28),
+        // push dword ptr [ebp + param_8]
+        // push dword ptr [ebp + param_7]
+        OV_MATCH(0x14, 0xFF, 0x75, 0x24, 0xFF, 0x75, 0x20),
+        // push dword ptr [ebp + param_6]
+        OV_MATCH(0x1A, 0xFF, 0x75, 0x1C),
+OOVPA_END;
+
+// ******************************************************************
+// * XOnlineMatchSessionUpdate
+// ******************************************************************
+OOVPA_XREF(XOnlineMatchSessionUpdate, 4831, 1+11,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x28, XREF_CXo_XOnlineMatchSessionUpdate),
+
+        // push ebp
+        // mov ebp, esp
+        // push dword ptr [ebp + param_10]
+        // mov ecx, ...
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0xFF, 0x75, 0x2C, 0x8B, 0x0D),
+
+        // push dword ptr [ebp + param_9]
+        OV_MATCH(0x0C, 0xFF, 0x75, 0x28),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline/4831.inl
+++ b/src/OOVPADatabase/XOnline/4831.inl
@@ -210,3 +210,46 @@ OOVPA_XREF(XOnlineMatchSessionUpdate, 4831, 1+11,
         // push dword ptr [ebp + param_9]
         OV_MATCH(0x0C, 0xFF, 0x75, 0x28),
 OOVPA_END;
+
+// ******************************************************************
+// * CXo::XOnlineMatchSessionCreate
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSessionCreate, 4831, 12,
+
+    XREF_CXo_XOnlineMatchSessionCreate,
+    XRefZero)
+
+        // push ebp
+        // mov ebp, esp
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+        // jnz eip + 0x07
+        OV_MATCH(0x09, 0x75, 0x07),
+
+        // jmp eip + 0x55
+        OV_MATCH(0x10, 0xEB, 0x55),
+
+        // mov byte ptr [ebp - 0x08], al
+        OV_MATCH(0x18, 0x88, 0x45, 0xF8),
+
+        // jbe eip + 0x14
+        OV_MATCH(0x30, 0x76, 0x14),
+OOVPA_END;
+
+// ******************************************************************
+// * XOnlineMatchSessionCreate
+// ******************************************************************
+OOVPA_XREF(XOnlineMatchSessionCreate, 4831, 1+4,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x0B, XREF_CXo_XOnlineMatchSessionCreate),
+
+        // push ebp
+        // mov ebp, esp
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+        // jmp ...
+        OV_MATCH(0x0A, 0xE9),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline/4831.inl
+++ b/src/OOVPADatabase/XOnline/4831.inl
@@ -129,3 +129,40 @@ OOVPA_XREF(XOnlineMatchSearchResultsLen, 4831, 1+3,
         // jmp ...
         OV_MATCH(0x06, 0xE9),
 OOVPA_END;
+
+// ******************************************************************
+// * CXo::XOnlineMatchSearchGetResults
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSearchGetResults, 4831, 12,
+
+    XREF_CXo_XOnlineMatchSearchGetResults,
+    XRefZero)
+
+        // push ebp
+        // mov ebp, esp
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+        // cmp dword ptr [ecx + 0x30], 0xC8
+        OV_MATCH(0x1A, 0x81, 0x79, 0x30, 0xC8, 0x00, 0x00, 0x00),
+
+        // mov dword ptr [ebp - 0x04], ...
+        OV_MATCH(0x21, 0x89),
+        OV_MATCH(0x23, 0xFC),
+OOVPA_END;
+
+// ******************************************************************
+// * XOnlineMatchSearchGetResults
+// ******************************************************************
+OOVPA_XREF(XOnlineMatchSearchGetResults, 4831, 1+3,
+
+    XRefNoSaveIndex,
+    XRefOne)
+
+        XREF_ENTRY(0x07, XREF_CXo_XOnlineMatchSearchGetResults),
+
+        // mov ecx, ...
+        OV_MATCH(0x00, 0x8B, 0x0D),
+
+        // jmp ...
+        OV_MATCH(0x06, 0xE9),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline/5233.inl
+++ b/src/OOVPADatabase/XOnline/5233.inl
@@ -1,0 +1,49 @@
+// ******************************************************************
+// *
+// *   OOVPADatabase->XOnline->5233.inl
+// *
+// *  XbSymbolDatabase is free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have received a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// *
+// *  (c) 2020 Stefan Schmidt
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+// ******************************************************************
+// * CXo::XOnlineMatchSessionUpdate
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSessionUpdate, 5233, 19,
+
+    XREF_CXo_XOnlineMatchSessionUpdate,
+    XRefZero)
+
+        // push ebp
+        // mov ebp, esp
+        // push esi
+        // mov esi, ecx
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0x56, 0x8B, 0xF1),
+        // test esi, esi
+        // jnz eip + $07h
+        OV_MATCH(0x06, 0x85, 0xF6, 0x75),
+
+        // push 0
+        // push dword ptr [ebp + param_2]
+        // mov ecx, esi
+        OV_MATCH(0x11, 0x6A, 0x00, 0xFF, 0x75, 0x0C, 0x8B, 0xCE),
+        // push dword ptr [ebp + param_1]
+        OV_MATCH(0x18, 0xFF, 0x75, 0x08),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline/5849.inl
+++ b/src/OOVPADatabase/XOnline/5849.inl
@@ -49,3 +49,28 @@ OOVPA_XREF(CXo_XOnlineLogon, 5849, 15,
         { 0x41, 0x80 },
         { 0x42, 0xE9 },
 OOVPA_END;
+
+// ******************************************************************
+// * CXo::XOnlineMatchSessionCreate
+// ******************************************************************
+OOVPA_XREF(CXo_XOnlineMatchSessionCreate, 5849, 12,
+
+    XREF_CXo_XOnlineMatchSessionCreate,
+    XRefZero)
+
+        // push ebp
+        // mov ebp, esp
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+        // jnz eip + 0x07
+        OV_MATCH(0x0D, 0x75, 0x07),
+
+        // jmp eip + 0x5F
+        OV_MATCH(0x14, 0xEB, 0x5F),
+
+        // mov byte ptr [ebp - 0x07], bl
+        OV_MATCH(0x18, 0x88, 0x5D, 0xF9),
+
+        // jbe eip + 0x12
+        OV_MATCH(0x3E, 0x76, 0x12),
+OOVPA_END;

--- a/src/OOVPADatabase/XOnline_OOVPA.inl
+++ b/src/OOVPADatabase/XOnline_OOVPA.inl
@@ -59,6 +59,7 @@
 #include "XOnline/4627.inl"
 #include "XOnline/4831.inl"
 #include "XOnline/5028.inl"
+#include "XOnline/5233.inl"
 #include "XOnline/5455.inl"
 #include "XOnline/5558.inl"
 #include "XOnline/5659.inl"
@@ -79,6 +80,8 @@ OOVPATable XONLINE_OOVPA[] = {
     REGISTER_OOVPAS(XOnlineMatchSearchResultsLen, 4831),
     REGISTER_OOVPAS(CXo_XOnlineMatchSearchGetResults, 4831),
     REGISTER_OOVPAS(XOnlineMatchSearchGetResults, 4831),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSessionUpdate, 4831, 5233),
+    REGISTER_OOVPAS(XOnlineMatchSessionUpdate, 4831),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
 };
 

--- a/src/OOVPADatabase/XOnline_OOVPA.inl
+++ b/src/OOVPADatabase/XOnline_OOVPA.inl
@@ -77,6 +77,8 @@ OOVPATable XONLINE_OOVPA[] = {
     REGISTER_OOVPAS(XOnlineMatchSearch, 4831),
     REGISTER_OOVPAS(CXo_XOnlineMatchSearchResultsLen, 4831),
     REGISTER_OOVPAS(XOnlineMatchSearchResultsLen, 4831),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSearchGetResults, 4831),
+    REGISTER_OOVPAS(XOnlineMatchSearchGetResults, 4831),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
 };
 

--- a/src/OOVPADatabase/XOnline_OOVPA.inl
+++ b/src/OOVPADatabase/XOnline_OOVPA.inl
@@ -75,6 +75,8 @@ OOVPATable XONLINE_OOVPA[] = {
     REGISTER_OOVPAS(XOnlineLogon, 4361),
     REGISTER_OOVPAS(CXo_XOnlineMatchSearch, 4831),
     REGISTER_OOVPAS(XOnlineMatchSearch, 4831),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSearchResultsLen, 4831),
+    REGISTER_OOVPAS(XOnlineMatchSearchResultsLen, 4831),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
 };
 

--- a/src/OOVPADatabase/XOnline_OOVPA.inl
+++ b/src/OOVPADatabase/XOnline_OOVPA.inl
@@ -73,6 +73,8 @@ OOVPATable XONLINE_OOVPA[] = {
     // XOnline section
     REGISTER_OOVPAS(CXo_XOnlineLogon, 4361, 4627, 4831, 5455, 5558, 5849),
     REGISTER_OOVPAS(XOnlineLogon, 4361),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSearch, 4831),
+    REGISTER_OOVPAS(XOnlineMatchSearch, 4831),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
 };
 

--- a/src/OOVPADatabase/XOnline_OOVPA.inl
+++ b/src/OOVPADatabase/XOnline_OOVPA.inl
@@ -82,6 +82,8 @@ OOVPATable XONLINE_OOVPA[] = {
     REGISTER_OOVPAS(XOnlineMatchSearchGetResults, 4831),
     REGISTER_OOVPAS(CXo_XOnlineMatchSessionUpdate, 4831, 5233),
     REGISTER_OOVPAS(XOnlineMatchSessionUpdate, 4831),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSessionCreate, 4831, 5849),
+    REGISTER_OOVPAS(XOnlineMatchSessionCreate, 4831),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
 };
 


### PR DESCRIPTION
This picks @LukeUsher's Insignia RE wishlist from #74 and adds signatures for them, namely `XOnlineMatchSearch`, `XOnlineMatchSearchResultsLen`, `XOnlineMatchSearchGetResults`, `XOnlineMatchSessionUpdate` and `XOnlineMatchSessionCreate`.

I was only able to check against games built with XDK version 4831, 4928, 5659 and 5849. Testing the versions in-between would be appreciated.