### PR TITLE
Fix Kernel Thunk Table Not Being Found Outside of Section Filter List

### DIFF
--- a/include/Xbe.h
+++ b/include/Xbe.h
@@ -46,6 +46,13 @@ typedef struct _xbe_s_flags {
     uint32_t Unused_b3 : 8;                     // unused (or unknown)
 } xbe_s_flags;
 
+#define XBE_SECTION_HEADER_FLAGS_WRITABLE     (1 << 0)
+#define XBE_SECTION_HEADER_FLAGS_PRELOAD      (1 << 1)
+#define XBE_SECTION_HEADER_FLAGS_EXECUTABLE   (1 << 2)
+#define XBE_SECTION_HEADER_FLAGS_INSERTEDFILE (1 << 3)
+#define XBE_SECTION_HEADER_FLAGS_HEADPAGERO   (1 << 4)
+#define XBE_SECTION_HEADER_FLAGS_TAILPAGERO   (1 << 5)
+
 typedef struct _xbe_section_header {
 
     union {

--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -644,6 +644,12 @@ uint32_t XbSymbolDatabase_GenerateSectionFilter(const void* xb_header_addr, XbSD
             SectionName = (const char*)(xb_start_addr + xb_section_headers[section_index].SectionNameAddr);
             sh_index = &xb_section_headers[section_index];
 
+            // Verify if section is preload. If not, then skip it.
+            // Intend for optimization usage and avoid false positive detection.
+            if ((sh_index->dwFlags_value & XBE_SECTION_HEADER_FLAGS_PRELOAD) == 0) {
+                continue;
+            }
+
             bool is_detected = false;
 
             for (unsigned int SectionList_index = 0; SectionList_index < SectionListTotal; SectionList_index++) {


### PR DESCRIPTION
Simple test case is NFL Blitz 2002 title which has kernel thunk table within **.idata** section. It is not on the filter list, therefore require to enforce add section outside of filter list.

Plus add chance to avoid false positive if section doesn't have preload flag just in case. And also used for optimization too.