### PR TITLE
Fix couple errors and warnings from DSound OOVPA signatures

### DIFF
--- a/src/OOVPADatabase/DSound/3911.inl
+++ b/src/OOVPADatabase/DSound/3911.inl
@@ -1632,30 +1632,28 @@ OOVPA_END;
 // ******************************************************************
 // * CSensaura3d_GetLiteHRTFFilterPair
 // ******************************************************************
-OOVPA_XREF(CSensaura3d_GetLiteHRTFFilterPair, 3911, 10,
+// Generic OOVPA as of 3911 and newer
+OOVPA_XREF(CSensaura3d_GetLiteHRTFFilterPair, 3911, 11,
 
     XREF_CSensaura3d_GetLiteHRTFFilterPair,
     XRefZero)
 
-        //CSensaura3d_GetLiteHRTFFilterPair+0x00 : push ebp
-        { 0x00, 0x55 },
+        // push ebp
+        // mov ebp, esp
+        OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
 
-        //CSensaura3d_GetLiteHRTFFilterPair+0x14 : push ecx
-        { 0x15, 0x51 },
+        // push ecx
+        OV_MATCH(0x15, 0x51),
 
-        //CSensaura3d_GetLiteHRTFFilterPair+0x22 : push 3
-        { 0x1F, 0x6A },
-        { 0x20, 0x03 },
+        // call ...
+        OV_MATCH(0x19, 0xE8),
+        // cdq
+        // push 3
+        // pop ecx
+        OV_MATCH(0x1E, 0x99, 0x6A, 0x03, 0x59),
 
-        //CSensaura3d_GetLiteHRTFFilterPair+0x22 : idiv eax, ecx
-        { 0x22, 0xF7 },
-        { 0x23, 0xF9 },
-
-        //CSensaura3d_GetLiteHRTFFilterPair+0x24 : cmp dword ptr [ebp+10h], 0
-        { 0x24, 0x83 },
-        { 0x25, 0x7D },
-        { 0x26, 0x10 },
-        { 0x27, 0x00 },
+        // idiv eax, ecx
+        OV_MATCH(0x22, 0xF7, 0xF9),
 OOVPA_END;
 
 // ******************************************************************

--- a/src/OOVPADatabase/DSound/3936.inl
+++ b/src/OOVPADatabase/DSound/3936.inl
@@ -73,32 +73,3 @@ OOVPA_XREF(CMcpxStream_Flush, 3936, 15,
         { 0xA1, 0xC9 },
         { 0xA2, 0xC3 },
 OOVPA_END;
-
-// ******************************************************************
-// * CSensaura3d_GetLiteHRTFFilterPair
-// ******************************************************************
-OOVPA_XREF(CSensaura3d_GetLiteHRTFFilterPair, 3936, 10,
-
-    XREF_CSensaura3d_GetLiteHRTFFilterPair,
-    XRefZero)
-
-        //CSensaura3d_GetLiteHRTFFilterPair+0x00 : push ebp
-        { 0x00, 0x55 },
-
-        //CSensaura3d_GetLiteHRTFFilterPair+0x14 : push ecx
-        { 0x15, 0x51 },
-
-        //CSensaura3d_GetLiteHRTFFilterPair+0x22 : push 3
-        { 0x1F, 0x6A },
-        { 0x20, 0x03 },
-
-        //CSensaura3d_GetLiteHRTFFilterPair+0x22 : idiv eax, ecx
-        { 0x22, 0xF7 },
-        { 0x23, 0xF9 },
-
-        //CSensaura3d_GetLiteHRTFFilterPair+0x24 : cmp dword ptr [ebp+10h], 0
-        { 0x36, 0x83 },
-        { 0x37, 0x7D },
-        { 0x38, 0x10 },
-        { 0x39, 0x00 },
-OOVPA_END;

--- a/src/OOVPADatabase/DSound/4242.inl
+++ b/src/OOVPADatabase/DSound/4242.inl
@@ -129,25 +129,32 @@ OOVPA_END;
 // ******************************************************************
 // * CDirectSound_GetSpeakerConfig
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetSpeakerConfig, 4242, 12,
+OOVPA_XREF(CDirectSound_GetSpeakerConfig, 4242, 1+19,
 
     XREF_CDirectSound_GetSpeakerConfig,
-    XRefZero)
+    XRefOne)
 
-        { 0x00, 0xE8 },
-        { 0x20, 0xB8 },
+        // call DirectSoundEnterCriticalSection
+        XREF_ENTRY(0x01, XREF_DirectSoundEnterCriticalSection),
 
-        { 0x27, 0x8B },
-        { 0x28, 0x4C },
-        { 0x29, 0x24 },
-        { 0x2A, 0x04 },
-        { 0x2B, 0x8B },
-        { 0x2C, 0x49 },
-        { 0x2D, 0x08 },
-        { 0x2E, 0x8B },
+        // call DirectSoundEnterCriticalSection
+        OV_MATCH(0x00, 0xE8),
+        // cmp dword ptr [...], 0
+        OV_MATCH(0x05, 0x83, 0x3D),
 
-        { 0x4E, 0xC2 },
-        { 0x4F, 0x08 },
+        // mov ecx, [esp+0x04]
+        OV_MATCH(0x27, 0x8B, 0x4C, 0x24, 0x04),
+        // mov ecx, [ecx+0x08]
+        // mov ecx, [ecx+0x08]
+        OV_MATCH(0x2B, 0x8B, 0x49, 0x08, 0x8B),
+
+        // and ..., 0x7FFFFFFF
+        OV_MATCH(0x35, 0x81),
+        //OV_MATCH(0x36, 0xE1), (This value has changed, commented out to expand support for later revisions.)
+        OV_MATCH(0x37, 0xFF, 0xFF, 0xFF, 0x7F),
+
+        // ret 0x0008
+        OV_MATCH(0x4E, 0xC2, 0x08, 0x00),
 OOVPA_END;
 
 // ******************************************************************

--- a/src/OOVPADatabase/DSound/4627.inl
+++ b/src/OOVPADatabase/DSound/4627.inl
@@ -57,35 +57,6 @@ OOVPA_XREF(CDirectSound_SetVelocity, 4627, 15,
 OOVPA_END;
 
 // ******************************************************************
-// * CDirectSound_GetSpeakerConfig
-// ******************************************************************
-OOVPA_XREF(CDirectSound_GetSpeakerConfig, 4627, 14,
-
-    XREF_CDirectSound_GetSpeakerConfig,
-    XRefZero)
-
-        { 0x00, 0xE8 },
-
-        { 0x0B, 0x00 },
-        { 0x14, 0x0B },
-        { 0x20, 0xB8 },
-        { 0x2A, 0x04 },
-
-        { 0x35, 0x81 },
-        //{ 0x36, 0xE1 }, (This value has changed, commented out to expand support for later revisions.)
-        { 0x37, 0xFF },
-        { 0x38, 0xFF },
-        { 0x39, 0xFF },
-        { 0x3A, 0x7F },
-
-        { 0x40, 0x0B },
-        { 0x4C, 0x33 },
-
-        { 0x4E, 0xC2 },
-        { 0x4F, 0x08 },
-OOVPA_END;
-
-// ******************************************************************
 // * CMcpxBuffer_Play_Ex
 // ******************************************************************
 #define CMcpxBuffer_Play_Ex_4627 CMcpxBuffer_Play_Ex_4361

--- a/src/OOVPADatabase/DSound/5344.inl
+++ b/src/OOVPADatabase/DSound/5344.inl
@@ -1293,9 +1293,3 @@ OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 5344, 1+6,
         { 0x0D, 0xC0 },
         { 0x10, 0x00 },
 OOVPA_END;
-
-// ******************************************************************
-// * Reverted function signature
-// ******************************************************************
-// Generic OOVPA as of 5344 (aka 4134 sig) and newer
-#define DirectSoundUseFullHRTF_5344 DirectSoundUseFullHRTF_4134

--- a/src/OOVPADatabase/DSound_OOVPA.inl
+++ b/src/OOVPADatabase/DSound_OOVPA.inl
@@ -505,7 +505,7 @@ OOVPATable DSound_OOVPA[] = {
     REGISTER_OOVPAS(IDirectSound_UnmapBufferData, 5344), // undocument // Final generic OOVPA: 5344; Removed: 0 (introduced in 5344)
 
     REGISTER_OOVPAS(CSensaura3d_GetFullHRTFFilterPair, 3911, 3936), // Final generic OOVPA: 3936; Removed: 4134+ // NOTE: 4039 revert back to 3911
-    REGISTER_OOVPAS(CSensaura3d_GetLiteHRTFFilterPair, 3911, 3936), // Final generic OOVPA: 3936; Removed: 4134+ // NOTE: 4039 revert back to 3911
+    REGISTER_OOVPAS(CSensaura3d_GetLiteHRTFFilterPair, 3911), // Final generic OOVPA: 3911; Removed: 4134+
     REGISTER_OOVPAS(CFullHRTFSource_GetCenterVolume, 4039, 4134, 5344), // Final generic OOVPA: 5344; Removed: 4242-5233 (introduced in 4039)
     REGISTER_OOVPAS(CLightHRTFSource_GetCenterVolume, 4039,/* 4134,*/ 5344), // Final generic OOVPA: 5344; Removed: 4242-5233 (introduced in 4039)
     REGISTER_OOVPAS(CHRTFSource_SetFullHRTF5Channel, 4039, 5344), // Final generic OOVPA: 5344; Removed: 4242-5233 (introduced in 4039)

--- a/src/OOVPADatabase/DSound_OOVPA.inl
+++ b/src/OOVPADatabase/DSound_OOVPA.inl
@@ -523,7 +523,7 @@ OOVPATable DSound_OOVPA[] = {
     REGISTER_OOVPAS(DirectSoundDoWork, 3911, 4134), // Final generic OOVPA: 4134; Removed: 0
     REGISTER_OOVPAS(DirectSoundGetSampleTime, 3911, 4361), // Final generic OOVPA: 4361; Removed: 0
     REGISTER_OOVPAS(DirectSoundOverrideSpeakerConfig, 4039, 4134), // Final generic OOVPA: 4134; Removed: 0 (introduced in 4039)
-    REGISTER_OOVPAS(DirectSoundUseFullHRTF, 3911, 4039, 4134, 4242, 5344), // Final generic OOVPA: 5344; Removed: 0
+    REGISTER_OOVPAS(DirectSoundUseFullHRTF, 3911, 4039, 4134, 4242/*, 5344=revert to 4134*/), // Final generic OOVPA: 5344 (revert to 4134); Removed: 0
     REGISTER_OOVPAS(DirectSoundUseLightHRTF, 3911, 4039,/* 4134?,*/ 4242, 5344), // Final generic OOVPA: 5344; Removed: 0
     REGISTER_OOVPAS(DirectSoundUseFullHRTF4Channel, 5344), // undocument // Final generic OOVPA: 5344; Removed: 0 (introduced in 5344)
     REGISTER_OOVPAS(DirectSoundUseLightHRTF4Channel, 5344), // undocument // Final generic OOVPA: 5344; Removed: 0 (introduced in 5344)

--- a/src/OOVPADatabase/DSound_OOVPA.inl
+++ b/src/OOVPADatabase/DSound_OOVPA.inl
@@ -372,7 +372,7 @@ OOVPATable DSound_OOVPA[] = {
     REGISTER_OOVPAS(CDirectSound_GetCaps, 3911, 4039, 4134, 4361), // Final generic OOVPA: 4361; Removed: 0
     REGISTER_OOVPAS(CDirectSound_GetEffectData, 3911, 4039, 4134), // Final generic OOVPA: 4134; Removed: 0
     REGISTER_OOVPAS(CDirectSound_GetOutputLevels, 4361), // Final generic OOVPA: 4361; Removed: 0 (introduced in 4361)
-    REGISTER_OOVPAS(CDirectSound_GetSpeakerConfig, 3911, 4242, 4627, 5455), // Final generic OOVPA: 5455; Removed: 0
+    REGISTER_OOVPAS(CDirectSound_GetSpeakerConfig, 3911, 4242, 5455), // Final generic OOVPA: 5455; Removed: 0
     REGISTER_OOVPAS(CDirectSound_GetTime, 3911), // Final generic OOVPA: 3911; Removed: 0
     REGISTER_OOVPAS(CDirectSound_MapBufferData, 5344), // Final generic OOVPA: 5344; Removed: 0 (introduced in 5344)
     REGISTER_OOVPAS(CDirectSound_SetAllParameters, 3911, 4039, 4134), // Final generic OOVPA: 4134; Removed: 0

--- a/src/OOVPADatabase/DSound_OOVPA.inl
+++ b/src/OOVPADatabase/DSound_OOVPA.inl
@@ -47,6 +47,7 @@
 // * [5120] N.U.D.E.@                        |   100%    | Contain full library.
 // * [5233] Evil Dead                        |   100%    | Contain full library.
 // * [5344] Gladius OXM Demo Disc 20         |   100%    | Contain full library.
+// * [5344] The Hulk                         |   100%    | Contain full library.
 // * [5455] NCAA Football 2004               |   100%    | Contain full library.
 // * [5455] Dinosaur Hunting                 |   100%    | Contain full library.
 // * [5558] Dino Crisis 3                    |   100%    | Contain full library.


### PR DESCRIPTION
Resolves 4 errors found from internal test. Plus a duplicate warning detected by update and remove unnecessary extra signature. Plus add The Hulk note to the list.

Total internal test errors before was 154, now it is 150.