### PR TITLE
DSound: Split CDirectSoundStream_GetStatus into Two Symbols for Difference Handler

### DIFF
--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -1892,8 +1892,14 @@ static bool manual_scan_section_dsound(iXbSymbolContext* pContext,
             internal_RegisterSymbol(pContext, pLibrarySession, XRefNoSaveIndex, 3911,
                 "CDirectSoundStream_GetInfo", *(uint32_t*)(pFuncAddr + 2 * 4));
 
-            internal_RegisterSymbol(pContext, pLibrarySession, XRefNoSaveIndex, 3911,
-                "CDirectSoundStream_GetStatus", *(uint32_t*)(pFuncAddr + 3 * 4));
+            if (pLibrary->build_version < 4134) {
+                internal_RegisterSymbol(pContext, pLibrarySession, XRefNoSaveIndex, 3911,
+                    "CDirectSoundStream_GetStatus__r1", *(uint32_t*)(pFuncAddr + 3 * 4));
+            }
+            else {
+                internal_RegisterSymbol(pContext, pLibrarySession, XRefNoSaveIndex, 4134,
+                    "CDirectSoundStream_GetStatus__r2", *(uint32_t*)(pFuncAddr + 3 * 4));
+            }
 
             internal_RegisterSymbol(pContext, pLibrarySession, XRefNoSaveIndex, 3911,
                 "CDirectSoundStream_Process", *(uint32_t*)(pFuncAddr + 4 * 4));


### PR DESCRIPTION
I already verified titles with 4039 and 4134 build. CDirectSoundStream_GetStatus's function of 4039 and below only use one flag which check if CMcpxStream class is ready for input stream packets. 4134 function and later use extended feature of general status.

Low risk merge since I will make a new pull request to Cxbx-Reloaded for resolve GetStatus difference between two different revisions.