### PR TITLE
Added XUnmountMU and MU_Init

### DIFF
--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -784,6 +784,7 @@ typedef enum _XRefDatabaseOffset {
 
     // XAPI
     XREF_XAPI_GetTypeInformation,
+    XREF_XUnmountAlternateTitleA,
 
     // JVS
     XREF_JVS_SendCommand_String,

--- a/src/OOVPADatabase/Xapi/3911.inl
+++ b/src/OOVPADatabase/Xapi/3911.inl
@@ -1319,3 +1319,22 @@ OOVPA_XREF(XUnmountMU, 3911, 1 + 9,
     OV_MATCH(0x5D, 0x6A, 0x20, 0x6A, 0x01, 0x33, 0xFF),
 
 } OOVPA_END;
+
+// ******************************************************************
+// * MU_Init
+// ******************************************************************
+OOVPA_NO_XREF(MU_Init, 3911, 14)
+{
+
+    // push ebp
+    // mov ebp, esp
+    // sub esp, 0x10
+    OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0x83, 0xEC, 0x10),
+
+    // push eax
+    // push 0x00
+    // push 0x3A
+    // lea eax, [ebp-0x10]
+    OV_MATCH(0x95, 0x50, 0x6A, 0x00, 0x6A, 0x3A, 0x8D, 0x45, 0xF0),
+
+} OOVPA_END;

--- a/src/OOVPADatabase/Xapi/3911.inl
+++ b/src/OOVPADatabase/Xapi/3911.inl
@@ -813,7 +813,10 @@ OOVPA_NO_XREF(XMountAlternateTitleA, 3911, 13)
 // ******************************************************************
 // * XUnmountAlternateTitleA
 // ******************************************************************
-OOVPA_NO_XREF(XUnmountAlternateTitleA, 3911, 7)
+OOVPA_XREF(XUnmountAlternateTitleA, 3911, 7,
+
+           XREF_XUnmountAlternateTitleA,
+           XRefZero)
 {
 
     { 0x0A, 0x65 },
@@ -1293,4 +1296,26 @@ OOVPA_NO_XREF(XapiFiberStartup, 3911, 14)
     { 0x2F, 0xE8 },
 
     { 0x44, 0xCC },
+} OOVPA_END;
+
+// ******************************************************************
+// * XUnmountMU
+// ******************************************************************
+OOVPA_XREF(XUnmountMU, 3911, 1 + 9,
+
+           XRefNoSaveIndex,
+           XRefOne)
+{
+
+    XREF_ENTRY(0x38, XREF_XUnmountAlternateTitleA),
+
+    // push EBP
+    // mov EBP, ESP
+    OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+    // push 0x20
+    // push 0x01
+    // xor edi, edi
+    OV_MATCH(0x5D, 0x6A, 0x20, 0x6A, 0x01, 0x33, 0xFF),
+
 } OOVPA_END;

--- a/src/OOVPADatabase/Xapi/4242.inl
+++ b/src/OOVPADatabase/Xapi/4242.inl
@@ -187,3 +187,26 @@ OOVPA_NO_XREF(XapiInitProcess, 4242, 7)
     { 0x42, 0x75 },
     { 0x43, 0x0B },
 } OOVPA_END;
+
+// ******************************************************************
+// * XUnmountMU
+// ******************************************************************
+// Generic OOVPA as of 4242 and newer.
+OOVPA_XREF(XUnmountMU, 4242, 1 + 9,
+
+           XRefNoSaveIndex,
+           XRefOne)
+{
+
+    XREF_ENTRY(0x50, XREF_XUnmountAlternateTitleA), // Was 3911 offset 0x38
+
+    // push EBP
+    // mov EBP, ESP
+    OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
+
+    // push 0x20
+    // push 0x01
+    // xor edi, edi
+    OV_MATCH(0x74, 0x6A, 0x20, 0x6A, 0x01, 0x33, 0xFF), // Was 3911 offset 0x5D
+
+} OOVPA_END;

--- a/src/OOVPADatabase/Xapi/4242.inl
+++ b/src/OOVPADatabase/Xapi/4242.inl
@@ -210,3 +210,22 @@ OOVPA_XREF(XUnmountMU, 4242, 1 + 9,
     OV_MATCH(0x74, 0x6A, 0x20, 0x6A, 0x01, 0x33, 0xFF), // Was 3911 offset 0x5D
 
 } OOVPA_END;
+
+// ******************************************************************
+// * MU_Init
+// ******************************************************************
+OOVPA_NO_XREF(MU_Init, 4242, 14)
+{
+
+    // push ebp
+    // mov ebp, esp
+    // sub esp, 0x0C // Was 3911 opcode ..., 0x10
+    OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0x83, 0xEC, 0x0C),
+
+    // push eax
+    // push 0x00
+    // push 0x3A
+    // lea eax, [ebp-0x0C] // Was 3911 opcode ...-0x10]
+    OV_MATCH(0x8A, 0x50, 0x6A, 0x00, 0x6A, 0x3A, 0x8D, 0x45, 0xF4), // Was 3911 offset 0x95
+
+} OOVPA_END;

