### PR TITLE
Add a signature for D3DDevice_DrawIndexedVertices for xdk-3911 LTCG

### DIFF
--- a/src/OOVPADatabase/D3D8LTCG/3911.inl
+++ b/src/OOVPADatabase/D3D8LTCG/3911.inl
@@ -696,6 +696,24 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1024, 10)
 OOVPA_END;
 
 // ******************************************************************
+// * D3DDevice_DrawIndexedVertices
+// ******************************************************************
+OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1024, 15)
+
+        // push ebp
+        OV_MATCH(0x00, 0x55),
+
+        // mov eax, [esi+0x0478]
+        OV_MATCH(0x0D, 0x8B, 0x86, 0x78, 0x04, 0x00, 0x00),
+
+        // mov dword ptr [eax], 000417FC
+        OV_MATCH(0x51, 0xC7, 0x00, 0xFC, 0x17, 0x04, 0x00),
+
+        // lea ebx, [ebx+0]
+        OV_MATCH(0x15A, 0x8D, 0x9B),
+OOVPA_END;
+
+// ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
 //F6C30155568B35 ...C3

--- a/src/OOVPADatabase/D3D8LTCG/4039.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4039.inl
@@ -27,7 +27,7 @@
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
 //558BEC83EC0853568B35
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1024, 10)
+OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1036, 10)
 
         { 0x00, 0x55 },
         { 0x01, 0x8B },

--- a/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -89,7 +89,7 @@ OOVPATable D3D8LTCG_OOVPA[] = {
     REGISTER_OOVPAS(D3DDevice_DeletePixelShader_0, 2024),
     REGISTER_OOVPAS(D3DDevice_DeleteStateBlock, 1024),
     REGISTER_OOVPAS(D3DDevice_DeleteVertexShader_0, 2024, 2036),
-    REGISTER_OOVPAS(D3DDevice_DrawIndexedVertices, 1024),
+    REGISTER_OOVPAS(D3DDevice_DrawIndexedVertices, 1024, 1036),
     REGISTER_OOVPAS(D3DDevice_DrawIndexedVerticesUP, 1024, 1036, 1048, 1060, 1072),
     REGISTER_OOVPAS(D3DDevice_DrawVertices, 1024),
     REGISTER_OOVPAS(D3DDevice_DrawVertices_4, 2048),


### PR DESCRIPTION
Practically enables rendering in xdk-3911 LTCG games, in this case NASCAR Heat 2002.

Marking as draft in case I find more required patches tomorrow or on Friday, but if I don't I'll just mark it as complete.