### PR TITLE
Add a CLI tool and build it with GH actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,26 @@ cmake_minimum_required (VERSION 3.10.2)
 
 project (XbSymbolDatabase)
 
-if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
- option(XBSDB_INSTALL_LIB "Install libXbSymbolDatabase library" OFF)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+ set(XBSDB_DEFAULT_CONFIGS ON)
 else()
- set(XBSDB_INSTALL_LIB ON)
+ set(XBSDB_DEFAULT_CONFIGS OFF)
 endif()
+
+option(XBSDB_INSTALL_LIB "Install libXbSymbolDatabase library" ${XBSDB_DEFAULT_CONFIGS})
+option(XBSDB_BUILD_CLI "Build XbSymbolDatabase CLI tool" ${XBSDB_DEFAULT_CONFIGS})
+include(CMakeDependentOption)
+cmake_dependent_option(XBSDB_INSTALL_CLI "Install XbSymbolDatabase CLI tool" ${XBSDB_DEFAULT_CONFIGS}
+                       "XBSDB_BUILD_CLI" OFF)
 
 # For any optional tools, use list(APPEND XBSDB_INSTALL_TOOLS "tool_name")
 
 if(XBSDB_INSTALL_LIB)
  list(APPEND XBSDB_INSTALL_TOOLS "libXbSymbolDatabase")
+endif()
+
+if(XBSDB_INSTALL_CLI)
+ list(APPEND XBSDB_INSTALL_TOOLS "XbSymbolDatabaseCLI")
 endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -3,3 +3,7 @@
 cmake_minimum_required (VERSION 3.10.2)
 
 add_subdirectory("libXbSymbolDatabase")
+
+if(XBSDB_BUILD_CLI)
+ add_subdirectory("cli")
+endif()

--- a/projects/cli/CMakeLists.txt
+++ b/projects/cli/CMakeLists.txt
@@ -1,0 +1,19 @@
+# CMakeList.txt : CMake project for XbSymbolDatabaseCLI.
+#
+cmake_minimum_required(VERSION 3.10.2)
+
+project(XbSymbolDatabaseCLI LANGUAGES C)
+
+find_package(Threads)
+
+add_executable(XbSymbolDatabaseCLI ${XBSDB_ROOT_DIR}/src/cli/main.c)
+
+target_compile_definitions(XbSymbolDatabaseCLI PRIVATE _CRT_SECURE_NO_WARNINGS)
+
+target_link_libraries(XbSymbolDatabaseCLI libXbSymbolDatabase Threads::Threads)
+
+set_target_properties(XbSymbolDatabaseCLI PROPERTIES
+ C_STANDARD 11
+ C_STANDARD_REQUIRED ON
+ FOLDER XbSymbolDatabase
+)

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1,0 +1,103 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include <libXbSymbolDatabase.h>
+
+static void msg_cb(xb_output_message message_flag, const char *msg)
+{
+    fprintf(stderr, "XbSymbolDatabase: %s\n", msg);
+}
+
+static void reg_cb(const char* library_str, uint32_t library_flag, const char* symbol_str, xbaddr address, uint32_t build_verison)
+{
+    printf("%.8s__%s = 0x%08x\n", library_str, symbol_str, address);
+}
+
+int main(int argc, char const *argv[])
+{
+    int verbose = 0;
+    const char *xbe_path = NULL;
+    int arg_off = 1;
+
+    if (argc > 1 && strcmp(argv[1], "-verbose") == 0) {
+        verbose = 1;
+        arg_off++;
+    }
+
+    if (arg_off >= argc) {
+        fprintf(stderr, "usage: %s [-verbose] xbefile\n", argv[0]);
+        return 1;
+    } else {
+        xbe_path = argv[arg_off];
+    }
+
+    unsigned int version = XbSymbolDatabase_LibraryVersion();
+    if (verbose) {
+        fprintf(stderr, "Database Version = %x\n", version);
+    }
+
+    FILE *fd = fopen(xbe_path, "rb");
+    if (fd == NULL) {
+        fprintf(stderr, "failed to open %s for reading\n", xbe_path);
+        return 1;
+    }
+
+    fseek(fd, 0, SEEK_END);
+    size_t size = ftell(fd);
+    rewind(fd);
+
+    unsigned char *xbe = malloc(size);
+    assert(xbe != NULL);
+    size_t num_read = fread(xbe, 1, size, fd);
+    assert(num_read == size);
+    if (memcmp(xbe, "XBEH", 4) != 0) {
+        fprintf(stderr, "invalid xbe header\n");
+        free(xbe);
+        return 1;
+    }
+
+    XbSymbolDatabase_SetOutputMessage(&msg_cb);
+
+    if (verbose) {
+        XbSymbolDatabase_SetOutputVerbosity(XB_OUTPUT_MESSAGE_DEBUG);
+    }
+
+    XbSDBLibraryHeader lib_hdr;
+    lib_hdr.count = XbSymbolDatabase_GenerateLibraryFilter(xbe, NULL);
+    lib_hdr.filters = malloc(lib_hdr.count * sizeof(XbSDBLibrary));
+    assert(lib_hdr.filters != NULL);
+    XbSymbolDatabase_GenerateLibraryFilter(xbe, &lib_hdr);
+
+    if (verbose) {
+        fprintf(stderr, "%u libraries\n", lib_hdr.count);
+        for (unsigned int i = 0; i < lib_hdr.count; i++) {
+            fprintf(stderr, "  %.8s\n", lib_hdr.filters[i].name);
+        }
+    }
+
+    XbSDBSectionHeader sec_hdr;
+    sec_hdr.count = XbSymbolDatabase_GenerateSectionFilter(xbe, NULL, 1);
+    sec_hdr.filters = malloc(sec_hdr.count * sizeof(XbSDBSection));
+    assert(sec_hdr.filters != NULL);
+    XbSymbolDatabase_GenerateSectionFilter(xbe, &sec_hdr, 1);
+
+    if (verbose) {
+        fprintf(stderr, "%u sections\n", sec_hdr.count);
+        for (unsigned int i = 0; i < sec_hdr.count; i++) {
+            fprintf(stderr, "  %.8s\n", sec_hdr.filters[i].name);
+        }
+    }
+
+    XbSymbolContextHandle ctx;
+    bool status = XbSymbolDatabase_CreateXbSymbolContext(&ctx,
+        reg_cb, lib_hdr, sec_hdr, XbSymbolDatabase_GetKernelThunkAddress(xbe));
+    assert(status == 1);
+    XbSymbolContext_ScanManual(ctx);
+    XbSymbolContext_ScanAllLibraryFilter(ctx);
+    XbSymbolContext_Release(ctx);
+
+    free(lib_hdr.filters);
+    free(sec_hdr.filters);
+    free(xbe);
+    return 0;
+}


### PR DESCRIPTION
This adds a cli tool, which can be used to run symbol detection on an XBE. The actual tool was written by @mborgerson, I only tweaked the CMakeLists to fix building under some Linux distributions and to make building the tool optional (as Cxbx-Reloaded probably doesn't want it built). The Actions file is also his work, I slightly modified it to ignore the readme (like the current Actions file does) and make it use checkout@v2.

The Actions file also uploads the created CLI tool binaries as an artifact. This is then used in @mborgerson's Ghidra XBE plugin, where this artifact is downloaded and included to provide symbol detection.