### PR TITLE
HOTFIX: Corrected bypass build version limit to allow set before start scan

### DIFF
--- a/XbSymbolDatabase.c
+++ b/XbSymbolDatabase.c
@@ -355,7 +355,7 @@ bool XbSymbolContext_RegisterLibrary(XbSymbolContextHandle pHandle, uint32_t lib
 {
     iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
 
-    if (!iXbSymbolContext_AllowSetParameter(pContext)) {
+    if (iXbSymbolContext_AllowSetParameter(pContext)) {
         return false;
     }
 


### PR DESCRIPTION
This bug was introduced in original pull request #94.

With this fix, I can receive warnings for any signatures that are too high which may or may not need to be lower.