### PR TITLE
Fix CLI Tool missing XbSymbolContext_RegisterXRefs call

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -98,6 +98,7 @@ int main(int argc, char const* argv[])
     assert(status == 1);
     XbSymbolContext_ScanManual(ctx);
     XbSymbolContext_ScanAllLibraryFilter(ctx);
+    XbSymbolContext_RegisterXRefs(ctx);
     XbSymbolContext_Release(ctx);
 
     free(lib_hdr.filters);


### PR DESCRIPTION
While testing with Ghidra-Xbe extension with Ghrida. I notice couple symbols were not output, including #139 pull request.

This pull request now do manual output derived references that is not part of OOVPA signature database after second part of the scan process.