### PR TITLE
fix clang format lint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,9 @@ jobs:
           sync-labels: true
 
       - uses: actions/checkout@v2
+        with:
+          # IMPORTANT: Make sure checkout is pulling pull request's merge commit!
+          ref: 'refs/pull/${{ github.event.number }}/merge'
       - name: Clang-Format Lint Verify
         uses: DoozyX/clang-format-lint-action@v0.11
         with:

--- a/src/OOVPADatabase/D3D8LTCG/5849.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5849.inl
@@ -747,17 +747,17 @@ OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 1024, 12)
 // ******************************************************************
 OOVPA_XREF(D3DDevice_SetStreamSource_0__LTCG_eax_StreamNumber_edi_pStreamData_ebx_Stride, 2058, 1 + 12,
 
-    XRefNoSaveIndex,
-    XRefOne)
+           XRefNoSaveIndex,
+           XRefOne)
 {
 
-        XREF_ENTRY(0x19, XREF_G_STREAM), // Derived
+    XREF_ENTRY(0x19, XREF_G_STREAM), // Derived
 
-        // test edi, edi; mov ecx, [...]
-        OV_MATCH(0x00, 0x85, 0xFF, 0x8B, 0x0D),
+    // test edi, edi; mov ecx, [...]
+    OV_MATCH(0x00, 0x85, 0xFF, 0x8B, 0x0D),
 
-        // jz ...; add dword ptr [edi], 80000h
-        OV_MATCH(0x08, 0x74, 0x06, 0x81, 0x07, 0x00, 0x00, 0x08, 0x00),
+    // jz ...; add dword ptr [edi], 80000h
+    OV_MATCH(0x08, 0x74, 0x06, 0x81, 0x07, 0x00, 0x00, 0x08, 0x00),
 } OOVPA_END;
 
 // ******************************************************************


### PR DESCRIPTION
Somehow, #135 changes escaped from clang format lint check from our pull request manager workflow. This pull request resolve the lint verification.

And add a fix for the checkout process to pull merged commit to verify pull request's changes.