--- a/src/OOVPADatabase/Xapi/5233.inl
+++ b/src/OOVPADatabase/Xapi/5233.inl
@@ -1,0 +1,42 @@
+// ******************************************************************
+// *
+// *   OOVPADatabase->Xapi->5233.inl
+// *
+// *  XbSymbolDatabase is free software; you can redistribute them
+// *  and/or modify them under the terms of the GNU General Public
+// *  License as published by the Free Software Foundation; either
+// *  version 2 of the license, or (at your option) any later version.
+// *
+// *  This program is distributed in the hope that it will be useful,
+// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// *  GNU General Public License for more details.
+// *
+// *  You should have recieved a copy of the GNU General Public License
+// *  along with this program; see the file COPYING.
+// *  If not, write to the Free Software Foundation, Inc.,
+// *  59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// *
+// *  All rights reserved
+// *
+// ******************************************************************
+
+// ******************************************************************
+// * MU_Init
+// ******************************************************************
+// Generic OOVPA as of 5233 and newer.
+OOVPA_NO_XREF(MU_Init, 5233, 14)
+{
+
+    // push ebp
+    // mov ebp, esp
+    // sub esp, 0x0C
+    OV_MATCH(0x00, 0x55, 0x8B, 0xEC, 0x83, 0xEC, 0x0C),
+
+    // push eax
+    // push 0x00
+    // push 0x3A
+    // lea eax, [ebp-0x0C]
+    OV_MATCH(0x8E, 0x50, 0x6A, 0x00, 0x6A, 0x3A, 0x8D, 0x45, 0xF4), // Was 5233 offset 0x8A
+
+} OOVPA_END;

--- a/src/OOVPADatabase/Xapi_OOVPA.inl
+++ b/src/OOVPADatabase/Xapi_OOVPA.inl
@@ -115,6 +115,7 @@
 #include "Xapi/4831.inl"
 #include "Xapi/5028.inl"
 #include "Xapi/5120.inl"
+#include "Xapi/5233.inl"
 #include "Xapi/5344.inl"
 #include "Xapi/5455.inl"
 #include "Xapi/5788.inl"
@@ -143,6 +144,7 @@ OOVPATable XAPILIB_OOVPA[] = {
     REGISTER_OOVPAS(GetThreadPriority, 3911),
     REGISTER_OOVPAS(GetTimeZoneInformation, 3911),
     REGISTER_OOVPAS(GetTypeInformation, 4134), // TODO: Actually introduced in some unknown XDK between 4134 and 4361
+    REGISTER_OOVPAS(MU_Init, 3911, 4242, 5233),
     REGISTER_OOVPAS(OutputDebugStringA, 3911),
     REGISTER_OOVPAS(QueueUserAPC, 3911),
     REGISTER_OOVPAS(QueryPerformanceCounter, 3911),

--- a/src/OOVPADatabase/Xapi_OOVPA.inl
+++ b/src/OOVPADatabase/Xapi_OOVPA.inl
@@ -124,6 +124,8 @@
 // ******************************************************************
 OOVPATable XAPILIB_OOVPA[] = {
 
+    REGISTER_OOVPAS(XUnmountAlternateTitleA, 3911),
+
     REGISTER_OOVPAS(CreateMutex, 3911), // Too High Level (from 3911's comment)
     REGISTER_OOVPAS(CreateThread, 3911), // Too High Level (from 3911's comment)
     REGISTER_OOVPAS(ExitThread, 3911), //
@@ -171,7 +173,7 @@ OOVPATable XAPILIB_OOVPA[] = {
     REGISTER_OOVPAS(XMountUtilityDrive, 3911, 4432),
     REGISTER_OOVPAS(XRegisterThreadNotifyRoutine, 3911),
     REGISTER_OOVPAS(XSetProcessQuantumLength, 4134),
-    REGISTER_OOVPAS(XUnmountAlternateTitleA, 3911),
+    REGISTER_OOVPAS(XUnmountMU, 3911, 4242),
     REGISTER_OOVPAS(XapiFiberStartup, 3911),
     REGISTER_OOVPAS(timeKillEvent, 3911),
     REGISTER_OOVPAS(timeSetEvent, 3911),


### PR DESCRIPTION
This function is necessary to emulate memory units in Cxbx-Reloaded.
I only checked with XDK 3944 and 4831, so testing with other versions would be appreciated.

EDIT: this now also adds `MU_Init`, which is necessary to derive the memory unit device type. It was tested with xdk versions 3911, 4627, 4831 and 5849.