### PR TITLE
Reformat General OOVPA Signatures (almost all)

### DIFF
--- a/src/OOVPADatabase/D3D8/3911.inl
+++ b/src/OOVPADatabase/D3D8/3911.inl
@@ -32,12 +32,13 @@
 //       D3DDevice_BlockUntilVerticalBlank detection.
 //       So, even though it's scanning for D3DDevice_BlockUntilVerticalBlank,
 //       this OOVPA itself is not a symbol.
-OOVPA_XREF_EXTEND(D3DDevice__m_VerticalBlankEvent__ManualFindGeneric, 3911, 2 + 14,
+OOVPA_SIG_HEADER_XREF_EXTEND(D3DDevice__m_VerticalBlankEvent__ManualFindGeneric,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefTwo,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefTwo,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // D3DDevice__m_VerticalBlankEvent__ManualFindGeneric+0x00 : mov eax, [D3D__PDEVICE]
     XREF_ENTRY(0x01, XREF_D3DDEVICE),
@@ -66,13 +67,15 @@ OOVPA_XREF_EXTEND(D3DDevice__m_VerticalBlankEvent__ManualFindGeneric, 3911, 2 + 
     // D3DDevice__m_VerticalBlankEvent__ManualFindGeneric+0x1D : call e__
     OV_MATCH(0x1D, 0xFF),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Direct3D_CreateDevice
 // ******************************************************************
-OOVPA_NO_XREF(Direct3D_CreateDevice, 3911, 18) // Also for 4361, 4627, 5558, 5659, 5788, 5849, 5933 (NOT 5344!)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice,
+                         3911) // Also for 4361, 4627, 5558, 5659, 5788, 5849, 5933 (NOT 5344!)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -95,7 +98,8 @@ OOVPA_NO_XREF(Direct3D_CreateDevice, 3911, 18) // Also for 4361, 4627, 5558, 565
     { 0x1B, 0x0A },
     { 0x1C, 0xC7 },
     { 0x1D, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTexture, named with 2 suffix to match EMUPATCH(D3DDevice_GetTexture2)
@@ -191,8 +195,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_DrawRectPatch
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawRectPatch, 3911, 27) // Also verified for 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawRectPatch,
+                         3911) // Also verified for 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -223,13 +228,15 @@ OOVPA_NO_XREF(D3DDevice_DrawRectPatch, 3911, 27) // Also verified for 4361, 4627
     { 0x1D, 0x89 },
     { 0x1E, 0x6C },
     { 0x1F, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawTriPatch
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawTriPatch, 3911, 27) // Also verified for 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawTriPatch,
+                         3911) // Also verified for 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -260,14 +267,16 @@ OOVPA_NO_XREF(D3DDevice_DrawTriPatch, 3911, 27) // Also verified for 4361, 4627,
     { 0x1D, 0x89 },
     { 0x1E, 0x44 },
     { 0x1F, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexShader
 // ******************************************************************
 // Based on Dxbx patterns for 3911, 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
-OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 3911, 38)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateVertexShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // IDirect3DDevice8_CreateVertexShader+0x00 : push ecx; push ebx; push ebp
     { 0x00, 0x51 },
@@ -317,7 +326,7 @@ OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 3911, 38)
     { 0x48, 0x30 },
     /*
     OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 5558)
-{
+OOVPA_SIG_MATCH(
 
         // D3DDevice_CreateVertexShader+0x73 : mov eax, 0x8007000E
         { 0x65, 0x07 },
@@ -329,7 +338,7 @@ OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 3911, 38)
 */
     /*
     OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 5788)
-{
+OOVPA_SIG_MATCH(
 
         { 0x3E, 0xE8 },
         { 0x5E, 0x75 },
@@ -341,7 +350,7 @@ OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 3911, 38)
 */
     /*
     OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 5849)
-{
+OOVPA_SIG_MATCH(
 
         { 0x3E, 0xE8 },
         { 0x5E, 0x75 },
@@ -351,13 +360,15 @@ OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 3911, 38)
         { 0xDE, 0x83 },
         { 0xFE, 0xC7 },
 */
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Release
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Release, 3911, 12) // Also for 4034, 4361, 4627, 5344, 5558, 5788, 5849, 5933
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Release,
+                         3911) // Also for 4034, 4361, 4627, 5344, 5558, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x57 },
     { 0x08, 0x87 },
@@ -371,7 +382,8 @@ OOVPA_NO_XREF(D3DDevice_Release, 3911, 12) // Also for 4034, 4361, 4627, 5344, 5
     { 0x12, 0x8B },
     { 0x13, 0xCF },
     { 0x14, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDepthStencilSurface
@@ -416,8 +428,9 @@ OOVPA_END;
 // * D3DDevice_GetGammaRamp
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3DDevice_GetGammaRamp, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetGammaRamp,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x8B },
@@ -435,17 +448,19 @@ OOVPA_NO_XREF(D3DDevice_GetGammaRamp, 3911, 14)
     { 0x1C, 0x00 },
     { 0x22, 0x00 },
     { 0x27, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_DestroyResource
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(D3D_DestroyResource, 3911, 1 + 22,
+OOVPA_SIG_HEADER_XREF(D3D_DestroyResource,
+                      3911,
 
-           XREF_D3D_DestroyResource,
-           XRefOne)
-{
+                      XREF_D3D_DestroyResource,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3D_DestroyResource+0x1D : D3D_BlockOnResource
     XREF_ENTRY(0x1E, XREF_D3D_BlockOnResource),
@@ -468,14 +483,16 @@ OOVPA_XREF(D3D_DestroyResource, 3911, 1 + 22,
     // relative to 0x06; STD offset 0x22 vs LTCG offset 0x24
     // D3D_DestroyResource+0x : cmp esi, $50000
     OV_MATCH(0x28, 0x81, 0xFE, 0x00, 0x00, 0x05, 0x00),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_SetPushBufferSize
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3D_SetPushBufferSize, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_SetPushBufferSize,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -490,16 +507,18 @@ OOVPA_NO_XREF(D3D_SetPushBufferSize, 3911, 13)
     { 0x0E, 0x0D },
     { 0x13, 0xC2 },
     { 0x14, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LightEnable
 // ******************************************************************
-OOVPA_XREF(D3DDevice_LightEnable, 3911, 2 + 24, // valid upto at least 4627, next known difference is from 5344 onwards
+OOVPA_SIG_HEADER_XREF(D3DDevice_LightEnable,
+                      3911, // valid upto at least 4627, next known difference is from 5344 onwards
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DDEVICE), // Derived
     XREF_ENTRY(0x67, XREF_D3DDevice_SetLight),
@@ -545,16 +564,18 @@ OOVPA_XREF(D3DDevice_LightEnable, 3911, 2 + 24, // valid upto at least 4627, nex
         { 0xA6, 0x75 },
         { 0xC2, 0x00 },
 */
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetLightEnable
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetLightEnable, 3911, 1 + 24, // valid upto at least 5233, next known difference is from 5344 onwards
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetLightEnable,
+                      3911, // valid upto at least 5233, next known difference is from 5344 onwards
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x05, XREF_D3DDEVICE), // Derived
 
@@ -591,16 +612,18 @@ OOVPA_XREF(D3DDevice_GetLightEnable, 3911, 1 + 24, // valid upto at least 5233, 
     { 0x1D, 0x85 },
     { 0x1E, 0xC0 },
     { 0x1F, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_ClearStateBlockFlags
 // ******************************************************************
-OOVPA_XREF(D3D_ClearStateBlockFlags, 3911, 13,
+OOVPA_SIG_HEADER_XREF(D3D_ClearStateBlockFlags,
+                      3911,
 
-           XREF_D3D_ClearStateBlockFlags,
-           XRefZero)
-{
+                      XREF_D3D_ClearStateBlockFlags,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x15 },
     { 0x07, 0x57 },
@@ -617,16 +640,18 @@ OOVPA_XREF(D3D_ClearStateBlockFlags, 3911, 13,
     { 0x1D, 0xF6 },
     { 0x1E, 0x8D },
     { 0x1F, 0x82 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginStateBlock
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BeginStateBlock, 3911, 1 + 6,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BeginStateBlock,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BeginStateBlock+0x0F : call [ClearStateBlockFlags]
     XREF_ENTRY(0x0A, XREF_D3D_ClearStateBlockFlags),
@@ -640,16 +665,18 @@ OOVPA_XREF(D3DDevice_BeginStateBlock, 3911, 1 + 6,
     { 0x07, 0x0C }, //0C VS 08
     { 0x08, 0x20 },
     { 0x09, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_RecordStateBlock
 // ******************************************************************
-OOVPA_XREF(D3D_RecordStateBlock, 3911, 19,
+OOVPA_SIG_HEADER_XREF(D3D_RecordStateBlock,
+                      3911,
 
-           XREF_D3D_RecordStateBlock,
-           XRefZero)
-{
+                      XREF_D3D_RecordStateBlock,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -672,16 +699,18 @@ OOVPA_XREF(D3D_RecordStateBlock, 3911, 19,
     { 0x3D, 0x84 },
     { 0x3E, 0xC0 },
     { 0x5C, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndStateBlock
 // ******************************************************************
-OOVPA_XREF(D3DDevice_EndStateBlock, 3911, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_EndStateBlock,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_EndStateBlock+0x0F : call [ClearStateBlockFlags]
     XREF_ENTRY(0x0A, XREF_D3D_RecordStateBlock),
@@ -694,13 +723,15 @@ OOVPA_XREF(D3DDevice_EndStateBlock, 3911, 1 + 5,
     { 0x06, 0x60 },
     { 0x07, 0x0C },
     { 0x08, 0xDF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport::InitHardware
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_InitHardware, 3911, 24)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_InitHardware,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -728,13 +759,15 @@ OOVPA_NO_XREF(CMiniport_InitHardware, 3911, 24)
     { 0x1D, 0x80 },
     { 0x1E, 0xA6 },
     { 0x1F, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport::CreateCtxDmaObject
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_CreateCtxDmaObject, 3911, 32)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_CreateCtxDmaObject,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -768,13 +801,15 @@ OOVPA_NO_XREF(CMiniport_CreateCtxDmaObject, 3911, 32)
     { 0x1D, 0x89 },
     { 0x1E, 0x75 },
     { 0x1F, 0xFC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CMiniport_GetDisplayCapabilities
 // ******************************************************************
-OOVPA_NO_XREF(D3D_CMiniport_GetDisplayCapabilities, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_CMiniport_GetDisplayCapabilities,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3D_CMiniport_GetDisplayCapabilities+0x00 : xor eax, eax
     { 0x00, 0x33 },
@@ -801,7 +836,8 @@ OOVPA_NO_XREF(D3D_CMiniport_GetDisplayCapabilities, 3911, 15)
     { 0x19, 0xA1 },
     // D3D_CMiniport_GetDisplayCapabilities+0x1E : retn
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DBaseTexture_GetLevelCount
@@ -809,8 +845,9 @@ OOVPA_NO_XREF(D3D_CMiniport_GetDisplayCapabilities, 3911, 15)
 /* Accuracy is not gauranteed.
    It might be a ?GetMipmapLevelCount@PixelJar@D3D@@YGKPAUD3DPixelContainer@@@Z
    that has an identical signature... */
-OOVPA_NO_XREF(D3DBaseTexture_GetLevelCount, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DBaseTexture_GetLevelCount,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DBaseTexture_GetLevelCount+0x00 : mov eax, [esp+0x04]
     { 0x00, 0x8B },
@@ -832,13 +869,15 @@ OOVPA_NO_XREF(D3DBaseTexture_GetLevelCount, 3911, 13)
     // D3DBaseTexture_GetLevelCount+0x0B : retn 0x04
     { 0x0B, 0xC2 },
     { 0x0C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DCubeTexture_GetCubeMapSurface
 // ******************************************************************
-OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DCubeTexture_GetCubeMapSurface,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0xEC },
     { 0x18, 0x54 },
@@ -851,13 +890,15 @@ OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface, 3911, 11)
     { 0x1F, 0x50 },
     { 0x32, 0x4C },
     { 0x45, 0x51 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetCreationParameters
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetCreationParameters, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetCreationParameters,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x06, 0x8B },
@@ -867,13 +908,15 @@ OOVPA_NO_XREF(D3DDevice_GetCreationParameters, 3911, 8)
     { 0x26, 0x00 },
     { 0x2E, 0x5E },
     { 0x36, 0xC9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetScissors
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetScissors, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetScissors,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x4C },
@@ -892,13 +935,15 @@ OOVPA_NO_XREF(D3DDevice_GetScissors, 3911, 15)
     { 0x1D, 0x8B },
     { 0x1E, 0x90 },
     //{ 0x1F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::LazySetPointParams
 // ******************************************************************
-OOVPA_NO_XREF(D3D_LazySetPointParams, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_LazySetPointParams,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x0A, 0x57 },
@@ -913,16 +958,18 @@ OOVPA_NO_XREF(D3D_LazySetPointParams, 3911, 13)
     { 0x13, 0xE8 },
     { 0x37, 0x89 },
     { 0x6E, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Lock3DSurface
 // ******************************************************************
-OOVPA_XREF(Lock3DSurface, 3911, 12,
+OOVPA_SIG_HEADER_XREF(Lock3DSurface,
+                      3911,
 
-           XREF_Lock3DSurface,
-           XRefZero)
-{
+                      XREF_Lock3DSurface,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::PixelJar::Lock3DSurface + 0x00: sub esp, 8
     { 0x00, 0x83 },
@@ -945,13 +992,15 @@ OOVPA_XREF(Lock3DSurface, 3911, 12,
     // D3D::PixelJar::Lock3DSurface + 0x99: ret 0x14
     { 0x99, 0xC2 },
     { 0x9A, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::SetStateUP
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStateUP, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStateUP,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0xEC },
     { 0x0A, 0xE8 },
@@ -972,13 +1021,15 @@ OOVPA_NO_XREF(D3DDevice_SetStateUP, 3911, 16)
     { 0x9F, 0x56 },
 
     { 0xA5, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::SetStateVB
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStateVB, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStateVB,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x08, 0xE8 },
@@ -999,13 +1050,15 @@ OOVPA_NO_XREF(D3DDevice_SetStateVB, 3911, 16)
     { 0x8F, 0xC1 },
 
     { 0xA5, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Direct3D_CheckDeviceMultiSampleType
 // ******************************************************************
-OOVPA_NO_XREF(Direct3D_CheckDeviceMultiSampleType, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CheckDeviceMultiSampleType,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x00 },
     { 0x1E, 0x54 },
@@ -1014,13 +1067,15 @@ OOVPA_NO_XREF(Direct3D_CheckDeviceMultiSampleType, 3911, 7)
     { 0x4E, 0x08 },
     { 0x5E, 0x72 },
     { 0x6E, 0x03 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetOverlayUpdateStatus
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetOverlayUpdateStatus, 3911, 16) // Also for 4134, 4361, 4627, 5344, 5558, 5788, 5849
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetOverlayUpdateStatus,
+                         3911) // Also for 4134, 4361, 4627, 5344, 5558, 5788, 5849
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -1046,13 +1101,15 @@ OOVPA_NO_XREF(D3DDevice_GetOverlayUpdateStatus, 3911, 16) // Also for 4134, 4361
     { 0x1A, 0x8B },
     { 0x1B, 0xC2 },
     { 0x1C, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CheckDeviceFormat
 // ******************************************************************
-OOVPA_NO_XREF(D3D_CheckDeviceFormat, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_CheckDeviceFormat,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x0E, 0x18 },
@@ -1062,12 +1119,14 @@ OOVPA_NO_XREF(D3D_CheckDeviceFormat, 3911, 8)
     { 0x4E, 0x74 },
     { 0x5E, 0x08 },
     { 0x6E, 0x3C },
-} OOVPA_END;
+    //
+);
 // ******************************************************************
 // * D3DDevice_EnableOverlay
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_EnableOverlay, 3911, 24)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EnableOverlay,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -1094,13 +1153,15 @@ OOVPA_NO_XREF(D3DDevice_EnableOverlay, 3911, 24)
     { 0x1D, 0xEB },
     { 0x1E, 0x0A },
     { 0x1F, 0xC7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x08 },
     { 0x1F, 0x7C },
@@ -1114,16 +1175,18 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 3911, 11)
     { 0x85, 0x3F },
     { 0x86, 0x83 },
     { 0x87, 0xE1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 3911, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -1148,16 +1211,18 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 3911, 1 + 12,
     // D3DDevice_SetTextureState_TexCoordIndex+0x97 : shl eax, cl
     { 0x97, 0xD3 },
     { 0x98, 0xE0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_CullMode
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 3911, 2 + 16,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_CullMode,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
 
@@ -1188,13 +1253,15 @@ OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 3911, 2 + 16,
     // D3DDevice_SetRenderState_CullMode+0x5F : retn 4
     { 0x5F, 0xC2 },
     { 0x60, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x05, 0x1D },
@@ -1210,13 +1277,15 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 3911, 12)
 
     { 0x1A, 0x83 },
     { 0x23, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsBusy
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_IsBusy, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_IsBusy,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x12, 0x49 },
@@ -1231,13 +1300,15 @@ OOVPA_NO_XREF(D3DDevice_IsBusy, 3911, 11)
     { 0x27, 0x92 },
 
     { 0x33, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDeviceCaps
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetDeviceCaps, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDeviceCaps,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetDeviceCaps+0x00 : push esi; push edi
     { 0x00, 0x56 },
@@ -1257,13 +1328,15 @@ OOVPA_NO_XREF(D3DDevice_GetDeviceCaps, 3911, 11)
     // D3DDevice_GetDeviceCaps+0x14 : retn 0x04
     { 0x14, 0xC2 },
     { 0x15, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginVisibilityTest
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginVisibilityTest,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BeginVisibilityTest+0x00 : push esi
     { 0x00, 0x56 },
@@ -1284,13 +1357,15 @@ OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 3911, 12)
     { 0x1E, 0x83 },
     { 0x1F, 0xC0 },
     { 0x20, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x56 },
@@ -1302,14 +1377,16 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 3911, 10)
     { 0x11, 0xB9 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndVisibilityTest
 // ******************************************************************
 //Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3DDevice_EndVisibilityTest, 3911, 21)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EndVisibilityTest,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x06, 0xE8 },
@@ -1334,13 +1411,15 @@ OOVPA_NO_XREF(D3DDevice_EndVisibilityTest, 3911, 21)
     { 0x1C, 0x3D },
 
     { 0x37, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVisibilityTestResult
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVisibilityTestResult, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVisibilityTestResult,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetVisibilityTestResult+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -1361,16 +1440,18 @@ OOVPA_NO_XREF(D3DDevice_GetVisibilityTestResult, 3911, 12)
     { 0x2D, 0x08 },
     { 0x2E, 0x76 },
     { 0x2F, 0x88 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::KickOff
 // ******************************************************************
-OOVPA_XREF(D3DDevice_KickOff, 3911, 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_KickOff,
+                      3911,
 
-           XREF_D3D_CDevice_KickOff,
-           XRefZero)
-{
+                      XREF_D3D_CDevice_KickOff,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0xA1 },
 
@@ -1385,13 +1466,15 @@ OOVPA_XREF(D3DDevice_KickOff, 3911, 10,
     { 0x90, 0x83 },
     { 0x91, 0xEA },
     { 0x92, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_LoadVertexShader+0x00 : push ebx
     { 0x00, 0x53 },
@@ -1411,13 +1494,15 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 3911, 11)
     // D3DDevice_LoadVertexShader+0x4E : mov [ebx], ebx
     { 0x4E, 0x89 },
     { 0x4F, 0x13 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SelectVertexShader+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -1438,17 +1523,19 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 3911, 12)
     // D3DDevice_SelectVertexShader+0x51 : mov [esi], eax
     { 0x51, 0x89 },
     { 0x52, 0x06 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BlockUntilVerticalBlank
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(D3DDevice_BlockUntilVerticalBlank, 3911, 2 + 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BlockUntilVerticalBlank,
+                      3911,
 
-           XREF_D3DDevice_BlockUntilVerticalBlank,
-           XRefTwo)
-{
+                      XREF_D3DDevice_BlockUntilVerticalBlank,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BlockUntilVerticalBlank+0x00 : mov eax, [D3D__PDEVICE]
     XREF_ENTRY(0x01, XREF_D3DDEVICE),
@@ -1477,17 +1564,19 @@ OOVPA_XREF(D3DDevice_BlockUntilVerticalBlank, 3911, 2 + 15,
     // D3DDevice_BlockUntilVerticalBlank+0x23 : ret
     OV_MATCH(0x23, 0xC3), // NOTE: LTCG doesn't have a ret here and is extended function.
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVerticalBlankCallback
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(D3DDevice_SetVerticalBlankCallback, 3911, 2 + 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVerticalBlankCallback,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVerticalBlankCallback+0x04 : mov ecx,[D3D__PDEVICE]
     XREF_ENTRY(0x06, XREF_D3DDEVICE),
@@ -1504,7 +1593,8 @@ OOVPA_XREF(D3DDevice_SetVerticalBlankCallback, 3911, 2 + 9,
     // D3DDevice_SetVerticalBlankCallback+0x10 : retn 0x04
     OV_MATCH(0x10, 0xC2, 0x04, 0x00),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
@@ -1542,8 +1632,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DSurface_GetDesc
 // ******************************************************************
-OOVPA_NO_XREF(D3DSurface_GetDesc, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DSurface_GetDesc,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DSurface_GetDesc+0x00 : mov eax, [esp+0x08]
     { 0x00, 0x8B },
@@ -1575,13 +1666,15 @@ OOVPA_NO_XREF(D3DSurface_GetDesc, 3911, 16)
     { 0x12, 0x08 },
     { 0x13, 0x00 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetTransform, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetTransform,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetTransform+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -1605,16 +1698,18 @@ OOVPA_NO_XREF(D3DDevice_GetTransform, 3911, 13)
     // D3DDevice_GetTransform+0x20 : retn 0x08
     { 0x20, 0xC2 },
     { 0x21, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetStreamSource, 3911, 1 + 13,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetStreamSource,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x23, XREF_G_STREAM), // Derived
 
@@ -1638,16 +1733,18 @@ OOVPA_XREF(D3DDevice_SetStreamSource, 3911, 1 + 13,
     { 0x6B, 0xC9 },
     { 0x6C, 0x80 },
     { 0x6D, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShader, 3911, 1 + 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x12, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived
 
@@ -1675,13 +1772,15 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 3911, 1 + 15,
     { 0x8E, 0x08 },
     { 0x8F, 0x94 },
     { 0x90, 0x1E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreatePixelShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreatePixelShader+0x00 : push 0xFC
     { 0x00, 0x68 },
@@ -1701,7 +1800,8 @@ OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 3911, 11)
     // D3DDevice_CreatePixelShader+0x42 : retn 0x08
     { 0x42, 0xC2 },
     { 0x43, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
@@ -1744,8 +1844,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SetIndices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetIndices, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetIndices,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetIndices+0x00 : push esi
     { 0x00, 0x56 },
@@ -1766,13 +1867,15 @@ OOVPA_NO_XREF(D3DDevice_SetIndices, 3911, 12)
     { 0x68, 0xBE },
     { 0x69, 0x7C },
     { 0x6A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetViewport, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetViewport+0x00 : sub esp, 0x08
     { 0x00, 0x83 },
@@ -1791,13 +1894,15 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 3911, 10)
 
     // D3DDevice_SetViewport+0x9D : inc edx
     { 0x9D, 0x42 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVertices,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVertices+0x00 : push ebp
     { 0x00, 0X55 },
@@ -1819,13 +1924,15 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 3911, 13)
     // D3DDevice_DrawIndexedVertices+0xDA : lea ebx, [ebx+0]
     { 0xDA, 0x8D },
     { 0xDB, 0x9B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Begin
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Begin, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Begin,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_Begin+0x00 : push esi
     { 0x00, 0x56 },
@@ -1846,13 +1953,15 @@ OOVPA_NO_XREF(D3DDevice_Begin, 3911, 12)
     // D3DDevice_Begin+0x38 : retn 0x08
     { 0x38, 0xC2 },
     { 0x39, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2f
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2f,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexData2f+0x00 : push esi
     { 0x00, 0x56 },
@@ -1878,13 +1987,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 3911, 15)
     // D3DDevice_SetVertexData2f+0x2E : retn 0x0C
     { 0x2E, 0xC2 },
     { 0x2F, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2s
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2s,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexData2f+0x00 : push esi
     { 0x00, 0x56 },
@@ -1907,13 +2018,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 3911, 12)
     // D3DDevice_SetVertexData2s+0x32 : retn 0x0C
     { 0x32, 0xC2 },
     { 0x33, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexData4f+0x00 : push esi
     { 0x00, 0x56 },
@@ -1934,13 +2047,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 3911, 12)
     // D3DDevice_SetVertexData4f+0x50 : retn 0x14
     { 0x50, 0xC2 },
     { 0x51, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexDataColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 3911, 18)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexDataColor,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexDataColor+0x00 : push esi
     { 0x00, 0x56 },
@@ -1967,13 +2082,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 3911, 18)
     { 0x34, 0xFF },
     { 0x35, 0x00 },
     { 0x36, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_End
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_End, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_End,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_End+0x00 : push esi
     { 0x00, 0x56 },
@@ -1997,13 +2114,15 @@ OOVPA_NO_XREF(D3DDevice_End, 3911, 13)
 
     // D3DDevice_End+0x40 : retn
     { 0x40, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Clear
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Clear, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Clear,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_Clear+0x00 : sub esp, 0x38
     { 0x00, 0x83 },
@@ -2020,13 +2139,15 @@ OOVPA_NO_XREF(D3DDevice_Clear, 3911, 10)
     { 0x5E, 0x06 },
     { 0x5F, 0x33 },
     { 0x60, 0xED },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePalette
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreatePalette, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreatePalette,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreatePalette+0x01 : push 0x0C
     { 0x01, 0x6A },
@@ -2047,7 +2168,8 @@ OOVPA_NO_XREF(D3DDevice_CreatePalette, 3911, 12)
     { 0x4E, 0xC1 },
     { 0x4F, 0xE6 },
     { 0x50, 0x1E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPalette
@@ -2087,8 +2209,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_CreateTexture
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateTexture, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateTexture,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateTexture+0x00 : mov eax, [esp+0x1C]
     { 0x00, 0x8B },
@@ -2119,13 +2242,15 @@ OOVPA_NO_XREF(D3DDevice_CreateTexture, 3911, 14)
     // D3DDevice_CreateTexture+0x29 : retn 0x1C
     { 0x29, 0xC2 },
     { 0x2A, 0x1C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVolumeTexture
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateVolumeTexture, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateVolumeTexture,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateVolumeTexture+0x00 : mov eax, [esp+0x1C]
     { 0x00, 0x8B },
@@ -2153,13 +2278,15 @@ OOVPA_NO_XREF(D3DDevice_CreateVolumeTexture, 3911, 15)
     // D3DDevice_CreateVolumeTexture+0x2C : retn 0x20
     { 0x2C, 0xC2 },
     { 0x2D, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateCubeTexture
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateCubeTexture, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateCubeTexture,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateCubeTexture+0x00 : mov eax, [esp+0x1C]
     { 0x00, 0x8B },
@@ -2187,13 +2314,15 @@ OOVPA_NO_XREF(D3DDevice_CreateCubeTexture, 3911, 15)
     // D3DDevice_CreateCubeTexture+0x25 : retn 0x18
     { 0x25, 0xC2 },
     { 0x26, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateIndexBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateIndexBuffer, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateIndexBuffer,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateIndexBuffer+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -2216,13 +2345,15 @@ OOVPA_NO_XREF(D3DDevice_CreateIndexBuffer, 3911, 14)
     { 0x31, 0x00 },
     { 0x32, 0x01 },
     { 0x33, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstant,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstant+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2244,13 +2375,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant, 3911, 11)
     // D3DDevice_SetVertexShaderConstant+0x9B : retn 0x0C
     { 0x9B, 0xC2 },
     { 0x9C, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetFlickerFilter
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetFlickerFilter, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetFlickerFilter,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetFlickerFilter+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -2272,13 +2405,15 @@ OOVPA_NO_XREF(D3DDevice_SetFlickerFilter, 3911, 13)
     // D3DDevice_SetFlickerFilter+0x1C : retn 0x08
     { 0x1C, 0xC2 },
     { 0x1D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetSoftDisplayFilter
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetSoftDisplayFilter,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetSoftDisplayFilter+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -2300,13 +2435,15 @@ OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter, 3911, 13)
     // D3DDevice_SetSoftDisplayFilter+0x1C : retn 0x08
     { 0x1C, 0xC2 },
     { 0x1D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetTextureState_BorderColor+0x00 : push esi
     { 0x00, 0x56 },
@@ -2331,13 +2468,15 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 3911, 14)
     // D3DDevice_SetTextureState_BorderColor+0x34 : retn 0x08
     { 0x34, 0xC2 },
     { 0x35, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_PSTextureModes
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_PSTextureModes, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_PSTextureModes,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_PSTextureModes+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -2358,13 +2497,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_PSTextureModes, 3911, 12)
     // D3DDevice_SetRenderState_PSTextureModes+0x21 : retn 4
     { 0x21, 0xC2 },
     { 0x22, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_StencilFail+0x00 : push esi
     { 0x00, 0x56 },
@@ -2386,14 +2527,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 3911, 13)
     { 0x4B, 0x1D },
     { 0x4C, 0x04 },
     { 0x4D, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_Simple
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(D3DDevice_SetRenderState_Simple, 3911, 12, XREF_D3DDevice_SetRenderState_Simple, XRefZero)
-{
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_Simple,
+                      3911,
+                      XREF_D3DDevice_SetRenderState_Simple,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_Simple+0x00 : mov eax, [D3D__DEVICE]
     OV_MATCH(0x00, 0xA1),
@@ -2413,13 +2558,15 @@ OOVPA_XREF(D3DDevice_SetRenderState_Simple, 3911, 12, XREF_D3DDevice_SetRenderSt
     OV_MATCH(0x1C, 0x52, 0x51),
 
     // Offset 0x1E and later has shift forward in 4034
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTransform, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetTransform+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -2444,16 +2591,18 @@ OOVPA_NO_XREF(D3DDevice_SetTransform, 3911, 14)
     // D3DDevice_SetTransform+0x7A : fdivp st(1), st
     { 0x7A, 0xDE },
     { 0x7B, 0xF9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::UpdateProjectionViewportTransform
 // ******************************************************************
-OOVPA_XREF(D3D_UpdateProjectionViewportTransform, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3D_UpdateProjectionViewportTransform,
+                      3911,
 
-           XREF_D3D_UpdateProjectionViewportTransform,
-           XRefOne)
-{
+                      XREF_D3D_UpdateProjectionViewportTransform,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     // mov e??, XREF_D3DDEVICE
     XREF_ENTRY(0x0C, XREF_D3DDEVICE), // Derived
 
@@ -2471,14 +2620,15 @@ OOVPA_XREF(D3D_UpdateProjectionViewportTransform, 3911, 1 + 11,
 
     // jge +0x06
     OV_MATCH(0x1F, 0x7D, 0x06),
-
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_MultiplyTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_MultiplyTransform, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_MultiplyTransform,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -2498,13 +2648,15 @@ OOVPA_NO_XREF(D3DDevice_MultiplyTransform, 3911, 16)
     { 0x4D, 0xC2 },
     { 0x4E, 0x08 },
     { 0x4F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FogColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FogColor,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_FogColor+0x00 : push esi
     { 0x00, 0x56 },
@@ -2525,13 +2677,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 3911, 12)
     // D3DDevice_SetRenderState_FogColor+0x44 : retn 0x04
     { 0x44, 0xC2 },
     { 0x45, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FillMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FillMode,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_FillMode+0x00 : push esi
     { 0x00, 0x56 },
@@ -2552,13 +2706,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 3911, 12)
     // D3DDevice_SetRenderState_FillMode+0x3B : retn 0x04
     { 0x3B, 0xC2 },
     { 0x3C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_StencilEnable+0x00 : push esi
     { 0x00, 0x56 },
@@ -2579,15 +2735,17 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 3911, 12)
     // D3DDevice_SetRenderState_StencilEnable+0x7D : retn 0x04
     { 0x7D, 0xC2 },
     { 0x7E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_Dxt1NoiseEnable
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
 // 1024 (4627), 1036 (3911) <-- jarupxx, this doesn't make sense.
-OOVPA_NO_XREF(D3DDevice_SetRenderState_Dxt1NoiseEnable, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_Dxt1NoiseEnable,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_Dxt1NoiseEnable+0x00 : push ebx
     OV_MATCH(0x00, 0x53),
@@ -2607,13 +2765,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_Dxt1NoiseEnable, 3911, 12)
     // D3DDevice_SetRenderState_Dxt1NoiseEnable+0x2E : and ecx,0x01
     OV_MATCH(0x2E, 0x83, 0xE1, 0x01),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZBias
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZBias,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_ZBias+0x00 : push ecx
     { 0x00, 0x51 },
@@ -2635,13 +2795,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 3911, 11)
     // D3DDevice_SetRenderState_ZBias+0x45 : retn 0x04
     { 0x71, 0xC2 },
     { 0x72, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_ZEnable+0x00 : push esi
     { 0x00, 0x56 },
@@ -2666,13 +2828,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 3911, 14)
     // D3DDevice_SetRenderState_ZEnable+0x69 : retn 0x04
     { 0x69, 0xC2 },
     { 0x6A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Present
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Present, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Present,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_Present+0x00 : sub esp, 8
     { 0x00, 0x83 },
@@ -2694,13 +2858,15 @@ OOVPA_NO_XREF(D3DDevice_Present, 3911, 11)
     // D3DDevice_Present+0xC0 : xor edi, edi
     { 0xC0, 0x33 },
     { 0xC1, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetShaderConstantMode+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -2722,13 +2888,15 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode, 3911, 13)
     { 0xE5, 0xC3 },
     { 0xE6, 0x24 },
     { 0xE7, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetBackBuffer+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -2752,7 +2920,8 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer, 3911, 13)
     // D3DDevice_GetBackBuffer+0x31 : retn 0x0C
     { 0x31, 0xC2 },
     { 0x32, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetRenderTarget
@@ -2818,8 +2987,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_CreateVertexBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateVertexBuffer, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateVertexBuffer,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateVertexBuffer+0x00 : push esi
     { 0x00, 0x56 },
@@ -2844,13 +3014,15 @@ OOVPA_NO_XREF(D3DDevice_CreateVertexBuffer, 3911, 14)
     // D3DDevice_CreateVertexBuffer+0x53 : retn 0x14
     { 0x53, 0xC2 },
     { 0x54, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DVertexBuffer_Lock
 // ******************************************************************
-OOVPA_NO_XREF(D3DVertexBuffer_Lock, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DVertexBuffer_Lock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DVertexBuffer_Lock+0x01 : mov bl, [esp+0x18]
     { 0x01, 0x8A },
@@ -2870,13 +3042,15 @@ OOVPA_NO_XREF(D3DVertexBuffer_Lock, 3911, 11)
     // D3DVertexBuffer_Lock+0x4A : retn 0x14
     { 0x4A, 0xC2 },
     { 0x4B, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_Register
 // ******************************************************************
-OOVPA_NO_XREF(D3DResource_Register, 3911, 19)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_Register,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DResource_Register+0x00 : mov ecx, [esp+0x04]
     { 0x00, 0x8B },
@@ -2910,14 +3084,15 @@ OOVPA_NO_XREF(D3DResource_Register, 3911, 19)
     // D3DResource_Register+0x25 : retn 0x08
     { 0x25, 0xC2 },
     { 0x26, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_Release
 // ******************************************************************
-OOVPA_NO_XREF(D3DResource_Release, 3911, 12)
-{
-#define D3DResource_Release_4627 D3DResource_Release_3911
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_Release,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DResource_Release+0x00 : push esi
     { 0x00, 0x56 },
@@ -2942,16 +3117,18 @@ OOVPA_NO_XREF(D3DResource_Release, 3911, 12)
     // D3DResource_Release+0x4B : retn 0x04
     { 0x4B, 0xC2 },
     { 0x4C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_AddRef
 // ******************************************************************
-OOVPA_XREF(D3DResource_AddRef, 3911, 11,
+OOVPA_SIG_HEADER_XREF(D3DResource_AddRef,
+                      3911,
 
-           XREF_D3DResource_AddRef,
-           XRefZero)
-{
+                      XREF_D3DResource_AddRef,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DResource_AddRef+0x00 : push esi
     { 0x00, 0x56 },
@@ -2975,13 +3152,15 @@ OOVPA_XREF(D3DResource_AddRef, 3911, 11,
     // D3DResource_AddRef+0x34 : retn 0x04
     { 0x34, 0xC2 },
     { 0x35, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_IsBusy
 // ******************************************************************
-OOVPA_NO_XREF(D3DResource_IsBusy, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_IsBusy,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DResource_IsBusy+0x00 : mov ecx, [esp+arg_0]
     { 0x00, 0x8B },
@@ -3004,13 +3183,15 @@ OOVPA_NO_XREF(D3DResource_IsBusy, 3911, 12)
     // D3DResource_IsBusy+0x79 : jnb +0x09
     { 0x79, 0x73 },
     { 0x7A, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DSurface_LockRect
 // ******************************************************************
-OOVPA_NO_XREF(D3DSurface_LockRect, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DSurface_LockRect,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DSurface_LockRect+0x00 : mov eax, [esp+0x10]
     { 0x00, 0x8B },
@@ -3039,13 +3220,15 @@ OOVPA_NO_XREF(D3DSurface_LockRect, 3911, 16)
     // D3DSurface_LockRect+0x11 : retn 0x10
     { 0x1D, 0xC2 },
     { 0x1E, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DPalette_Lock
 // ******************************************************************
-OOVPA_NO_XREF(D3DPalette_Lock, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DPalette_Lock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DPalette_Lock+0x00 : test [esp+0x0C], 0xA0
     { 0x00, 0xF6 },
@@ -3067,13 +3250,15 @@ OOVPA_NO_XREF(D3DPalette_Lock, 3911, 13)
     // D3DPalette_Lock+0x1C : mov [ecx], eax
     { 0x1C, 0x89 },
     { 0x1D, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_LockRect
 // ******************************************************************
-OOVPA_NO_XREF(D3DTexture_LockRect, 3911, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DTexture_LockRect,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DTexture_LockRect+0x00 : mov eax, [esp+0x14]
     { 0x00, 0x8B },
@@ -3101,41 +3286,47 @@ OOVPA_NO_XREF(D3DTexture_LockRect, 3911, 17)
     // D3DTexture_LockRect+0x20 : retn 0x14
     { 0x20, 0xC2 },
     { 0x21, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DVolumeTexture_LockBox
 // ******************************************************************
-OOVPA_XREF(D3DVolumeTexture_LockBox, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(D3DVolumeTexture_LockBox,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_Lock3DSurface),
 
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DCubeTexture_LockRect
 // ******************************************************************
-OOVPA_XREF(D3DCubeTexture_LockRect, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(D3DCubeTexture_LockRect,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_Lock2DSurface),
 
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetSurfaceLevel
 // ******************************************************************
-OOVPA_NO_XREF(D3DTexture_GetSurfaceLevel, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DTexture_GetSurfaceLevel,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DTexture_GetSurfaceLevel+0x08 : lea [esp+0x14]
     { 0x08, 0x8D },
@@ -3163,16 +3354,18 @@ OOVPA_NO_XREF(D3DTexture_GetSurfaceLevel, 3911, 11)
     // D3DTexture_GetSurfaceLevel+0x4C : retn 0x0C
     { 0x4C, 0xC2 },
     { 0x4D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Lock2DSurface
 // ******************************************************************
-OOVPA_XREF(Lock2DSurface, 3911, 12,
+OOVPA_SIG_HEADER_XREF(Lock2DSurface,
+                      3911,
 
-           XREF_Lock2DSurface,
-           XRefZero)
-{
+                      XREF_Lock2DSurface,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x06, 0xF6 },
@@ -3189,13 +3382,15 @@ OOVPA_XREF(Lock2DSurface, 3911, 12,
 
     { 0x98, 0xC2 },
     { 0x99, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Get2DSurfaceDesc
 // ******************************************************************
-OOVPA_NO_XREF(Get2DSurfaceDesc, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(Get2DSurfaceDesc,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // Get2DSurfaceDesc+0x2B : sub esp, 8
     { 0x00, 0x83 },
@@ -3215,13 +3410,15 @@ OOVPA_NO_XREF(Get2DSurfaceDesc, 3911, 11)
     // Get2DSurfaceDesc+0xAE : retn 0x0C
     { 0xAE, 0xC2 },
     { 0xAF, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderSize
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderSize, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderSize,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -3247,13 +3444,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderSize, 3911, 12)
         { 0x0D, 0x51 },
         { 0x10, 0x10 },
         { 0x13, 0x00 },*/
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetGammaRamp
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetGammaRamp,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetGammaRamp+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -3272,13 +3471,15 @@ OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 3911, 10)
     { 0x3E, 0x53 },
     { 0x3F, 0x8B },
     { 0x40, 0xCA },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetMaterial+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -3301,13 +3502,15 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 3911, 12)
     // D3DDevice_SetMaterial+0x23 : retn 0x04
     { 0x23, 0xC2 },
     { 0x24, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -3326,13 +3529,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 3911, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x08 },
     { 0x0F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetViewport
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetViewport, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetViewport,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x0C, 0xB0 },
@@ -3351,13 +3556,15 @@ OOVPA_NO_XREF(D3DDevice_GetViewport, 3911, 16)
     { 0x1A, 0xC2 },
     { 0x1B, 0x04 },
     { 0x1C, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDisplayFieldStatus
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetDisplayFieldStatus, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDisplayFieldStatus,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -3373,13 +3580,15 @@ OOVPA_NO_XREF(D3DDevice_GetDisplayFieldStatus, 3911, 12)
     { 0x12, 0xF7 },
 
     { 0x1C, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x0B, 0x8B },
@@ -3389,13 +3598,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 3911, 8)
     { 0x38, 0x0B },
     { 0x40, 0x89 },
     { 0x49, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_VertexBlend
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_VertexBlend,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_VertexBlend+0x00 : push esi
     { 0x00, 0x56 },
@@ -3420,13 +3631,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 3911, 14)
     // D3DDevice_SetRenderState_VertexBlend+0x2F : retn 0x04
     { 0x2F, 0xC2 },
     { 0x30, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_BackFillMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_BackFillMode, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_BackFillMode,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_BackFillMode+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -3450,13 +3663,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_BackFillMode, 3911, 13)
     // D3DDevice_SetRenderState_BackFillMode+0x48 : retn 0x04
     { 0x48, 0xC2 },
     { 0x49, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_TwoSidedLighting+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -3481,13 +3696,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 3911, 14)
     // D3DDevice_SetRenderState_TwoSidedLighting+0x51 : retn 0x04
     { 0x51, 0xC2 },
     { 0x52, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_NormalizeNormals
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_NormalizeNormals+0x00 : push esi
     { 0x00, 0x56 },
@@ -3505,13 +3722,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 3911, 9)
     // D3DDevice_SetRenderState_NormalizeNormals+0x2A : retn 0x04
     { 0x2A, 0xC2 },
     { 0x2B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FrontFace
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FrontFace,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_FrontFace+0x00 : push esi
     { 0x00, 0x56 },
@@ -3529,13 +3748,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 3911, 9)
     { 0x1A, 0x83 },
     { 0x1B, 0xC0 },
     { 0x1C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TextureFactor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TextureFactor, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TextureFactor,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_TextureFactor+0x00 : push esi
     { 0x00, 0x56 },
@@ -3557,13 +3778,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TextureFactor, 3911, 11)
     // D3DDevice_SetRenderState_TextureFactor+0x49 : retn 0x04
     { 0x49, 0xC2 },
     { 0x4A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LogicOp
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LogicOp,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_LogicOp+0x00 : push esi
     { 0x00, 0x56 },
@@ -3582,13 +3805,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 3911, 10)
     // D3DDevice_SetRenderState_LogicOp+0x49 : retn 0x04
     { 0x49, 0xC2 },
     { 0x4A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_EdgeAntiAlias
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_EdgeAntiAlias+0x00 : push esi
     { 0x00, 0x56 },
@@ -3611,13 +3836,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 3911, 12)
     // D3DDevice_SetRenderState_EdgeAntiAlias+0x29 : retn 0x04
     { 0x29, 0xC2 },
     { 0x2A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_MultiSampleMask+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -3642,16 +3869,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask, 3911, 14)
     // D3DDevice_SetRenderState_MultiSampleMask+0x49 : retn 0x04
     { 0x49, 0xC2 },
     { 0x4A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PersistDisplay
 // ******************************************************************
-OOVPA_XREF(D3DDevice_PersistDisplay, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_PersistDisplay,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_PersistDisplay+0x02 : mov ebx,[D3D__PDEVICE]
     XREF_ENTRY(0x04, XREF_D3DDEVICE),
@@ -3671,13 +3900,15 @@ OOVPA_XREF(D3DDevice_PersistDisplay, 3911, 1 + 8,
     // D3DDevice_PersistDisplay+0x36 : ret
     OV_MATCH(0x36, 0xC3),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ShadowFunc
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ShadowFunc,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_ShadowFunc+0x00 : push esi
     { 0x00, 0x56 },
@@ -3700,13 +3931,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 3911, 14)
     { 0x20, 0x83 },
     { 0x21, 0xC0 },
     { 0x22, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LineWidth
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LineWidth,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_LineWidth+0x00 : push ebx
     { 0x00, 0x53 },
@@ -3728,13 +3961,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 3911, 11)
     // D3DDevice_SetRenderState_LineWidth+0x5C : retn 0x04
     { 0x5C, 0xC2 },
     { 0x5D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_YuvEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_YuvEnable, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_YuvEnable,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_YuvEnable+0x00 : mov eax, [esp+0x04]
     { 0x00, 0x8B },
@@ -3755,18 +3990,20 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_YuvEnable, 3911, 10)
     // D3DDevice_SetRenderState_YuvEnable+0x22 : retn 0x04
     { 0x22, 0xC2 },
     { 0x23, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_OcclusionCullEnable
 // ******************************************************************
 // NOTE: asm codes are the same as D3DDevice_SetRenderState_StencilCullEnable
 //       except for the offset references.
-OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 3911, 2 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_OcclusionCullEnable,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_OcclusionCullEnable+0x05 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x07, XREF_D3DDEVICE),
@@ -3789,18 +4026,20 @@ OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 3911, 2 + 14,
 
     // D3DDevice_SetRenderState_OcclusionCullEnable+0x59 : retn 0x04
     OV_MATCH(0x59, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilCullEnable
 // ******************************************************************
 // NOTE: asm codes are the same as D3DDevice_SetRenderState_OcclusionCullEnable
 //       except for the offset references.
-OOVPA_XREF(D3DDevice_SetRenderState_StencilCullEnable, 3911, 2 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_StencilCullEnable,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_StencilCullEnable+0x05 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x07, XREF_D3DDEVICE),
@@ -3823,16 +4062,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_StencilCullEnable, 3911, 2 + 14,
 
     // D3DDevice_SetRenderState_StencilCullEnable+0x59 : retn 0x04
     OV_MATCH(0x59, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVerticesUP
 // ******************************************************************
-OOVPA_XREF(D3DDevice_DrawVerticesUP, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawVerticesUP,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawVerticesUP+0x09 : mov edi,[D3D__PDEVICE]
     XREF_ENTRY(0x0B, XREF_D3DDEVICE),
@@ -3853,16 +4094,18 @@ OOVPA_XREF(D3DDevice_DrawVerticesUP, 3911, 1 + 10,
     OV_MATCH(0x11, 0x89),
     OV_MATCH(0x13, 0xFC), // D3DDevice_DrawVerticesUP 0xFC vs D3DDevice_DrawIndexedVerticesUP 0xF8
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
-OOVPA_XREF(D3DDevice_DrawIndexedVerticesUP, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawIndexedVerticesUP,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVerticesUP+0x09 : mov edi,[D3D__PDEVICE]
     XREF_ENTRY(0x0B, XREF_D3DDEVICE),
@@ -3883,13 +4126,15 @@ OOVPA_XREF(D3DDevice_DrawIndexedVerticesUP, 3911, 1 + 10,
     OV_MATCH(0x11, 0x89),
     OV_MATCH(0x13, 0xF8), // D3DDevice_DrawIndexedVerticesUP 0xF8 vs D3DDevice_DrawVerticesUP 0xFC
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVertices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawVertices, 3911, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVertices,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -3909,13 +4154,15 @@ OOVPA_NO_XREF(D3DDevice_DrawVertices, 3911, 17)
     { 0x1E, 0x46 },
     { 0x1F, 0x05 },
     { 0x20, 0x50 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDisplayMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetDisplayMode, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDisplayMode,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x09, 0xB4 },
@@ -3925,13 +4172,15 @@ OOVPA_NO_XREF(D3DDevice_GetDisplayMode, 3911, 8)
     { 0x35, 0x8B },
     { 0x41, 0x89 },
     { 0x4B, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BumpEnv
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BumpEnv,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x0E, 0x8B },
@@ -3941,13 +4190,15 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv, 3911, 8)
     { 0x3A, 0x04 },
     { 0x46, 0x8B },
     { 0x52, 0xB5 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x56 },
@@ -3957,13 +4208,15 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 3911, 8)
     { 0x21, 0x83 },
     { 0x28, 0x07 },
     { 0x2F, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4s
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4s,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x56 },
@@ -3974,13 +4227,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 3911, 9)
     { 0x34, 0x24 },
     { 0x3D, 0x08 },
     { 0x46, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_GetType
 // ******************************************************************
-OOVPA_NO_XREF(D3DResource_GetType, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_GetType,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x13, 0x2A },
@@ -3990,13 +4245,15 @@ OOVPA_NO_XREF(D3DResource_GetType, 3911, 8)
     { 0x67, 0x00 },
     { 0x7C, 0x04 },
     { 0x91, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_AllocContiguousMemory
 // ******************************************************************
-OOVPA_NO_XREF(D3D_AllocContiguousMemory, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_AllocContiguousMemory,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3D_AllocContiguousMemory+0x00 : mov eax,[esp+0x08]
     OV_MATCH(0x00, 0x8B, 0x44, 0x24, 0x08),
@@ -4013,13 +4270,15 @@ OOVPA_NO_XREF(D3D_AllocContiguousMemory, 3911, 14)
 
     // Offset 0x0E and later has change over time.
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_Deferred
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_Deferred, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_Deferred,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_Deferred+0x00 : mov eax, ds:(g_DirtyFromRenderState)-148[ecx*4]
     { 0x00, 0x8B },
@@ -4037,13 +4296,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_Deferred, 3911, 9)
 
     // D3DDevice_SetRenderState_Deferred+0x14 : retn
     { 0x14, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetLight
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetLight, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetLight,
+                         3911)
+OOVPA_SIG_MATCH(
     // Based on Dxbx patterns for 3911, 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
 
     // D3DDevice_GetLight+0x00 : mov ecx, [addr]
@@ -4064,16 +4325,18 @@ OOVPA_NO_XREF(D3DDevice_GetLight, 3911, 11)
     // D3DDevice_GetLight+0x1F : mov ecx, 1Ah
     { 0x1E, 0xB9 },
     { 0x1F, 0x1A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetLight
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetLight, 3911, 16,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetLight,
+                      3911,
 
-           XREF_D3DDevice_SetLight,
-           XRefZero)
-{
+                      XREF_D3DDevice_SetLight,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x15, 0x00 },
@@ -4093,13 +4356,15 @@ OOVPA_XREF(D3DDevice_SetLight, 3911, 16,
 
     { 0x62, 0x8B },
     { 0x63, 0xF3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetProjectionViewportMatrix
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetProjectionViewportMatrix,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x02, 0x35 },
@@ -4109,13 +4374,15 @@ OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 3911, 8)
     { 0x12, 0xB9 },
     { 0x16, 0x00 },
     { 0x1A, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTile
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetTile, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetTile,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -4135,13 +4402,15 @@ OOVPA_NO_XREF(D3DDevice_GetTile, 3911, 16)
     { 0x1F, 0xF3 },
     { 0x23, 0xC2 },
     { 0x24, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_ApplyStateBlock
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_ApplyStateBlock, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_ApplyStateBlock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x1D, 0x83 },
@@ -4152,13 +4421,15 @@ OOVPA_NO_XREF(D3DDevice_ApplyStateBlock, 3911, 9)
     { 0xB8, 0x06 },
     { 0xD7, 0x39 },
     { 0xF6, 0x51 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CaptureStateBlock
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CaptureStateBlock, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CaptureStateBlock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x1E, 0x76 },
@@ -4168,13 +4439,15 @@ OOVPA_NO_XREF(D3DDevice_CaptureStateBlock, 3911, 8)
     { 0x9E, 0xFF },
     { 0xBE, 0x04 },
     { 0xDE, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeleteStateBlock
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DeleteStateBlock, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeleteStateBlock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x11, 0x76 },
@@ -4184,13 +4457,15 @@ OOVPA_NO_XREF(D3DDevice_DeleteStateBlock, 3911, 8)
     { 0x5D, 0x74 },
     { 0x70, 0x06 },
     { 0x83, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x56 },
@@ -4201,13 +4476,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 3911, 9)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateStateBlock
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateStateBlock, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateStateBlock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x1E, 0x8B },
@@ -4218,13 +4495,15 @@ OOVPA_NO_XREF(D3DDevice_CreateStateBlock, 3911, 9)
     { 0xBE, 0xB6 },
     { 0xDE, 0xF8 },
     { 0xFE, 0x76 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeletePixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DeletePixelShader, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeletePixelShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0x75 },
@@ -4233,13 +4512,15 @@ OOVPA_NO_XREF(D3DDevice_DeletePixelShader, 3911, 7)
     { 0x12, 0x04 },
     { 0x18, 0xC2 },
     { 0x1A, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderProgram
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderProgram, 3911, 19)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderProgram,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x54 },
@@ -4262,18 +4543,20 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderProgram, 3911, 19)
 
     { 0x29, 0x89 },
     { 0x3A, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
 // * This is for the real D3D::KickOffAndWaitForIdle
 // ******************************************************************
-OOVPA_XREF(D3D_KickOffAndWaitForIdle, 3911, 6,
+OOVPA_SIG_HEADER_XREF(D3D_KickOffAndWaitForIdle,
+                      3911,
 
-           XREF_D3D_KickOffAndWaitForIdle,
-           XRefZero)
-{
+                      XREF_D3D_KickOffAndWaitForIdle,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x8B },
@@ -4281,13 +4564,15 @@ OOVPA_XREF(D3D_KickOffAndWaitForIdle, 3911, 6,
     { 0x07, 0x1C },
     { 0x0A, 0x51 },
     { 0x10, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetModelView
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetModelView, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetModelView,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x12, 0x08 },
@@ -4297,13 +4582,15 @@ OOVPA_NO_XREF(D3DDevice_SetModelView, 3911, 8)
     { 0x62, 0x00 },
     { 0x76, 0x00 },
     { 0x8A, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_FlushVertexCache
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_FlushVertexCache, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_FlushVertexCache,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x56 },
@@ -4313,13 +4600,15 @@ OOVPA_NO_XREF(D3DDevice_FlushVertexCache, 3911, 8)
     { 0x12, 0x00 },
     { 0x17, 0x00 },
     { 0x1C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetScissors, 3911, 17) // Up to 5233
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         3911) // Up to 5233
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -4339,13 +4628,15 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 3911, 17) // Up to 5233
     { 0x3F, 0x24 },
     { 0x52, 0x44 },
     { 0x53, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderInput
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderInput, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderInput,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x1E, 0x03 },
@@ -4356,13 +4647,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderInput, 3911, 9)
     { 0xBE, 0x7F },
     { 0xDE, 0xCA },
     { 0xFE, 0x17 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PrimeVertexCache
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_PrimeVertexCache, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_PrimeVertexCache,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x0D, 0x00 },
@@ -4373,13 +4666,15 @@ OOVPA_NO_XREF(D3DDevice_PrimeVertexCache, 3911, 9)
     { 0x58, 0x74 },
     { 0x67, 0x00 },
     { 0x76, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4ub
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4ub,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x56 },
@@ -4389,13 +4684,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 3911, 8)
     { 0x2B, 0x14 },
     { 0x34, 0x24 },
     { 0x3D, 0xFC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderConstant,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x1E, 0x4C },
@@ -4405,13 +4702,15 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 3911, 8)
     { 0x9E, 0x05 },
     { 0xC0, 0x51 },
     { 0xDE, 0xC4 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_InsertCallback
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_InsertCallback, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_InsertCallback,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0D, 0x8B },
@@ -4421,13 +4720,15 @@ OOVPA_NO_XREF(D3DDevice_InsertCallback, 3911, 8)
     { 0x3F, 0x00 },
     { 0x4C, 0x00 },
     { 0x59, 0x03 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPushBuffer,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0B, 0xCE },
@@ -4437,13 +4738,15 @@ OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 3911, 8)
     { 0x3F, 0x03 },
     { 0x4C, 0x04 },
     { 0x59, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_EndPushBuffer, 3911, 13) // Up to 5849
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EndPushBuffer,
+                         3911) // Up to 5849
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x56 },
     { 0x11, 0x8D },
@@ -4460,17 +4763,19 @@ OOVPA_NO_XREF(D3DDevice_EndPushBuffer, 3911, 13) // Up to 5849
 
     { 0x6D, 0x8B },
     { 0x6E, 0x86 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_RopZCmpAlwaysRead
 // ******************************************************************
 // LTCG: 1024
-OOVPA_XREF(D3DDevice_SetRenderState_RopZCmpAlwaysRead, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_RopZCmpAlwaysRead,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_RopZCmpAlwaysRead+0x05 : D3D__RenderState[D3DRS_ROPZCMPALWAYSREAD]
     XREF_ENTRY(0x05, XREF_D3DRS_ROPZCMPALWAYSREAD), // Derived
@@ -4488,17 +4793,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_RopZCmpAlwaysRead, 3911, 1 + 8,
     { 0x0E, 0xC2 },
     { 0x0F, 0x04 },
     { 0x10, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_RopZRead
 // ******************************************************************
 // LTCG: 1024
-OOVPA_XREF(D3DDevice_SetRenderState_RopZRead, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_RopZRead,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_RopZRead+0x05 : D3D__RenderState[D3DRS_ROPZREAD]
     XREF_ENTRY(0x05, XREF_D3DRS_ROPZREAD), // Derived
@@ -4516,17 +4823,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_RopZRead, 3911, 1 + 8,
     { 0x0E, 0xC2 },
     { 0x0F, 0x04 },
     { 0x10, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_DoNotCullUncompressed
 // ******************************************************************
 // LTCG: 1024
-OOVPA_XREF(D3DDevice_SetRenderState_DoNotCullUncompressed, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_DoNotCullUncompressed,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_DoNotCullUncompressed+0x05 : D3D__RenderState[D3DRS_DONOTCULLUNCOMPRESSED]
     XREF_ENTRY(0x05, XREF_D3DRS_DONOTCULLUNCOMPRESSED), // Derived
@@ -4544,17 +4853,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_DoNotCullUncompressed, 3911, 1 + 8,
     { 0x0E, 0xC2 },
     { 0x0F, 0x04 },
     { 0x10, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMETAL_StartPush
 // ******************************************************************
 // Generic OOVPA as of 3911; Removed in 4034??
-OOVPA_XREF(XMETAL_StartPush, 3911, 11,
+OOVPA_SIG_HEADER_XREF(XMETAL_StartPush,
+                      3911,
 
-           XREF_XMETAL_StartPush,
-           XRefZero)
-{
+                      XREF_XMETAL_StartPush,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // XMETAL_StartPush+0x00 : mov ecx, [esp+0x4]
     { 0x00, 0x8B },
@@ -4574,16 +4885,18 @@ OOVPA_XREF(XMETAL_StartPush, 3911, 11,
     // XMETAL_StartPush+0x10 : retn 4
     { 0x10, 0xC2 },
     { 0x11, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 3911, 12,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      3911,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::SetFence+0x00 : push ebx
     { 0x00, 0x53 },
@@ -4606,16 +4919,18 @@ OOVPA_XREF(D3D_SetFence, 3911, 12,
     // D3D::SetFence+0x96 : retn 4
     { 0x96, 0xC2 },
     { 0x97, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_InsertFence
 // ******************************************************************
-OOVPA_XREF(D3DDevice_InsertFence, 3911, 1 + 4,
+OOVPA_SIG_HEADER_XREF(D3DDevice_InsertFence,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3D_SetFence),
 
@@ -4623,13 +4938,15 @@ OOVPA_XREF(D3DDevice_InsertFence, 3911, 1 + 4,
     { 0x01, 0x00 },
     { 0x02, 0xE8 },
     { 0x07, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShaderProgram
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShaderProgram,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -4648,13 +4965,15 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 3911, 16)
     { 0x15, 0x02 },
     { 0x16, 0xF6 },
     { 0x17, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeleteVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DeleteVertexShader, 3911, 6)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeleteVertexShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0xFF },
@@ -4664,16 +4983,18 @@ OOVPA_NO_XREF(D3DDevice_DeleteVertexShader, 3911, 6)
     // D3DDevice_DeleteVertexShader+0x16 : retn 4
     { 0x16, 0xC2 },
     { 0x17, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BlockOnFence
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BlockOnFence, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BlockOnFence,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x08, XREF_D3D_BlockOnTime),
 
@@ -4684,13 +5005,15 @@ OOVPA_XREF(D3DDevice_BlockOnFence, 3911, 1 + 7,
     { 0x0C, 0xC2 },
     { 0x0D, 0x04 },
     { 0x0E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Reset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Reset, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_Reset+0x00 : push ebx
     { 0x00, 0x53 },
@@ -4712,13 +5035,15 @@ OOVPA_NO_XREF(D3DDevice_Reset, 3911, 11)
     // D3DDevice_Reset+0x37 : jge +0x10
     { 0x37, 0x7D },
     { 0x38, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_GetAdapterIdentifier
 // ******************************************************************
-OOVPA_NO_XREF(D3D_GetAdapterIdentifier, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_GetAdapterIdentifier,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x85 },
     { 0x0A, 0x08 },
@@ -4727,13 +5052,15 @@ OOVPA_NO_XREF(D3D_GetAdapterIdentifier, 3911, 7)
     { 0x20, 0xF3 },
     { 0x22, 0x5F },
     { 0x28, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_GetDeviceCaps
 // ******************************************************************
-OOVPA_NO_XREF(D3D_GetDeviceCaps, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_GetDeviceCaps,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x85 },
     { 0x0A, 0x08 },
@@ -4742,13 +5069,15 @@ OOVPA_NO_XREF(D3D_GetDeviceCaps, 3911, 7)
     { 0x1C, 0xC2 },
     { 0x22, 0x0C },
     { 0x29, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetCommonDebugRegisters
 // ******************************************************************
-OOVPA_NO_XREF(D3D_SetCommonDebugRegisters, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_SetCommonDebugRegisters,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x08, 0x96 },
@@ -4760,13 +5089,15 @@ OOVPA_NO_XREF(D3D_SetCommonDebugRegisters, 3911, 10)
     { 0x34, 0xFF },
     { 0x35, 0xEF },
     { 0x36, 0xE7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateImageSurface
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateImageSurface, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateImageSurface,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0x24 },
@@ -4775,16 +5106,18 @@ OOVPA_NO_XREF(D3DDevice_CreateImageSurface, 3911, 7)
     { 0x12, 0x00 },
     { 0x16, 0xE8 },
     { 0x1B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnTime
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnTime, 3911, 10,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      3911,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::BlockOnFence+0x00 : push ebp
     { 0x00, 0x55 },
@@ -4803,16 +5136,18 @@ OOVPA_XREF(D3D_BlockOnTime, 3911, 10,
     { 0x6F, 0x00 },
     { 0x70, 0x01 },
     { 0x71, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnResource
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnResource, 3911, 10,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnResource,
+                      3911,
 
-           XREF_D3D_BlockOnResource,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnResource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x34, 0x8B }, // mov edx, [ecx+0x1C]
@@ -4824,27 +5159,31 @@ OOVPA_XREF(D3D_BlockOnResource, 3911, 10,
     { 0x7E, 0xC2 }, // retn 4
     { 0x7F, 0x04 },
     { 0x80, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_BlockUntilNotBusy
 // ******************************************************************
-OOVPA_XREF(D3DResource_BlockUntilNotBusy, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(D3DResource_BlockUntilNotBusy,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3D_BlockOnResource),
 
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTile
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTile, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetTile+0x06 : sub esp, 0x18
     { 0x06, 0x83 },
@@ -4866,13 +5205,15 @@ OOVPA_NO_XREF(D3DDevice_SetTile, 3911, 13)
     { 0x8F, 0x8E },
     { 0x90, 0xD0 },
     { 0x91, 0x21 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x0A, 0x57 },
@@ -4884,13 +5225,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 3911, 10)
     { 0x14, 0x00 },
     { 0x18, 0x8B },
     { 0x1E, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SwitchTexture
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SwitchTexture, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SwitchTexture,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SwitchTexture+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -4912,13 +5255,15 @@ OOVPA_NO_XREF(D3DDevice_SwitchTexture, 3911, 10)
     { 0x22, 0xC2 },
     { 0x23, 0x04 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetModelView
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetModelView, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetModelView,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x57 },
@@ -4931,13 +5276,15 @@ OOVPA_NO_XREF(D3DDevice_GetModelView, 3911, 11)
     { 0x15, 0xB9 },
     { 0x16, 0x10 },
     { 0x1C, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CopyRects
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CopyRects, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x81 },
     { 0x10, 0x0F },
@@ -4949,13 +5296,15 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 3911, 10)
     { 0x40, 0xF6 },
     { 0x4F, 0x84 },
     { 0x75, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DVertexBuffer_GetDesc
 // ******************************************************************
-OOVPA_NO_XREF(D3DVertexBuffer_GetDesc, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DVertexBuffer_GetDesc,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0x74 },
@@ -4964,13 +5313,15 @@ OOVPA_NO_XREF(D3DVertexBuffer_GetDesc, 3911, 7)
     { 0x15, 0x89 },
     { 0x16, 0x46 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -4989,13 +5340,15 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 3911, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShader, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -5014,13 +5367,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShader, 3911, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderConstant, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderConstant,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x05, 0x8B },
@@ -5032,13 +5387,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderConstant, 3911, 10)
     { 0x0B, 0x3D },
     { 0x18, 0x00 },
     { 0x1F, 0xF7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderInput
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderInput, 3911, 18)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderInput,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x05, 0xC9 },
@@ -5060,13 +5417,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderInput, 3911, 18)
 
     { 0x34, 0x8D },
     { 0x35, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunVertexStateShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunVertexStateShader, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunVertexStateShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0D, 0x8B },
@@ -5078,13 +5437,15 @@ OOVPA_NO_XREF(D3DDevice_RunVertexStateShader, 3911, 10)
     { 0x15, 0xD9 },
     { 0x16, 0x41 },
     { 0x1F, 0x41 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderType
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderType, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderType,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x04, 0x8B },
@@ -5094,13 +5455,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderType, 3911, 8)
     { 0x1C, 0x40 },
     { 0x22, 0xC9 },
     { 0x28, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderDeclaration
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderDeclaration, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderDeclaration,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x04, 0x8A },
@@ -5120,13 +5483,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderDeclaration, 3911, 15)
     { 0x1F, 0x0C },
 
     { 0x40, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderFunction
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderFunction, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderFunction,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x16, 0xC0 },
@@ -5136,13 +5501,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderFunction, 3911, 8)
     { 0x76, 0xC7 },
     { 0x8E, 0x00 },
     { 0xA6, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPixelShader, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPixelShader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -5161,13 +5528,15 @@ OOVPA_NO_XREF(D3DDevice_GetPixelShader, 3911, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsFencePending
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_IsFencePending, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_IsFencePending,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x8B },
@@ -5181,13 +5550,15 @@ OOVPA_NO_XREF(D3DDevice_IsFencePending, 3911, 12)
     { 0x0D, 0x1C },
     { 0x1A, 0x1B },
     { 0x1F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPushBufferOffset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPushBufferOffset, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPushBufferOffset,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x14, 0xB8 },
@@ -5197,13 +5568,15 @@ OOVPA_NO_XREF(D3DDevice_GetPushBufferOffset, 3911, 8)
     { 0x6C, 0xAB },
     { 0x82, 0x04 },
     { 0x98, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_GetAdapterDisplayMode
 // ******************************************************************
-OOVPA_NO_XREF(D3D_GetAdapterDisplayMode, 3911, 21)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_GetAdapterDisplayMode,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -5229,14 +5602,16 @@ OOVPA_NO_XREF(D3D_GetAdapterDisplayMode, 3911, 21)
 
     { 0x30, 0x00 },
     { 0x31, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_EnumAdapterModes
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3D_EnumAdapterModes, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_EnumAdapterModes,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -5254,14 +5629,16 @@ OOVPA_NO_XREF(D3D_EnumAdapterModes, 3911, 14)
 
     { 0x50, 0x6C },
     { 0x51, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_GetAdapterModeCount
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3D_GetAdapterModeCount, 3911, 20)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_GetAdapterModeCount,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -5285,14 +5662,16 @@ OOVPA_NO_XREF(D3D_GetAdapterModeCount, 3911, 20)
 
     { 0x40, 0x14 },
     { 0x41, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeletePatch
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(D3DDevice_DeletePatch, 3911, 19)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeletePatch,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x05, 0x0D },
@@ -5315,29 +5694,33 @@ OOVPA_NO_XREF(D3DDevice_DeletePatch, 3911, 19)
     { 0x1F, 0x00 },
 
     { 0x25, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_KickPushBuffer
 // ******************************************************************
-OOVPA_XREF(D3DDevice_KickPushBuffer, 3911, 1 + 3,
+OOVPA_SIG_HEADER_XREF(D3DDevice_KickPushBuffer,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x07, XREF_D3D_CDevice_KickOff),
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
     { 0x06, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport_IsFlipPending
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_IsFlipPending, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_IsFlipPending,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x81 },
@@ -5353,13 +5736,17 @@ OOVPA_NO_XREF(CMiniport_IsFlipPending, 3911, 14)
     { 0x0B, 0x00 },
     { 0x0C, 0x00 },
     { 0x0D, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDevice::MakeSpace_4
 // ******************************************************************
-OOVPA_XREF(CDevice_MakeSpace, 3911, 13, XREF_D3D_CDevice_MakeSpace, XRefZero)
-{
+OOVPA_SIG_HEADER_XREF(CDevice_MakeSpace,
+                      3911,
+                      XREF_D3D_CDevice_MakeSpace,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDevice::MakeSpace_4+0x00 : sub esp,0x__
     OV_MATCH(0x00, 0x83, 0xEC),
@@ -5376,14 +5763,18 @@ OOVPA_XREF(CDevice_MakeSpace, 3911, 13, XREF_D3D_CDevice_MakeSpace, XRefZero)
     // CDevice::MakeSpace_4+0x32 : ret
     OV_MATCH(0x32, 0xC3),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice::SetRenderStateNotInline
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(D3DDevice_SetRenderStateNotInline, 3911, 1 + 6, XREF_D3DDevice_SetRenderStateNotInline, XRefOne)
-{
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderStateNotInline,
+                      3911,
+                      XREF_D3DDevice_SetRenderStateNotInline,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice::SetRenderStateNotInline+0x18 : call D3DDevice_SetRenderState_Simple
     XREF_ENTRY(0x19, XREF_D3DDevice_SetRenderState_Simple),
@@ -5402,14 +5793,19 @@ OOVPA_XREF(D3DDevice_SetRenderStateNotInline, 3911, 1 + 6, XREF_D3DDevice_SetRen
 
     // After offset 0x24 has various instruction changes
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice::SetRenderState
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF_DETECT(D3DDevice_SetRenderState, 3911, 1 + 4, XRefNoSaveIndex, XRefOne, DetectFirst)
-{
+OOVPA_SIG_HEADER_XREF_DETECT(D3DDevice_SetRenderState,
+                             3911,
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // D3DDevice::SetRenderState+0x02 : call D3DDevice_SetRenderStateNotInline
     XREF_ENTRY(0x03, XREF_D3DDevice_SetRenderStateNotInline),
@@ -5423,15 +5819,20 @@ OOVPA_XREF_DETECT(D3DDevice_SetRenderState, 3911, 1 + 4, XRefNoSaveIndex, XRefOn
     // D3DDevice::SetRenderState+0x07 : ret
     OV_MATCH(0x07, 0xC3),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice::SetRenderState (duplicate)
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
 // TODO: Add another macro to accept duplicates.
-OOVPA_XREF_DETECT(D3DDevice_SetRenderState2, 3911, 1 + 4, XRefNoSaveIndex, XRefOne, DetectSecond)
-{
+OOVPA_SIG_HEADER_XREF_DETECT(D3DDevice_SetRenderState2,
+                             3911,
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // D3DDevice::SetRenderState+0x02 : call D3DDevice_SetRenderStateNotInline
     XREF_ENTRY(0x03, XREF_D3DDevice_SetRenderStateNotInline),
@@ -5445,4 +5846,5 @@ OOVPA_XREF_DETECT(D3DDevice_SetRenderState2, 3911, 1 + 4, XRefNoSaveIndex, XRefO
     // D3DDevice::SetRenderState+0x07 : ret
     OV_MATCH(0x07, 0xC3),
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/3911.inl
+++ b/src/OOVPADatabase/D3D8/3911.inl
@@ -32,7 +32,7 @@
 //       D3DDevice_BlockUntilVerticalBlank detection.
 //       So, even though it's scanning for D3DDevice_BlockUntilVerticalBlank,
 //       this OOVPA itself is not a symbol.
-OOVPA_SIG_HEADER_XREF_EXTEND(D3DDevice__m_VerticalBlankEvent__ManualFindGeneric,
+OOVPA_SIG_HEADER_XREF_DETECT(D3DDevice__m_VerticalBlankEvent__ManualFindGeneric,
                              3911,
 
                              XRefNoSaveIndex,

--- a/src/OOVPADatabase/D3D8/3925.inl
+++ b/src/OOVPADatabase/D3D8/3925.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 3925, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode,
+                         3925)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_MultiSampleMode+0x05 : mov ecx, [esp+4]
     { 0x05, 0x8B },
@@ -48,4 +49,5 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 3925, 12)
     // D3DDevice_SetRenderState_MultiSampleMode+0x22 : retn 0x04
     { 0x22, 0xC2 },
     { 0x23, 0x04 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4034.inl
+++ b/src/OOVPADatabase/D3D8/4034.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * CMiniport::InitHardware
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_InitHardware, 4034, 23)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_InitHardware,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -55,13 +56,15 @@ OOVPA_NO_XREF(CMiniport_InitHardware, 4034, 23)
     { 0x1D, 0x80 },
     { 0x1E, 0xA6 },
     //{ 0x1F, 0xD8 }, // 4034 0xD8 vs 4242 0xDC
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport::CreateCtxDmaObject
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_CreateCtxDmaObject, 4034, 32) // Also for 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_CreateCtxDmaObject,
+                         4034) // Also for 4361, 4627, 5344, 5558, 5659, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -95,13 +98,15 @@ OOVPA_NO_XREF(CMiniport_CreateCtxDmaObject, 4034, 32) // Also for 4361, 4627, 53
     { 0x1D, 0xD1 },
     { 0x1E, 0x8B },
     { 0x1F, 0x3A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetViewport, 4034, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetViewport+0x00 : sub esp, 0x08
     { 0x00, 0x83 },
@@ -120,13 +125,15 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 4034, 10)
 
     // D3DDevice_SetViewport+0x9B : inc edx
     { 0x9B, 0x42 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTransform, 4034, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetTransform+0x00 : mov eax, [esp+arg_0]
     { 0x00, 0x8B },
@@ -152,17 +159,19 @@ OOVPA_NO_XREF(D3DDevice_SetTransform, 4034, 13)
     // D3DDevice_SetTransform+0x10B : retn 8
     { 0x10B, 0xC2 },
     { 0x10C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::UpdateProjectionViewportTransform
 // ******************************************************************
 // Generic OOVPA as of 4034 and newer
-OOVPA_XREF(D3D_UpdateProjectionViewportTransform, 4034, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3D_UpdateProjectionViewportTransform,
+                      4034,
 
-           XREF_D3D_UpdateProjectionViewportTransform,
-           XRefOne)
-{
+                      XREF_D3D_UpdateProjectionViewportTransform,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     // mov e??, XREF_D3DDEVICE
     XREF_ENTRY(0x0B, XREF_D3DDEVICE), // Derived
 
@@ -180,14 +189,15 @@ OOVPA_XREF(D3D_UpdateProjectionViewportTransform, 4034, 1 + 11,
 
     // jge +0x06
     OV_MATCH(0x1E, 0x7D, 0x06),
-
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_MultiplyTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_MultiplyTransform, 4034, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_MultiplyTransform,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -207,16 +217,18 @@ OOVPA_NO_XREF(D3DDevice_MultiplyTransform, 4034, 16)
     { 0x51, 0xC2 },
     { 0x52, 0x08 },
     { 0x53, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_CullMode
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 4034, 2 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_CullMode,
+                      4034,
 
-           XREF_D3DDevice_SetRenderState_CullMode,
-           XRefTwo)
-{
+                      XREF_D3DDevice_SetRenderState_CullMode,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
 
@@ -245,13 +257,15 @@ OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 4034, 2 + 14,
     { 0x54, 0xC2 },
     { 0x55, 0x04 },
     { 0x56, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginVisibilityTest
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginVisibilityTest,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0A, 0x46 },
@@ -260,13 +274,15 @@ OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 4034, 7)
     { 0x1C, 0x00 },
     { 0x22, 0x48 },
     { 0x28, 0x06 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CopyRects
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CopyRects, 4034, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x57 },
     { 0x3E, 0xF6 },
@@ -276,13 +292,15 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 4034, 8)
     { 0xBE, 0x24 },
     { 0xDE, 0x22 },
     { 0xFE, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 4034, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVertices,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVertices+0x0E : mov eax, [esi+0x1C]
     { 0x0E, 0x8B },
@@ -302,7 +320,8 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 4034, 11)
     { 0xF2, 0x18 },
     { 0xF3, 0x46 },
     { 0xF4, 0x3C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
@@ -375,8 +394,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 4034, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -386,13 +406,15 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 4034, 8)
     { 0x26, 0x24 },
     { 0x2E, 0x89 },
     { 0x39, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 4034, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -402,13 +424,15 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 4034, 8)
     { 0x26, 0x04 },
     { 0x2E, 0x07 },
     { 0x36, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 4034, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_LoadVertexShader+0x07 : mov al, [ebx+0x08]
     { 0x07, 0x8A },
@@ -425,13 +449,15 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 4034, 10)
     // D3DDevice_LoadVertexShader+0x4E : mov [ebx], ebx
     { 0x4E, 0x89 },
     { 0x4F, 0x13 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetIndices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetIndices, 4034, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetIndices,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x02, 0x35 },
@@ -449,13 +475,15 @@ OOVPA_NO_XREF(D3DDevice_SetIndices, 4034, 14)
 
     { 0x48, 0x50 },
     { 0x49, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_EdgeAntiAlias
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0C, 0x72 },
@@ -464,13 +492,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 4034, 7)
     { 0x21, 0x48 },
     { 0x28, 0x89 },
     { 0x2F, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FillMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 4034, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FillMode,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -480,13 +510,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 4034, 8)
     { 0x2B, 0x8C },
     { 0x34, 0x08 },
     { 0x40, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_BackFillMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_BackFillMode, 4034, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_BackFillMode,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_BackFillMode+0x1C : jb +0x05
     { 0x1C, 0x72 },
@@ -508,13 +540,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_BackFillMode, 4034, 13)
     // D3DDevice_SetRenderState_BackFillMode+0x4E : retn 0x04
     { 0x4E, 0xC2 },
     { 0x4F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FogColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FogColor,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x06 },
     { 0x14, 0x8B },
@@ -523,13 +557,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 4034, 7)
     { 0x30, 0x00 },
     { 0x3A, 0x89 },
     { 0x44, 0x0D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FrontFace
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FrontFace,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -538,13 +574,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 4034, 7)
     { 0x1E, 0x48 },
     { 0x2A, 0x89 },
     { 0x30, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LogicOp
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LogicOp,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x3B },
     { 0x14, 0x4C },
@@ -553,13 +591,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 4034, 7)
     { 0x35, 0xBC },
     { 0x40, 0x89 },
     { 0x4E, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x8B },
     { 0x17, 0x8B },
@@ -568,13 +608,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 4034, 7)
     { 0x38, 0xC1 },
     { 0x40, 0x7C },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x8B },
     { 0x17, 0x8B },
@@ -583,13 +625,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask, 4034, 7)
     { 0x38, 0x83 },
     { 0x40, 0x7C },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_NormalizeNormals
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0E, 0xE8 },
@@ -598,13 +642,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 4034, 7)
     { 0x26, 0x0D },
     { 0x2E, 0x00 },
     { 0x36, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ShadowFunc
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ShadowFunc,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0C, 0x72 },
@@ -613,13 +659,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 4034, 7)
     { 0x21, 0xFF },
     { 0x28, 0x08 },
     { 0x31, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 4034, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x13, 0x8B },
@@ -629,13 +677,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 4034, 8)
     { 0x53, 0x89 },
     { 0x64, 0x00 },
     { 0x75, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x0C, 0x72 },
     { 0x1A, 0xC9 },
@@ -644,13 +694,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 4034, 7)
     { 0x44, 0x83 },
     { 0x52, 0x24 },
     { 0x60, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_YuvEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_YuvEnable, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_YuvEnable,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x56 },
     { 0x0B, 0xA3 },
@@ -659,13 +711,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_YuvEnable, 4034, 7)
     { 0x1C, 0x8B },
     { 0x25, 0x89 },
     { 0x28, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x8B },
     { 0x18, 0x15 },
@@ -674,13 +728,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 4034, 7)
     { 0x43, 0x75 },
     { 0x4C, 0x00 },
     { 0x59, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_VertexBlend
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_VertexBlend,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0xCA },
     { 0x13, 0x89 },
@@ -689,13 +745,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 4034, 7)
     { 0x2B, 0x28 },
     { 0x34, 0x08 },
     { 0x3D, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Get2DSurfaceDesc
 // ******************************************************************
-OOVPA_NO_XREF(Get2DSurfaceDesc, 4034, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(Get2DSurfaceDesc,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x10, 0x0D },
     { 0x48, 0x08 },
@@ -707,13 +765,15 @@ OOVPA_NO_XREF(Get2DSurfaceDesc, 4034, 10)
     { 0x58, 0x53 },
     { 0x63, 0x80 },
     { 0xAE, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 4034, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_ZEnable+0x0C : jb +0x05
     { 0x0C, 0x72 },
@@ -735,13 +795,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 4034, 13)
     // D3DDevice_SetRenderState_ZEnable+0x98 : retn 0x04
     { 0x98, 0xC2 },
     { 0x99, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TextureFactor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TextureFactor, 4034, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TextureFactor,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -760,13 +822,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TextureFactor, 4034, 15)
 
     { 0x4E, 0xC2 },
     { 0x4F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Clear
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Clear, 4034, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Clear,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -786,16 +850,18 @@ OOVPA_NO_XREF(D3DDevice_Clear, 4034, 16)
 
     { 0x54, 0x05 },
     { 0x81, 0xB6 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DVertexBuffer_Lock
 // ******************************************************************
-OOVPA_XREF(D3DVertexBuffer_Lock, 4034, 1 + 9,
+OOVPA_SIG_HEADER_XREF(D3DVertexBuffer_Lock,
+                      4034,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DVertexBuffer_Lock+0x0B : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x0D, XREF_D3DDEVICE),
@@ -814,7 +880,8 @@ OOVPA_XREF(D3DVertexBuffer_Lock, 4034, 1 + 9,
 
     // 4034 0x50 vs 4531 0x54 : retn 0x14
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTexture
@@ -887,11 +954,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 4034, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex,
+                      4034,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x18, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -912,13 +980,15 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 4034, 1 + 10,
     { 0xB4, 0xC1 },
     { 0xB5, 0xE2 },
     { 0xB6, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetMaterial+0x0C : add edi, 0x0B70
     { 0x0C, 0x81 },
@@ -939,16 +1009,18 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 4034, 12)
     // D3DDevice_SetMaterial+0x2D : retn 0x04
     { 0x2D, 0xC2 },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShader, 4034, 1 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      4034,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived
 
@@ -973,13 +1045,15 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 4034, 1 + 14,
     { 0xB2, 0x4C },
     { 0xB3, 0x19 },
     { 0xB4, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Swap, 4034, 20) // Up to 4432
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap,
+                         4034) // Up to 4432
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -1003,13 +1077,15 @@ OOVPA_NO_XREF(D3DDevice_Swap, 4034, 20) // Up to 4432
     { 0x1F, 0x03 },
 
     { 0x29, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
-OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle, 4034, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_KickOffAndWaitForIdle,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3D_KickOffAndWaitForIdle+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -1031,16 +1107,18 @@ OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle, 4034, 9)
 
     // D3D_KickOffAndWaitForIdle+0x10 : retn
     { 0x10, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CreateStandAloneSurface
 // ******************************************************************
-OOVPA_XREF(D3D_CreateStandAloneSurface, 4034, 12,
+OOVPA_SIG_HEADER_XREF(D3D_CreateStandAloneSurface,
+                      4034,
 
-           XREF_D3D_CreateStandAloneSurface,
-           XRefZero)
-{
+                      XREF_D3D_CreateStandAloneSurface,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x54 },
 
@@ -1056,27 +1134,31 @@ OOVPA_XREF(D3D_CreateStandAloneSurface, 4034, 12,
 
     { 0x36, 0xF0 },
     { 0x4B, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateImageSurface
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateImageSurface, 4034, 1 + 1,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateImageSurface,
+                      4034,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3D_CreateStandAloneSurface),
 
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetBackBuffer+0x04 : cmp eax, 0xFFFFFFFF
     { 0x04, 0x83 },
@@ -1097,13 +1179,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer, 4034, 12)
     { 0x1F, 0x81 },
     { 0x20, 0xFC },
     { 0x21, 0x21 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant, 4034, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstant,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstant+0x11 : mov cl, [ebx+0x08]
     { 0x11, 0x8A },
@@ -1122,13 +1206,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant, 4034, 10)
     // D3DDevice_SetVertexShaderConstant+0x98 : retn 0x0C
     { 0x98, 0xC2 },
     { 0x99, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetTransform, 4034, 12) // Also for 4134
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetTransform,
+                         4034) // Also for 4134
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetTransform+0x0A : shl ecx, 0x06
     { 0x0A, 0xC1 },
@@ -1151,13 +1237,15 @@ OOVPA_NO_XREF(D3DDevice_GetTransform, 4034, 12) // Also for 4134
     // D3DDevice_GetTransform+0x22 : retn 0x08
     { 0x22, 0xC2 },
     { 0x23, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SelectVertexShader+0x00 : mov eax, [esp+4]
     { 0x00, 0x8B },
@@ -1176,7 +1264,8 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 4034, 12)
     // D3DDevice_SelectVertexShader+0x55 : mov [esi], eax
     { 0x55, 0x89 },
     { 0x56, 0x06 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
@@ -1245,8 +1334,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode, 4034, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x1D },
     { 0x1A, 0x81 },
@@ -1257,16 +1347,18 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode, 4034, 9)
     { 0x1F, 0xFF },
     { 0x38, 0x00 },
     { 0x43, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnResource
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnResource, 4034, 12,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnResource,
+                      4034,
 
-           XREF_D3D_BlockOnResource,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnResource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x85 },
@@ -1280,13 +1372,15 @@ OOVPA_XREF(D3D_BlockOnResource, 4034, 12,
     { 0x1F, 0x70 },
     { 0x40, 0x5E },
     { 0x4A, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetFlickerFilter
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetFlickerFilter, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetFlickerFilter,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetFlickerFilter+0x0A : mov edx, [ecx+0x23E8]
     { 0x0A, 0x8B },
@@ -1305,13 +1399,15 @@ OOVPA_NO_XREF(D3DDevice_SetFlickerFilter, 4034, 12)
     // D3DDevice_SetFlickerFilter+0x1C : retn 0x08
     { 0x1C, 0xC2 },
     { 0x1D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetSoftDisplayFilter
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetSoftDisplayFilter,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetSoftDisplayFilter+0x0A : mov edx, [ecx+0x23E8]
     { 0x0A, 0x8B },
@@ -1330,13 +1426,15 @@ OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter, 4034, 12)
     // D3DDevice_SetSoftDisplayFilter+0x1C : retn 0x08
     { 0x1C, 0xC2 },
     { 0x1D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_PSTextureModes
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_PSTextureModes, 4034, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_PSTextureModes,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x0A, 0x89 },
     { 0x0B, 0x81 },
@@ -1348,7 +1446,8 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_PSTextureModes, 4034, 10)
     { 0x17, 0x40 },
     { 0x1A, 0xA3 },
     { 0x1F, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMode
@@ -1439,8 +1538,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SetRenderState_LineWidth
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 4034, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LineWidth,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x0C, 0x89 },
 
@@ -1458,7 +1558,8 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 4034, 14)
     { 0x5A, 0x5E },
     { 0x5B, 0x89 },
     { 0x5C, 0x1D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_OcclusionCullEnable
@@ -1466,11 +1567,12 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 4034, 14)
 // Generic OOVPA as of 4034 and newer.
 // NOTE: asm codes are the same as D3DDevice_SetRenderState_StencilCullEnable
 //       except for the offset references.
-OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 4034, 2 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_OcclusionCullEnable,
+                      4034,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_StencilCullEnable+0x05 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x07, XREF_D3DDEVICE),
@@ -1493,7 +1595,8 @@ OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 4034, 2 + 14,
 
     // D3DDevice_SetRenderState_OcclusionCullEnable+0x5F : retn 0x04
     OV_MATCH(0x5F, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilCullEnable
@@ -1501,11 +1604,12 @@ OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 4034, 2 + 14,
 // Generic OOVPA as of 4034 and newer.
 // NOTE: asm codes are the same as D3DDevice_SetRenderState_OcclusionCullEnable
 //       except for the offset references.
-OOVPA_XREF(D3DDevice_SetRenderState_StencilCullEnable, 4034, 2 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_StencilCullEnable,
+                      4034,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_StencilCullEnable+0x05 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x07, XREF_D3DDEVICE),
@@ -1528,13 +1632,15 @@ OOVPA_XREF(D3DDevice_SetRenderState_StencilCullEnable, 4034, 2 + 14,
 
     // D3DDevice_SetRenderState_StencilCullEnable+0x5F : retn 0x04
     OV_MATCH(0x5F, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_GetType
 // ******************************************************************
-OOVPA_NO_XREF(D3DResource_GetType, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_GetType,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x10, 0x77 },
     { 0x22, 0x83 },
@@ -1543,13 +1649,15 @@ OOVPA_NO_XREF(D3DResource_GetType, 4034, 7)
     { 0x58, 0x00 },
     { 0x6A, 0x74 },
     { 0x7C, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BumpEnv
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BumpEnv,
+                         4034)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetTextureState_BumpEnv+0x18 : jnz +0x03
     { 0x18, 0x75 },
@@ -1570,16 +1678,18 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv, 4034, 12)
     { 0x50, 0xC1 },
     { 0x51, 0xE6 },
     { 0x52, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::KickOff
 // ******************************************************************
-OOVPA_XREF(D3DDevice_KickOff, 4034, 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_KickOff,
+                      4034,
 
-           XREF_D3D_CDevice_KickOff,
-           XRefZero)
-{
+                      XREF_D3D_CDevice_KickOff,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x0E, 0x04 },
@@ -1597,16 +1707,18 @@ OOVPA_XREF(D3DDevice_KickOff, 4034, 15,
     { 0x85, 0x59 },
     { 0x86, 0xC3 },
     { 0x87, 0xB8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 4034, 12,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      4034,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x02, 0x35 },
@@ -1622,16 +1734,18 @@ OOVPA_XREF(D3D_SetFence, 4034, 12,
     { 0x55, 0xC3 },
     { 0x56, 0x01 },
     { 0x57, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnTime
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnTime, 4034, 10,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      4034,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x3D },
 
@@ -1645,13 +1759,15 @@ OOVPA_XREF(D3D_BlockOnTime, 4034, 10,
     { 0x1F, 0x83 },
 
     { 0x2F, 0x53 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTile
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTile, 4034, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x1D },
 
@@ -1667,13 +1783,15 @@ OOVPA_NO_XREF(D3DDevice_SetTile, 4034, 12)
 
     { 0x7B, 0x5F },
     { 0x8A, 0x76 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScreenSpaceOffset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetScreenSpaceOffset, 4034, 11) // Up to 5344
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScreenSpaceOffset,
+                         4034) // Up to 5344
+OOVPA_SIG_MATCH(
 
     { 0x06, 0x56 },
     { 0x07, 0xD8 },
@@ -1687,13 +1805,15 @@ OOVPA_NO_XREF(D3DDevice_SetScreenSpaceOffset, 4034, 11) // Up to 5344
     { 0x2F, 0x06 },
     { 0x46, 0xC2 },
     { 0x47, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::LazySetPointParams
 // ******************************************************************
-OOVPA_NO_XREF(D3D_LazySetPointParams, 4034, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_LazySetPointParams,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -1702,13 +1822,15 @@ OOVPA_NO_XREF(D3D_LazySetPointParams, 4034, 7)
     { 0x73, 0xF6 },
     { 0x74, 0xC4 },
     { 0x75, 0x41 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::SetStateVB
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStateVB, 4034, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStateVB,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -1729,13 +1851,15 @@ OOVPA_NO_XREF(D3DDevice_SetStateVB, 4034, 17)
 
     { 0x66, 0x3B },
     { 0x67, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::SetStateUP
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStateUP, 4034, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStateUP,
+                         4034)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -1754,17 +1878,19 @@ OOVPA_NO_XREF(D3DDevice_SetStateUP, 4034, 15)
 
     { 0x4F, 0x3B },
     { 0x50, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::MakeRequestedSpace
 // ******************************************************************
 // Generic OOVPA as of 4034 and newer.
-OOVPA_XREF(D3D_MakeRequestedSpace_4, 4034, 12,
+OOVPA_SIG_HEADER_XREF(D3D_MakeRequestedSpace_4,
+                      4034,
 
-           XREF_D3D_MakeRequestedSpace,
-           XRefZero)
-{
+                      XREF_D3D_MakeRequestedSpace,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::MakeRequestedSpace+0x00 : push ecx; push esi
     OV_MATCH(0x00, 0x51, 0x56),
@@ -1778,16 +1904,18 @@ OOVPA_XREF(D3D_MakeRequestedSpace_4, 4034, 12,
     // D3D::MakeRequestedSpace+0x32 : ret 0x0004
     OV_MATCH(0x32, 0xC2, 0x04),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_MakeSpace
 // ******************************************************************
-OOVPA_XREF(D3DDevice_MakeSpace, 4034, 1 + 4,
+OOVPA_SIG_HEADER_XREF(D3DDevice_MakeSpace,
+                      4034,
 
-           XREF_D3DDevice_MakeSpace,
-           XRefOne)
-{
+                      XREF_D3DDevice_MakeSpace,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_MakeSpace+0x06 : call D3D::MakeRequestedSpace
     XREF_ENTRY(0x07, XREF_D3D_MakeRequestedSpace),
@@ -1804,4 +1932,5 @@ OOVPA_XREF(D3DDevice_MakeSpace, 4034, 1 + 4,
     // D3DDevice_MakeSpace+0x0B : ret
     OV_MATCH(0x0B, 0xC3),
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4039.inl
+++ b/src/OOVPADatabase/D3D8/4039.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 4039, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x56 },
@@ -38,13 +39,15 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 4039, 9)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 4039, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x04, 0x08 },
@@ -60,13 +63,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 4039, 12)
     { 0x22, 0x10 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 4039, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x56 },
@@ -77,7 +82,8 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 4039, 9)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
@@ -119,8 +125,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_Begin
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Begin, 4039, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Begin,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0xE8 },
 
@@ -137,17 +144,19 @@ OOVPA_NO_XREF(D3DDevice_Begin, 4039, 13)
 
     { 0x32, 0xC2 },
     { 0x33, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetSwapCallback
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer.
-OOVPA_XREF(D3DDevice_SetSwapCallback, 4039, 2 + 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetSwapCallback,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetSwapCallback+0x04 : mov ecx,[D3D__PDEVICE]
     XREF_ENTRY(0x06, XREF_D3DDEVICE),
@@ -164,13 +173,15 @@ OOVPA_XREF(D3DDevice_SetSwapCallback, 4039, 2 + 9,
     // D3DDevice_SetSwapCallback+0x10 : retn 0x04
     OV_MATCH(0x10, 0xC2, 0x04, 0x00),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2f
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 4039, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2f,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -186,13 +197,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 4039, 14)
     { 0x1F, 0x4C },
     { 0x34, 0xC2 },
     { 0x35, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2s
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 4039, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2s,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x02, 0x35 },
@@ -207,13 +220,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 4039, 12)
     { 0x1E, 0x0F },
     { 0x1F, 0xBF },
     { 0x25, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 4039, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -234,13 +249,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 4039, 11)
         { 0x3A, 0x24 },
         { 0x46, 0x8B },
         { 0x52, 0x14 },*/
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4s
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 4039, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4s,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0x06 },
@@ -253,13 +270,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 4039, 10)
     { 0x1A, 0x80 },
     { 0x1B, 0x19 },
     { 0x1F, 0xBF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4ub
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 4039, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4ub,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0x06 },
@@ -269,13 +288,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 4039, 8)
     { 0x30, 0x24 },
     { 0x3A, 0x24 },
     { 0x44, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexDataColor
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 4039, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexDataColor,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -291,13 +312,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 4039, 13)
     { 0x1D, 0x04 },
     { 0x1E, 0x00 },
     { 0x25, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_End
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_End, 4039, 16) // Up to 5233
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_End,
+                         4039) // Up to 5233
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x07, 0x8B },
@@ -317,13 +340,15 @@ OOVPA_NO_XREF(D3DDevice_End, 4039, 16) // Up to 5233
     { 0x2E, 0x01 },
     { 0x36, 0x08 },
     { 0x3C, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_IsBusy
 // ******************************************************************
-OOVPA_NO_XREF(D3DResource_IsBusy, 4039, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_IsBusy,
+                         4039)
+OOVPA_SIG_MATCH(
 
     // D3DResource_IsBusy+0x24 : test eax, 0x780000
     { 0x24, 0xA9 },
@@ -343,17 +368,19 @@ OOVPA_NO_XREF(D3DResource_IsBusy, 4039, 11)
     // D3DResource_IsBusy+0x76 : jnb +0x09
     { 0x76, 0x73 },
     { 0x77, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PersistDisplay
 // ******************************************************************
 // Reused in 5455 as well.
-OOVPA_XREF(D3DDevice_PersistDisplay, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_PersistDisplay,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_PersistDisplay+0x04 : mov edi,[D3D__PDEVICE]
     XREF_ENTRY(0x06, XREF_D3DDEVICE),
@@ -376,16 +403,18 @@ OOVPA_XREF(D3DDevice_PersistDisplay, 4039, 1 + 8,
     // D3DDevice_PersistDisplay+0x3A : ret
     OV_MATCH(0x3A, 0xC3),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVerticesUP
 // ******************************************************************
-OOVPA_XREF(D3DDevice_DrawVerticesUP, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawVerticesUP,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawVerticesUP+0x07 : mov edi,[D3D__PDEVICE]
     XREF_ENTRY(0x09, XREF_D3DDEVICE),
@@ -406,13 +435,15 @@ OOVPA_XREF(D3DDevice_DrawVerticesUP, 4039, 1 + 10,
     OV_MATCH(0x0F, 0x89),
     OV_MATCH(0x11, 0xEC), // D3DDevice_DrawVerticesUP 4039 0xEC vs D3DDevice_DrawIndexedVerticesUP 5028 0xF8
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDisplayMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetDisplayMode, 4039, 24)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDisplayMode,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -440,13 +471,15 @@ OOVPA_NO_XREF(D3DDevice_GetDisplayMode, 4039, 24)
 
     { 0x4C, 0xD3 },
     { 0x4D, 0xE0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 4039, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPushBuffer,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x57 },
@@ -460,13 +493,15 @@ OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 4039, 11)
     { 0x55, 0x46 },
     { 0x56, 0x08 },
     { 0x57, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 4039, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x07 },
     { 0x3E, 0x00 },
@@ -476,13 +511,15 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 4039, 8)
     { 0xBE, 0x74 },
     { 0xE2, 0x8B },
     { 0xFE, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShader, 4039, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShader,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -501,13 +538,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShader, 4039, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPixelShader, 4039, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPixelShader,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -526,13 +565,15 @@ OOVPA_NO_XREF(D3DDevice_GetPixelShader, 4039, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderConstant, 4039, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderConstant,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x0C, 0x24 },
@@ -548,16 +589,18 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderConstant, 4039, 12)
 
     { 0x28, 0x8B },
     { 0x2F, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsFencePending
 // ******************************************************************
-OOVPA_XREF(D3DDevice_IsFencePending, 4039, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_IsFencePending,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3DDEVICE), // Derived
 
@@ -566,13 +609,15 @@ OOVPA_XREF(D3DDevice_IsFencePending, 4039, 1 + 5,
     { 0x10, 0xD1 },
     { 0x17, 0x1B },
     { 0x1C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 4039, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         4039)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -591,13 +636,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 4039, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0xB4 },
     { 0x0F, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetModelView
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetModelView, 4039, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetModelView,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x15, 0x25 },
@@ -607,13 +654,15 @@ OOVPA_NO_XREF(D3DDevice_SetModelView, 4039, 8)
     { 0x72, 0x8D },
     { 0x88, 0x00 },
     { 0x9F, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetModelView
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetModelView, 4039, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetModelView,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x57 },
     { 0x0A, 0x85 },
@@ -622,13 +671,15 @@ OOVPA_NO_XREF(D3DDevice_GetModelView, 4039, 7)
     { 0x1C, 0x5E },
     { 0x22, 0xC1 },
     { 0x28, 0xE0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderInput
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderInput, 4039, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderInput,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x04 },
     { 0x04, 0x83 },
@@ -647,13 +698,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderInput, 4039, 16)
     { 0x1D, 0xBF },
     { 0x1E, 0x83 },
     { 0x1F, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunVertexStateShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunVertexStateShader, 4039, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunVertexStateShader,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x09, 0x3B },
@@ -663,16 +716,18 @@ OOVPA_NO_XREF(D3DDevice_RunVertexStateShader, 4039, 8)
     { 0x35, 0xF4 },
     { 0x40, 0xC7 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BeginPush2, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BeginPush2,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BeginPush__8+0x01 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x03, XREF_D3DDEVICE),
@@ -692,16 +747,18 @@ OOVPA_XREF(D3DDevice_BeginPush2, 4039, 1 + 11,
     // D3DDevice_BeginPush__8+0x23 : ret 0x0008
     OV_MATCH(0x23, 0xC2, 0x08),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndPush
 // ******************************************************************
-OOVPA_XREF(D3DDevice_EndPush, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_EndPush,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DDEVICE), // Derived
 
@@ -716,13 +773,15 @@ OOVPA_XREF(D3DDevice_EndPush, 4039, 1 + 11,
     { 0x0C, 0xC2 },
     { 0x0D, 0x04 },
     { 0x0E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PrimeVertexCache
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_PrimeVertexCache, 4039, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_PrimeVertexCache,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x2D },
 
@@ -741,13 +800,15 @@ OOVPA_NO_XREF(D3DDevice_PrimeVertexCache, 4039, 15)
     { 0x1D, 0xD1 },
     { 0x1E, 0xEE },
     { 0x1F, 0x3B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackBufferScale
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackBufferScale, 4039, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackBufferScale,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x86 },
 
@@ -767,4 +828,5 @@ OOVPA_NO_XREF(D3DDevice_SetBackBufferScale, 4039, 16)
     { 0x2C, 0x83 },
     { 0x2D, 0xE0 },
     { 0x2E, 0x0F },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4134.inl
+++ b/src/OOVPADatabase/D3D8/4134.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_GetBackBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer, 4134, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetBackBuffer+0x04 : cmp eax, 0xFFFFFFFF
     { 0x04, 0x83 },
@@ -48,13 +49,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer, 4134, 12)
     { 0x1F, 0x81 },
     { 0x20, 0x7C },
     { 0x21, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 4134, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_ZEnable+0x0C : jb +0x05
     { 0x0C, 0x72 },
@@ -76,16 +79,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 4134, 13)
     // D3DDevice_SetRenderState_ZEnable+0x98 : retn 0x04
     { 0x98, 0xC2 },
     { 0x99, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShader, 4134, 1 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived
 
@@ -110,13 +115,15 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 4134, 1 + 14,
     { 0xB2, 0x4C },
     { 0xB3, 0x19 },
     { 0xB4, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 4134, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetMaterial+0x0C : add edi, 0x0940
     { 0x0C, 0x81 },
@@ -137,13 +144,15 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 4134, 12)
     // D3DDevice_SetMaterial+0x2D : retn 0x04
     { 0x2D, 0xC2 },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 4134, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -156,13 +165,15 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 4134, 11)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 4134, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetBackMaterial+0x0C : add edi, 0x0A34
     { 0x0C, 0x81 },
@@ -183,13 +194,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 4134, 12)
     // D3DDevice_SetBackMaterial+0x2D : retn 0x04
     { 0x2D, 0xC2 },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 4134, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -204,13 +217,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 4134, 11)
 
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 4134, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_MultiSampleMode+0x0F : mov ecx, [eax+0x2070]
     { 0x0F, 0x8B },
@@ -231,16 +246,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 4134, 12)
     // D3DDevice_SetRenderState_MultiSampleMode+0x2A : retn 0x04
     { 0x2A, 0xC2 },
     { 0x2B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 4134, 12,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      4134,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0D, 0x72 },
     { 0x0E, 0x0E },
@@ -254,13 +271,15 @@ OOVPA_XREF(D3D_SetFence, 4134, 12,
     { 0x47, 0x3F },
     { 0xAA, 0xC2 },
     { 0xAB, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetFlickerFilter
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetFlickerFilter, 4134, 18)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetFlickerFilter,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x0D },
 
@@ -283,13 +302,15 @@ OOVPA_NO_XREF(D3DDevice_SetFlickerFilter, 4134, 18)
 
     { 0x3F, 0xC2 },
     { 0x40, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetSoftDisplayFilter
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter, 4134, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetSoftDisplayFilter,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x0D },
 
@@ -315,13 +336,15 @@ OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter, 4134, 13)
         { 0x27, 0x68 },
         { 0x28, 0x22 },*/
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EnableOverlay
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_EnableOverlay, 4134, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EnableOverlay,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_EnableOverlay+0x0B : mov ecx, [eax+0x8700]
     { 0x0B, 0x8B },
@@ -341,16 +364,18 @@ OOVPA_NO_XREF(D3DDevice_EnableOverlay, 4134, 11)
     // D3DDevice_EnableOverlay+0x60 : retn 0x04
     { 0x60, 0xC2 },
     { 0x61, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::MakeRequestedSpace
 // ******************************************************************
-OOVPA_XREF(D3D_MakeRequestedSpace_8, 4134, 14,
+OOVPA_SIG_HEADER_XREF(D3D_MakeRequestedSpace_8,
+                      4134,
 
-           XREF_D3D_MakeRequestedSpace,
-           XRefZero)
-{
+                      XREF_D3D_MakeRequestedSpace,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::MakeRequestedSpace+0x00 : sub esp,0x__
     OV_MATCH(0x00, 0x83, 0xEC),
@@ -367,13 +392,15 @@ OOVPA_XREF(D3D_MakeRequestedSpace_8, 4134, 14,
     // D3D::MakeRequestedSpace+0x36 : ret 0x0008
     OV_MATCH(0x36, 0xC2, 0x08),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_InsertCallback
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_InsertCallback, 4134, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_InsertCallback,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -390,13 +417,15 @@ OOVPA_NO_XREF(D3DDevice_InsertCallback, 4134, 13)
     { 0x26, 0x8C },
     { 0x27, 0x1D },
     { 0x28, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 4134, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -415,13 +444,15 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 4134, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetProjectionViewportMatrix
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 4134, 16) // Up to 4531
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetProjectionViewportMatrix,
+                         4134) // Up to 4531
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -441,13 +472,15 @@ OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 4134, 16) // Up to 4531
     { 0x19, 0x5F },
     { 0x1A, 0x5E },
     { 0x1B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CaptureStateBlock
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CaptureStateBlock, 4134, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CaptureStateBlock,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x14, 0x3D },
     { 0x36, 0x8B },
@@ -463,16 +496,18 @@ OOVPA_NO_XREF(D3DDevice_CaptureStateBlock, 4134, 12)
     { 0x58, 0xF8 },
 
     { 0x6A, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginStateBlock
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BeginStateBlock, 4134, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BeginStateBlock,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BeginStateBlock+0x0F : call [ClearStateBlockFlags]
     XREF_ENTRY(0x0A, XREF_D3D_ClearStateBlockFlags),
@@ -485,16 +520,18 @@ OOVPA_XREF(D3DDevice_BeginStateBlock, 4134, 1 + 5,
     { 0x06, 0x48 },
     { 0x07, 0x08 },
     { 0x08, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndStateBlock
 // ******************************************************************
-OOVPA_XREF(D3DDevice_EndStateBlock, 4134, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_EndStateBlock,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_EndStateBlock+0x0F : call [ClearStateBlockFlags]
     XREF_ENTRY(0x0A, XREF_D3D_RecordStateBlock),
@@ -507,13 +544,15 @@ OOVPA_XREF(D3DDevice_EndStateBlock, 4134, 1 + 5,
     { 0x06, 0x60 },
     { 0x07, 0x08 },
     { 0x08, 0xDF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShader, 4134, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShader,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -532,13 +571,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShader, 4134, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPixelShader, 4134, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPixelShader,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -557,13 +598,15 @@ OOVPA_NO_XREF(D3DDevice_GetPixelShader, 4134, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 4134, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -582,13 +625,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 4134, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x3C },
     { 0x0F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_FlushVertexCache
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_FlushVertexCache, 4134, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_FlushVertexCache,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -600,16 +645,18 @@ OOVPA_NO_XREF(D3DDevice_FlushVertexCache, 4134, 10)
     { 0x1C, 0x00 },
     { 0x21, 0xC0 },
     { 0x26, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_MakeSpace
 // ******************************************************************
-OOVPA_XREF(D3DDevice_MakeSpace, 4134, 1 + 4,
+OOVPA_SIG_HEADER_XREF(D3DDevice_MakeSpace,
+                      4134,
 
-           XREF_D3DDevice_MakeSpace,
-           XRefOne)
-{
+                      XREF_D3DDevice_MakeSpace,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_MakeSpace+0x09 : call D3D::MakeRequestedSpace
     XREF_ENTRY(0x0A, XREF_D3D_MakeRequestedSpace),
@@ -625,7 +672,8 @@ OOVPA_XREF(D3DDevice_MakeSpace, 4134, 1 + 4,
 
     // D3DDevice_MakeSpace+0x0E : ret
     OV_MATCH(0x0E, 0xC3),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTexture, named with 2 suffix to match EMUPATCH(D3DDevice_GetTexture2)
@@ -674,8 +722,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3D::CDevice::SetStateVB
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStateVB, 4134, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStateVB,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -696,13 +745,15 @@ OOVPA_NO_XREF(D3DDevice_SetStateVB, 4134, 17)
 
     { 0x66, 0x3B },
     { 0x67, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::SetStateUP
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStateUP, 4134, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStateUP,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -721,7 +772,8 @@ OOVPA_NO_XREF(D3DDevice_SetStateUP, 4134, 15)
 
     { 0x4F, 0x3B },
     { 0x50, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Rollback support signature(s)

--- a/src/OOVPADatabase/D3D8/4242.inl
+++ b/src/OOVPADatabase/D3D8/4242.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 4242, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         4242)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -46,16 +47,18 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 4242, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x40 },
     { 0x0F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 4242, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -76,13 +79,15 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 4242, 1 + 10,
     { 0xB3, 0xC1 },
     { 0xB4, 0xE2 },
     { 0xB5, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport_IsFlipPending
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_IsFlipPending, 4242, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_IsFlipPending,
+                         4242)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x81 },
@@ -101,4 +106,5 @@ OOVPA_NO_XREF(CMiniport_IsFlipPending, 4242, 17)
     { 0x0E, 0x00 },
     { 0x0F, 0x00 },
     { 0x10, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4361.inl
+++ b/src/OOVPADatabase/D3D8/4361.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3D_GetAdapterDisplayMode
 // ******************************************************************
-OOVPA_NO_XREF(D3D_GetAdapterDisplayMode, 4361, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_GetAdapterDisplayMode,
+                         4361)
+OOVPA_SIG_MATCH(
 
     // D3D_GetAdapterDisplayMode+0x08 : mov eax, 0x8876086C
     { 0x08, 0xB8 },
@@ -49,13 +50,15 @@ OOVPA_NO_XREF(D3D_GetAdapterDisplayMode, 4361, 13)
     // D3D_GetAdapterDisplayMode+0xBD : retn 0x08
     { 0xBD, 0xC2 },
     { 0xBE, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginVisibilityTest@0
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 4361, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginVisibilityTest,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0A, 0x46 },
@@ -64,7 +67,8 @@ OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 4361, 7)
     { 0x1C, 0x00 },
     { 0x22, 0x48 },
     { 0x28, 0x06 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTexture
@@ -118,8 +122,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SelectVertexShaderDirect
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect, 4361, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShaderDirect,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x05, 0x85 },
@@ -137,13 +142,15 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect, 4361, 13)
 
     { 0x29, 0x5E },
     { 0x32, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderInputDirect
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderInputDirect, 4361, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderInputDirect,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x05, 0x85 },
@@ -161,4 +168,5 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderInputDirect, 4361, 13)
 
     { 0x29, 0x5E },
     { 0x32, 0xE9 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4432.inl
+++ b/src/OOVPADatabase/D3D8/4432.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 4432, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         4432)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x06 },
     { 0x0E, 0xE8 },
@@ -43,13 +44,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 4432, 12)
 
     { 0x5A, 0x74 },
     { 0x60, 0x2A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetViewportOffsetAndScale
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale, 4432, 12) // Up to 5849
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetViewportOffsetAndScale,
+                         4432) // Up to 5849
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x19, 0x05 },
@@ -65,13 +68,15 @@ OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale, 4432, 12) // Up to 5849
 
     { 0x5B, 0x74 },
     { 0x5C, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetDepthClipPlanes
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetDepthClipPlanes, 4432, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetDepthClipPlanes,
+                         4432)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x0C },
     { 0x04, 0x48 },
@@ -90,4 +95,5 @@ OOVPA_NO_XREF(D3DDevice_SetDepthClipPlanes, 4432, 15)
 
     { 0x18, 0x8B },
     { 0x1F, 0x0C },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4531.inl
+++ b/src/OOVPADatabase/D3D8/4531.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Swap, 4531, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap,
+                         4531)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_Swap+0x10 : mov ebx, 5
     { 0x10, 0xBB },
@@ -47,13 +48,15 @@ OOVPA_NO_XREF(D3DDevice_Swap, 4531, 11)
     // D3DDevice_Swap+0xAE : retn 4
     { 0xB9, 0xC2 },
     { 0xBA, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 4531, 11) // Up to 5120
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         4531) // Up to 5120
+OOVPA_SIG_MATCH(
 
     { 0x03, 0xA1 },
     { 0x1A, 0x04 },
@@ -67,16 +70,18 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 4531, 11) // Up to 5120
     { 0x74, 0x8B },
     { 0x75, 0x44 },
     { 0x76, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::KickOff
 // ******************************************************************
-OOVPA_XREF(D3DDevice_KickOff, 4531, 13,
+OOVPA_SIG_HEADER_XREF(D3DDevice_KickOff,
+                      4531,
 
-           XREF_D3D_CDevice_KickOff,
-           XRefZero)
-{
+                      XREF_D3D_CDevice_KickOff,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::CDevice::KickOff+0x0B : mov edx, [ecx+0x35C]
     { 0x0B, 0x8B },
@@ -98,13 +103,15 @@ OOVPA_XREF(D3DDevice_KickOff, 4531, 13,
 
     // D3D::CDevice::KickOff+0xE2 : retn
     { 0xE2, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DPalette_Lock
 // ******************************************************************
-OOVPA_NO_XREF(D3DPalette_Lock, 4531, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DPalette_Lock,
+                         4531)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xF6 },
     { 0x01, 0x44 },
@@ -124,16 +131,18 @@ OOVPA_NO_XREF(D3DPalette_Lock, 4531, 17)
     { 0x12, 0x8B },
     { 0x21, 0xC2 },
     { 0x22, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BeginPush, 4531, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BeginPush,
+                      4531,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BeginPush__4+0x01 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x03, XREF_D3DDEVICE),
@@ -152,4 +161,5 @@ OOVPA_XREF(D3DDevice_BeginPush, 4531, 1 + 11,
 
     // D3DDevice_BeginPush__4+0x1D : ret 0x0004
     OV_MATCH(0x1D, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4627.inl
+++ b/src/OOVPADatabase/D3D8/4627.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_BeginVisibilityTest
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 4627, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginVisibilityTest,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BeginVisibilityTest+0x13 : mov dword ptr [eax], 0x000817C8
     { 0x13, 0xC7 },
@@ -45,14 +46,16 @@ OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 4627, 11)
     { 0x24, 0x83 },
     { 0x25, 0xC0 },
     { 0x26, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_GetAdapterDisplayMode
 // ******************************************************************
 // Generic OOVPA as of 4627 and newer.
-OOVPA_NO_XREF(D3D_GetAdapterDisplayMode, 4627, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_GetAdapterDisplayMode,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -69,13 +72,15 @@ OOVPA_NO_XREF(D3D_GetAdapterDisplayMode, 4627, 13)
 
     { 0x30, 0xC2 },
     { 0x31, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
-OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle, 4627, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_KickOffAndWaitForIdle,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3D_KickOffAndWaitForIdle+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -97,13 +102,15 @@ OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle, 4627, 9)
 
     // D3D_KickOffAndWaitForIdle+0x10 : retn
     { 0x10, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginPush, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPush,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x00 },
     { 0x12, 0x8B },
@@ -112,7 +119,8 @@ OOVPA_NO_XREF(D3DDevice_BeginPush, 4627, 7)
     { 0x30, 0xE8 },
     { 0x3A, 0x76 },
     { 0x44, 0x52 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CommonSetRenderTarget
@@ -157,11 +165,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderTarget, 4627, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderTarget,
+                      4627,
 
-           XREF_D3DDevice_SetRenderTarget,
-           XRefOne)
-{
+                      XREF_D3DDevice_SetRenderTarget,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderTarget+0x10 : call [D3D_CommonSetRenderTarget]
     XREF_ENTRY(0x10, XREF_D3D_CommonSetRenderTarget),
@@ -185,13 +194,15 @@ OOVPA_XREF(D3DDevice_SetRenderTarget, 4627, 1 + 12,
     // D3DDevice_SetRenderTarget+0x14 : retn 0x08
     { 0x14, 0xC2 },
     { 0x15, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 4627, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -210,13 +221,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 4627, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x00 },
     { 0x0F, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetGammaRamp
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 4627, 17) // Up to 5849
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetGammaRamp,
+                         4627) // Up to 5849
+OOVPA_SIG_MATCH(
 
     { 0x25, 0x57 },
     { 0x26, 0x83 },
@@ -238,13 +251,15 @@ OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 4627, 17) // Up to 5849
     { 0x75, 0x07 },
     { 0x76, 0x00 },
     { 0x77, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CopyRects
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CopyRects, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x57 },
     { 0x3E, 0xF6 },
@@ -254,16 +269,18 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 4627, 8)
     { 0xBE, 0x0C },
     { 0xDE, 0xF7 },
     { 0xFE, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetBackBuffer, 4627, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetBackBuffer,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DDevice_GetBackBuffer2),
 
@@ -278,16 +295,18 @@ OOVPA_XREF(D3DDevice_GetBackBuffer, 4627, 1 + 10,
     { 0x0F, 0x01 },
     { 0x10, 0xC2 },
     { 0x11, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetBackBuffer2, 4627, 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetBackBuffer2,
+                      4627,
 
-           XREF_D3DDevice_GetBackBuffer2,
-           XRefZero)
-{
+                      XREF_D3DDevice_GetBackBuffer2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_GetBackBuffer2+0x04 : cmp eax, 0xFFFFFFFF
     { 0x04, 0x83 },
@@ -310,16 +329,18 @@ OOVPA_XREF(D3DDevice_GetBackBuffer2, 4627, 12,
     // D3DDevice_GetBackBuffer2+0x40 : retn 0x04
     { 0x40, 0xC2 },
     { 0x41, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetRenderTarget
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetRenderTarget, 4627, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetRenderTarget,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3DDevice_GetRenderTarget2),
 
@@ -345,7 +366,8 @@ OOVPA_XREF(D3DDevice_GetRenderTarget, 4627, 1 + 12,
     { 0x0E, 0x04 },
     { 0x0F, 0x00 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetRenderTarget2
@@ -396,11 +418,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_GetDepthStencilSurface
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetDepthStencilSurface, 4627, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetDepthStencilSurface,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3DDevice_GetDepthStencilSurface2),
 
@@ -415,7 +438,8 @@ OOVPA_XREF(D3DDevice_GetDepthStencilSurface, 4627, 1 + 10,
     { 0x1A, 0xC2 },
     { 0x1B, 0xC2 },
     { 0x1C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDepthStencilSurface2
@@ -465,11 +489,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3D_SetTileNoWait
 // ******************************************************************
-OOVPA_XREF(D3D_SetTileNoWait, 4627, 11,
+OOVPA_SIG_HEADER_XREF(D3D_SetTileNoWait,
+                      4627,
 
-           XREF_D3D_SetTileNoWait,
-           XRefZero)
-{
+                      XREF_D3D_SetTileNoWait,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D_SetTileNoWait+0x06 : sub esp, 0x18
     { 0x06, 0x83 },
@@ -489,31 +514,35 @@ OOVPA_XREF(D3D_SetTileNoWait, 4627, 11,
     //{ 0x41, 0x22 },
     { 0x42, 0x00 },
     { 0x43, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTile
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetTile, 4627, 1 + 2,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTile,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3D_SetTileNoWait),
 
     { 0x00, 0xE8 },
     { 0x05, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateIndexBuffer2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateIndexBuffer2, 4627, 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateIndexBuffer2,
+                      4627,
 
-           XREF_D3DDevice_CreateIndexBuffer2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateIndexBuffer2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0xC0 },
     { 0x0F, 0x85 },
@@ -522,16 +551,18 @@ OOVPA_XREF(D3DDevice_CreateIndexBuffer2, 4627, 7,
     { 0x21, 0x08 },
     { 0x28, 0x00 },
     { 0x2F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateIndexBuffer
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateIndexBuffer, 4627, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateIndexBuffer,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DDevice_CreateIndexBuffer2),
 
@@ -547,16 +578,18 @@ OOVPA_XREF(D3DDevice_CreateIndexBuffer, 4627, 1 + 10,
     { 0x11, 0xC0 },
 
     { 0x1F, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShaderConstant, 4627, 2 + 13,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShaderConstant,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstant+0x08: jmp D3DDevice_SetVertexShaderConstant1
     XREF_ENTRY(0x09, XREF_D3DDevice_SetVertexShaderConstant1),
@@ -579,16 +612,18 @@ OOVPA_XREF(D3DDevice_SetVertexShaderConstant, 4627, 2 + 13,
     { 0x19, 0x02 },
 
     { 0x20, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant1
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShaderConstant1, 4627, 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShaderConstant1,
+                      4627,
 
-           XREF_D3DDevice_SetVertexShaderConstant1,
-           XRefZero)
-{
+                      XREF_D3DDevice_SetVertexShaderConstant1,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstant1+0x06 : add eax, 0x1C
     { 0x06, 0x83 },
@@ -610,16 +645,18 @@ OOVPA_XREF(D3DDevice_SetVertexShaderConstant1, 4627, 11,
     // D3DDevice_SetVertexShaderConstant1+0x5D : jmp +0xA2
     { 0x5D, 0xEB },
     { 0x5E, 0xA2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant4
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShaderConstant4, 4627, 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShaderConstant4,
+                      4627,
 
-           XREF_D3DDevice_SetVertexShaderConstant4,
-           XRefZero)
-{
+                      XREF_D3DDevice_SetVertexShaderConstant4,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstant4+0x05 : add eax, 0x4C
     { 0x05, 0x83 },
@@ -640,13 +677,15 @@ OOVPA_XREF(D3DDevice_SetVertexShaderConstant4, 4627, 12,
     // D3DDevice_SetVertexShaderConstant4+0x91 : emms
     { 0x91, 0x0F },
     { 0x92, 0x77 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstantNotInline
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline, 4627, 12) // (NOT 5344!)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline,
+                         4627) // (NOT 5344!)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstantNotInline+0x02 : test byte ptr ds:[abs], 0x10
     { 0x02, 0xF6 },
@@ -669,13 +708,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline, 4627, 12) // (NOT 5344
 
     // D3DDevice_SetVertexShaderConstantNotInline+0x28 : call [abs]
     { 0x28, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstantNotInlineFast
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInlineFast, 4627, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstantNotInlineFast,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstantNotInlineFast+0x00 : push esi
     { 0x00, 0x56 },
@@ -701,13 +742,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInlineFast, 4627, 13)
 
     // D3DDevice_SetVertexShaderConstantNotInlineFast+0x43 : emms
     { 0x43, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant1Fast
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant1Fast, 4627, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstant1Fast,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetVertexShaderConstant1Fast+0x05 : add eax, 0x1C
     { 0x05, 0x83 },
@@ -729,7 +772,8 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant1Fast, 4627, 11)
     // D3DDevice_SetVertexShaderConstant1Fast+0x47 : jmp +0xB7
     { 0x47, 0xEB },
     { 0x48, 0xB7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
@@ -770,11 +814,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_CreateTexture2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateTexture2, 4627, 13,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateTexture2,
+                      4627,
 
-           XREF_D3DDevice_CreateTexture2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateTexture2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateTexture2+0x02 : lea eax, [esp+0x20]
     { 0x02, 0x8D },
@@ -800,13 +845,15 @@ OOVPA_XREF(D3DDevice_CreateTexture2, 4627, 13,
     // D3DDevice_CreateTexture2+0xAE : retn 0x1C
     { 0xAE, 0xC2 },
     { 0xAF, 0x1C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateTexture
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateTexture, 4627, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateTexture,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x14 },
 
@@ -821,13 +868,15 @@ OOVPA_NO_XREF(D3DDevice_CreateTexture, 4627, 11)
 
     { 0x23, 0x54 },
     { 0x38, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 4627, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_RunPushBuffer+0x3C : mov edx, [esi+30h]
     { 0x3C, 0x8B },
@@ -846,13 +895,15 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 4627, 10)
     { 0xED, 0x8D },
     { 0xEE, 0x78 },
     { 0xEF, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Swap, 4627, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -870,16 +921,18 @@ OOVPA_NO_XREF(D3DDevice_Swap, 4627, 14)
     { 0x78, 0xE7 },
     { 0x79, 0x04 },
     { 0x7A, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexBuffer
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateVertexBuffer, 4627, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateVertexBuffer,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DDevice_CreateVertexBuffer2),
 
@@ -897,16 +950,18 @@ OOVPA_XREF(D3DDevice_CreateVertexBuffer, 4627, 1 + 12,
 
     { 0x1E, 0x8B },
     { 0x1F, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexBuffer2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateVertexBuffer2, 4627, 13,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateVertexBuffer2,
+                      4627,
 
-           XREF_D3DDevice_CreateVertexBuffer2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateVertexBuffer2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateVertexBuffer2+0x03 : push 0x40
     { 0x03, 0x6A },
@@ -928,16 +983,18 @@ OOVPA_XREF(D3DDevice_CreateVertexBuffer2, 4627, 13,
     // D3DDevice_CreateVertexBuffer2+0x4A : retn 0x04
     { 0x4A, 0xC2 },
     { 0x4B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 4627, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -958,13 +1015,15 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 4627, 1 + 10,
     { 0xAA, 0xC1 },
     { 0xAB, 0xE3 },
     { 0xAC, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 4627, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x56 },
 
@@ -985,13 +1044,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 4627, 17)
     { 0x5B, 0x72 },
     { 0x5C, 0x05 },
     { 0x5D, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 4627, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVertices,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVertices+0x0E : mov eax, [esi+0x1C]
     { 0x0E, 0x8B },
@@ -1011,13 +1072,15 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 4627, 11)
     { 0xFC, 0x18 },
     { 0xFD, 0x46 },
     { 0xFE, 0x3C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 4627, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetMaterial+0x0C : add edi, 0x0AB0
     { 0x0C, 0x81 },
@@ -1038,16 +1101,18 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 4627, 12)
     // D3DDevice_SetMaterial+0x2D : retn 0x04
     { 0x2D, 0xC2 },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DVertexBuffer_Lock2
 // ******************************************************************
-OOVPA_XREF(D3DVertexBuffer_Lock2, 4627, 12,
+OOVPA_SIG_HEADER_XREF(D3DVertexBuffer_Lock2,
+                      4627,
 
-           XREF_D3DVertexBuffer_Lock2,
-           XRefZero)
-{
+                      XREF_D3DVertexBuffer_Lock2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DVertexBuffer_Lock2B+0x00 : push ebx
     { 0x00, 0x53 },
@@ -1070,16 +1135,18 @@ OOVPA_XREF(D3DVertexBuffer_Lock2, 4627, 12,
     // D3DVertexBuffer_Lock2+0x48 : retn 0x08
     { 0x48, 0xC2 },
     { 0x49, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DVertexBuffer_Lock
 // ******************************************************************
-OOVPA_XREF(D3DVertexBuffer_Lock, 4627, 1 + 25,
+OOVPA_SIG_HEADER_XREF(D3DVertexBuffer_Lock,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DVertexBuffer_Lock2),
 
@@ -1109,16 +1176,18 @@ OOVPA_XREF(D3DVertexBuffer_Lock, 4627, 1 + 25,
     { 0x1A, 0x02 },
     { 0x1B, 0xC2 },
     { 0x1C, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetSurfaceLevel2
 // ******************************************************************
-OOVPA_XREF(D3DTexture_GetSurfaceLevel2, 4627, 12,
+OOVPA_SIG_HEADER_XREF(D3DTexture_GetSurfaceLevel2,
+                      4627,
 
-           XREF_D3DTexture_GetSurfaceLevel2,
-           XRefZero)
-{
+                      XREF_D3DTexture_GetSurfaceLevel2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DTexture_GetSurfaceLevel2+0x00 : sub esp, 0x0C
     { 0x00, 0x83 },
@@ -1143,16 +1212,18 @@ OOVPA_XREF(D3DTexture_GetSurfaceLevel2, 4627, 12,
 
     // D3DTexture_GetSurfaceLevel2+0x3E : call [abs]
     { 0x3E, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetSurfaceLevel
 // ******************************************************************
-OOVPA_XREF(D3DTexture_GetSurfaceLevel, 4627, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DTexture_GetSurfaceLevel,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DTexture_GetSurfaceLevel2),
 
@@ -1170,13 +1241,15 @@ OOVPA_XREF(D3DTexture_GetSurfaceLevel, 4627, 1 + 12,
     { 0x13, 0x33 },
     { 0x14, 0xC9 },
     { 0x15, 0x85 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 4627, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -1195,13 +1268,15 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 4627, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x08 },
     { 0x14, 0x75 },
@@ -1210,13 +1285,15 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 4627, 7)
     { 0x35, 0x9C },
     { 0x40, 0x14 },
     { 0x4B, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetStreamSource2 (Maybe same in older versions)
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetStreamSource2, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetStreamSource2,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x06, 0x34 },
     { 0x12, 0x85 },
@@ -1225,13 +1302,15 @@ OOVPA_NO_XREF(D3DDevice_GetStreamSource2, 4627, 7)
     { 0x26, 0x89 },
     { 0x2E, 0x00 },
     { 0x36, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport_IsFlipPending
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_IsFlipPending, 4627, 18) // Was D3DDevice_Reset
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_IsFlipPending,
+                         4627) // Was D3DDevice_Reset
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x81 },
@@ -1251,13 +1330,15 @@ OOVPA_NO_XREF(CMiniport_IsFlipPending, 4627, 18) // Was D3DDevice_Reset
     { 0x0F, 0x8B },
     { 0x10, 0x04 },
     { 0x11, 0x81 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetProjectionViewportMatrix
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 4627, 16) // Up to 5233
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetProjectionViewportMatrix,
+                         4627) // Up to 5233
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -1277,13 +1358,15 @@ OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 4627, 16) // Up to 5233
     { 0x19, 0x5F },
     { 0x1A, 0x5E },
     { 0x1B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x0A, 0xA3 },
     { 0x12, 0x56 },
@@ -1293,7 +1376,8 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMask, 4627, 8)
     { 0x3D, 0xC7 },
     { 0x44, 0x78 },
     { 0x4E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTexture, named with 2 suffix to match EMUPATCH(D3DDevice_GetTexture2)
@@ -1344,8 +1428,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 4627, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVerticesUP,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVerticesUP+0x4A : or edx, 0x800
     { 0x4A, 0x81 },
@@ -1362,13 +1447,15 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 4627, 10)
     // D3DDevice_DrawIndexedVerticesUP+0x6A : mov eax, 0x10
     { 0x6A, 0xB8 },
     { 0x6B, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStipple
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetStipple, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetStipple,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x03 },
     { 0x15, 0xF6 },
@@ -1377,16 +1464,18 @@ OOVPA_NO_XREF(D3DDevice_SetStipple, 4627, 7)
     { 0x30, 0x80 },
     { 0x3A, 0x00 },
     { 0x44, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PersistDisplay
 // ******************************************************************
-OOVPA_XREF(D3DDevice_PersistDisplay, 4627, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_PersistDisplay,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_PersistDisplay+0x02 : mov ebx,[D3D__PDEVICE]
     XREF_ENTRY(0x04, XREF_D3DDEVICE),
@@ -1406,13 +1495,15 @@ OOVPA_XREF(D3DDevice_PersistDisplay, 4627, 1 + 8,
     // D3DDevice_PersistDisplay+0x32 : ret
     OV_MATCH(0x32, 0xC3),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x89 },
     { 0x0F, 0x8B },
@@ -1422,13 +1513,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 4627, 8)
     { 0x21, 0x00 },
     { 0x28, 0x00 },
     { 0x31, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_ApplyStateBlock
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_ApplyStateBlock, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_ApplyStateBlock,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0xC6 },
     { 0x40, 0x83 },
@@ -1438,16 +1531,18 @@ OOVPA_NO_XREF(D3DDevice_ApplyStateBlock, 4627, 8)
     { 0xBE, 0x51 },
     { 0xDE, 0xE9 },
     { 0xFE, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnTime
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnTime, 4627, 6,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      4627,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x34 },
     { 0x27, 0x07 },
@@ -1455,13 +1550,15 @@ OOVPA_XREF(D3D_BlockOnTime, 4627, 6,
     { 0x7B, 0x58 },
     { 0xE3, 0x80 },
     { 0xF5, 0x30 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateImageSurface
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateImageSurface, 4627, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateImageSurface,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x8B },
     { 0x0A, 0x24 },
@@ -1472,13 +1569,15 @@ OOVPA_NO_XREF(D3DDevice_CreateImageSurface, 4627, 9)
     { 0x22, 0x01 },
     { 0x28, 0x07 },
     { 0x2E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DCubeTexture_GetCubeMapSurface
 // ******************************************************************
-OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface, 4627, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DCubeTexture_GetCubeMapSurface,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x0D, 0x51 },
@@ -1497,13 +1596,15 @@ OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface, 4627, 16)
     { 0x1D, 0x95 },
     { 0x2A, 0xC2 },
     { 0x2B, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DCubeTexture_GetCubeMapSurface2
 // ******************************************************************
-OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface2, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DCubeTexture_GetCubeMapSurface2,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x8D },
     { 0x12, 0x8D },
@@ -1512,16 +1613,18 @@ OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface2, 4627, 7)
     { 0x31, 0x8B },
     { 0x3A, 0x44 },
     { 0x46, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePalette2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreatePalette2, 4627, 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreatePalette2,
+                      4627,
 
-           XREF_D3DDevice_CreatePalette2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreatePalette2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0A, 0x8B },
     { 0x16, 0x74 },
@@ -1531,16 +1634,18 @@ OOVPA_XREF(D3DDevice_CreatePalette2, 4627, 8,
     { 0x46, 0xC1 },
     { 0x52, 0xFF },
     { 0x5E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePalette
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreatePalette, 4627, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreatePalette,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DDevice_CreatePalette2),
 
@@ -1555,16 +1660,18 @@ OOVPA_XREF(D3DDevice_CreatePalette, 4627, 1 + 10,
     { 0x18, 0x81 },
     { 0x19, 0xE2 },
     { 0x1A, 0x0E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DPalette_Lock2
 // ******************************************************************
-OOVPA_XREF(D3DPalette_Lock2, 4627, 7,
+OOVPA_SIG_HEADER_XREF(D3DPalette_Lock2,
+                      4627,
 
-           XREF_D3DPalette_Lock2,
-           XRefZero)
-{
+                      XREF_D3DPalette_Lock2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0x8B },
@@ -1573,16 +1680,18 @@ OOVPA_XREF(D3DPalette_Lock2, 4627, 7,
     { 0x13, 0x46 },
     { 0x16, 0x00 },
     { 0x1A, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DPalette_Lock
 // ******************************************************************
-OOVPA_XREF(D3DPalette_Lock, 4627, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DPalette_Lock,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DPalette_Lock2),
 
@@ -1593,13 +1702,15 @@ OOVPA_XREF(D3DPalette_Lock, 4627, 1 + 7,
     { 0x10, 0x54 },
     { 0x13, 0x89 },
     { 0x14, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPushBufferOffset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPushBufferOffset, 4627, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPushBufferOffset,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
     { 0x08, 0x86 },
@@ -1611,13 +1722,15 @@ OOVPA_NO_XREF(D3DDevice_GetPushBufferOffset, 4627, 10)
     { 0x1D, 0xE2 },
     { 0x1E, 0x07 },
     { 0x1F, 0x03 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetModelView
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetModelView, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetModelView,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x15, 0xFF },
     { 0x2D, 0x81 },
@@ -1626,13 +1739,15 @@ OOVPA_NO_XREF(D3DDevice_SetModelView, 4627, 7)
     { 0x71, 0x53 },
     { 0x8A, 0x8B },
     { 0x9F, 0x30 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::LazySetPointParams
 // ******************************************************************
-OOVPA_NO_XREF(D3D_LazySetPointParams, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_LazySetPointParams,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -1641,13 +1756,15 @@ OOVPA_NO_XREF(D3D_LazySetPointParams, 4627, 7)
     { 0x73, 0xF6 },
     { 0x74, 0xC4 },
     { 0x75, 0x41 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -1657,13 +1774,15 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 4627, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 4627, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
     { 0x0C, 0x81 },
@@ -1675,13 +1794,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 4627, 10)
     { 0x22, 0x10 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -1691,13 +1812,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 4627, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_SampleAlpha
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_SampleAlpha, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_SampleAlpha,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0xC1 },
     { 0x15, 0x0B },
@@ -1706,13 +1829,15 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_SampleAlpha, 4627, 7)
     { 0x30, 0x07 },
     { 0x3B, 0xC7 },
     { 0x44, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVolumeTexture
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreateVolumeTexture, 4627, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateVolumeTexture,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x18 },
     { 0x0B, 0x10 },
@@ -1729,16 +1854,18 @@ OOVPA_NO_XREF(D3DDevice_CreateVolumeTexture, 4627, 14)
 
     { 0x28, 0x20 },
     { 0x3B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateCubeTexture
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateCubeTexture, 4627, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateCubeTexture,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreateCubeTexture0x19: call D3DDevice_CreateTexture2
     XREF_ENTRY(0x20, XREF_D3DDevice_CreateTexture2),
@@ -1755,16 +1882,18 @@ OOVPA_XREF(D3DDevice_CreateCubeTexture, 4627, 1 + 11,
     { 0x18, 0x50 },
 
     { 0x1F, 0x4C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirect3DVertexBuffer8_Lock
 // ******************************************************************
-OOVPA_XREF(IDirect3DVertexBuffer8_Lock, 4627, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirect3DVertexBuffer8_Lock,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DVertexBuffer_Lock2),
 
@@ -1779,4 +1908,10 @@ OOVPA_XREF(IDirect3DVertexBuffer8_Lock, 4627, 1 + 10,
     { 0x0B, 0x8B },
     { 0x0C, 0x54 },
     { 0x0D, 0x24 },
-} OOVPA_END;
+    //
+);
+
+// ******************************************************************
+// * Rollback support signature(s)
+// ******************************************************************
+#define D3DResource_Release_4627 D3DResource_Release_3911

--- a/src/OOVPADatabase/D3D8/4831.inl
+++ b/src/OOVPADatabase/D3D8/4831.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * D3DDevice_CreateTexture2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateTexture2, 4831, 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateTexture2,
+                      4831,
 
-           XREF_D3DDevice_CreateTexture2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateTexture2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x57 },
@@ -46,7 +47,8 @@ OOVPA_XREF(D3DDevice_CreateTexture2, 4831, 12,
 
     { 0x51, 0x24 },
     { 0x52, 0xF7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTexture
@@ -121,11 +123,12 @@ OOVPA_END;
 // * D3DDevice_PersistDisplay
 // ******************************************************************
 // Up to 5849, excluding 5455
-OOVPA_XREF(D3DDevice_PersistDisplay, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_PersistDisplay,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_PersistDisplay+0x04 : mov ebx,[D3D__PDEVICE]
     XREF_ENTRY(0x06, XREF_D3DDEVICE),
@@ -145,13 +148,15 @@ OOVPA_XREF(D3DDevice_PersistDisplay, 4831, 1 + 8,
     // D3DDevice_PersistDisplay+0x36 : ret
     OV_MATCH(0x36, 0xC3),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 4831, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderConstant,
+                         4831)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetPixelShaderConstant+0x1E : test eax, eax
     { 0x1E, 0x85 },
@@ -173,4 +178,5 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 4831, 13)
     { 0xC0, 0x0A },
     { 0xC1, 0x04 },
     { 0xC2, 0x00 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/4928.inl
+++ b/src/OOVPADatabase/D3D8/4928.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_GetPersistedSurface2
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPersistedSurface2, 4928, 6) // For only on Unreal Championship
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPersistedSurface2,
+                         4928) // For only on Unreal Championship
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xFF },
     { 0x01, 0x25 },
@@ -35,13 +36,15 @@ OOVPA_NO_XREF(D3DDevice_GetPersistedSurface2, 4928, 6) // For only on Unreal Cha
     { 0x03, 0xC1 },
     { 0x04, 0x3A },
     { 0x05, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport_IsFlipPending
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_IsFlipPending, 4928, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_IsFlipPending,
+                         4928)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x81 },
@@ -60,4 +63,5 @@ OOVPA_NO_XREF(CMiniport_IsFlipPending, 4928, 17)
     { 0x0E, 0x04 },
     { 0x0F, 0x81 },
     { 0x10, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/5028.inl
+++ b/src/OOVPADatabase/D3D8/5028.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * Direct3D_CreateDevice
 // ******************************************************************
-OOVPA_NO_XREF(Direct3D_CreateDevice, 5028, 20) // Also for 5120, 5233, 5344 (5455 and later use generic 3911 version)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice,
+                         5028) // Also for 5120, 5233, 5344 (5455 and later use generic 3911 version)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -52,13 +53,15 @@ OOVPA_NO_XREF(Direct3D_CreateDevice, 5028, 20) // Also for 5120, 5233, 5344 (545
     { 0x1D, 0x75 },
     { 0x1E, 0x0A },
     { 0x1F, 0xC7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 5028, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVertices,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x1E, 0x5E },
@@ -69,13 +72,15 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 5028, 9)
     { 0xBE, 0x2B },
     { 0xDE, 0x00 },
     { 0xFE, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 5028, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x45 },
     { 0x14, 0x75 },
@@ -84,16 +89,18 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader, 5028, 7)
     { 0x35, 0x04 },
     { 0x40, 0x00 },
     { 0x4B, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShader, 5028, 1 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived
 
@@ -118,16 +125,18 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 5028, 1 + 14,
     { 0xB2, 0x4C },
     { 0xB3, 0x19 },
     { 0xB4, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 5028, 14,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      5028,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x05 },
     { 0x18, 0xC9 },
@@ -146,16 +155,18 @@ OOVPA_XREF(D3D_SetFence, 5028, 14,
     { 0x86, 0x5D },
     { 0x98, 0xE8 },
     { 0xA2, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnTime
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnTime, 5028, 6,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      5028,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x30 },
     { 0x27, 0x07 },
@@ -163,13 +174,15 @@ OOVPA_XREF(D3D_BlockOnTime, 5028, 6,
     { 0x7B, 0x58 },
     { 0xE3, 0x80 },
     { 0xF5, 0x2C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
-OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle, 5028, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_KickOffAndWaitForIdle,
+                         5028)
+OOVPA_SIG_MATCH(
 
     // D3D_KickOffAndWaitForIdle+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -191,13 +204,15 @@ OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle, 5028, 9)
 
     // D3D_KickOffAndWaitForIdle+0x10 : retn
     { 0x10, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstantNotInline
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline, 5028, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0B, 0x10 },
@@ -211,13 +226,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline, 5028, 10)
     { 0x1A, 0xC7 },
     { 0x31, 0xC2 },
     { 0x32, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 5028, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         5028)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -236,13 +253,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 5028, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0xFC },
     { 0x0F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_InsertCallback
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_InsertCallback, 5028, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_InsertCallback,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x0C, 0x72 },
     { 0x1A, 0x10 },
@@ -251,13 +270,15 @@ OOVPA_NO_XREF(D3DDevice_InsertCallback, 5028, 7)
     { 0x44, 0x0C },
     { 0x52, 0x00 },
     { 0x60, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShader, 5028, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShader,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -276,13 +297,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShader, 5028, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShaderConstant
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShaderConstant, 5028, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShaderConstant,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x24 },
     { 0x08, 0x08 },
@@ -292,13 +315,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShaderConstant, 5028, 8)
     { 0x10, 0x7C },
     { 0x14, 0xE6 },
     { 0x18, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPixelShader, 5028, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPixelShader,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -317,7 +342,8 @@ OOVPA_NO_XREF(D3DDevice_GetPixelShader, 5028, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CommonSetRenderTarget
@@ -357,11 +383,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_LazySetStateVB
 // ******************************************************************
-OOVPA_XREF(D3DDevice_LazySetStateVB, 5028, 17,
+OOVPA_SIG_HEADER_XREF(D3DDevice_LazySetStateVB,
+                      5028,
 
-           XREF_D3DDevice_LazySetStateVB,
-           XRefZero)
-{
+                      XREF_D3DDevice_LazySetStateVB,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -382,13 +409,15 @@ OOVPA_XREF(D3DDevice_LazySetStateVB, 5028, 17,
 
     { 0x66, 0x3B },
     { 0x67, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::LazySetStateUP
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LazySetStateUP, 5028, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LazySetStateUP,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -407,16 +436,18 @@ OOVPA_NO_XREF(D3DDevice_LazySetStateUP, 5028, 15)
 
     { 0x4F, 0x3B },
     { 0x50, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BeginPush, 5028, 1 + 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BeginPush,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x09, XREF_D3DDevice_LazySetStateVB),
 
@@ -432,16 +463,18 @@ OOVPA_XREF(D3DDevice_BeginPush, 5028, 1 + 9,
     { 0x13, 0x44 },
     { 0x14, 0x24 },
     { 0x15, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsFencePending
 // ******************************************************************
-OOVPA_XREF(D3DDevice_IsFencePending, 5028, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_IsFencePending,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3DDEVICE), // Derived
 
@@ -450,16 +483,18 @@ OOVPA_XREF(D3DDevice_IsFencePending, 5028, 1 + 5,
     { 0x10, 0xD1 },
     { 0x17, 0x1B },
     { 0x1C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::KickOff
 // ******************************************************************
-OOVPA_XREF(D3DDevice_KickOff, 5028, 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_KickOff,
+                      5028,
 
-           XREF_D3D_CDevice_KickOff,
-           XRefZero)
-{
+                      XREF_D3D_CDevice_KickOff,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x08 },
     { 0x17, 0xC4 },
@@ -469,13 +504,15 @@ OOVPA_XREF(D3DDevice_KickOff, 5028, 8,
     { 0x1B, 0xA1 },
     { 0x6D, 0x85 },
     { 0x7E, 0xBA },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginStateBig
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginStateBig, 5028, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginStateBig,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x0D },
     { 0x07, 0x01 },
@@ -494,13 +531,15 @@ OOVPA_NO_XREF(D3DDevice_BeginStateBig, 5028, 15)
     { 0x2B, 0x00 },
     { 0x34, 0xCA },
     { 0x40, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsBusy
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_IsBusy, 5028, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_IsBusy,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x06, 0x80 },
@@ -516,16 +555,18 @@ OOVPA_NO_XREF(D3DDevice_IsBusy, 5028, 12)
     { 0x1B, 0x00 },
 
     { 0x1F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
-OOVPA_XREF(D3DDevice_DrawIndexedVerticesUP, 5028, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawIndexedVerticesUP,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVerticesUP+0x07 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x09, XREF_D3DDEVICE),
@@ -546,13 +587,15 @@ OOVPA_XREF(D3DDevice_DrawIndexedVerticesUP, 5028, 1 + 10,
     OV_MATCH(0x0F, 0x89),
     OV_MATCH(0x11, 0xF8), // D3DDevice_DrawIndexedVerticesUP 5028 0xF8 vs D3DDevice_DrawVerticesUP 4039 0xEC
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5028, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -571,7 +614,8 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5028, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Rollback support signature(s)

--- a/src/OOVPADatabase/D3D8/5120.inl
+++ b/src/OOVPADatabase/D3D8/5120.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 5120, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         5120)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x57 },
     { 0x10, 0xE8 },
@@ -44,13 +45,15 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 5120, 13)
     { 0x93, 0x4E },
     { 0x94, 0x2C },
     { 0x95, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CopyRects
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CopyRects, 5120, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         5120)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0xE1 },
     { 0x42, 0x84 },
@@ -60,4 +63,5 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 5120, 8)
     { 0xBE, 0x00 },
     { 0xDE, 0xBD },
     { 0xFE, 0x4C },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/5233.inl
+++ b/src/OOVPADatabase/D3D8/5233.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 5233, 12) // Up to 5849
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         5233) // Up to 5849
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x13, 0x89 },
@@ -42,13 +43,15 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 5233, 12) // Up to 5849
     { 0x85, 0x25 },
     { 0x86, 0xFF },
     { 0x87, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 5233, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode,
+                         5233)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_MultiSampleMode+0x04 : mov ecx, ds:dword_XXXX
     { 0x04, 0x8B },
@@ -74,7 +77,8 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_MultiSampleMode, 5233, 13)
     { 0x24, 0xC2 },
     { 0x25, 0x04 },
     { 0x26, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTargetFast
@@ -146,8 +150,9 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_GetVisibilityTestResult
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVisibilityTestResult, 5233, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVisibilityTestResult,
+                         5233)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x08 },
     { 0x10, 0xFF },
@@ -156,4 +161,5 @@ OOVPA_NO_XREF(D3DDevice_GetVisibilityTestResult, 5233, 7)
     { 0x3F, 0x0C },
     { 0x51, 0x0A },
     { 0x5F, 0x0C },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/5344.inl
+++ b/src/OOVPADatabase/D3D8/5344.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * D3DDevice_SetLight
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetLight, 5344, 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetLight,
+                      5344,
 
-           XREF_D3DDevice_SetLight,
-           XRefZero)
-{
+                      XREF_D3DDevice_SetLight,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetLight+0x1f : add REG, 0x10
     { 0x1F, 0x83 },
@@ -58,13 +59,15 @@ OOVPA_XREF(D3DDevice_SetLight, 5344, 15,
     // D3DDevice_SetLight+0xfe : shr ???, 2
     { 0xFE, 0xC1 },
     { 0x100, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 5344, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         5344)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_SetRenderState_TwoSidedLighting+0x07 : mov eax, [esi]
     { 0x07, 0x8B },
@@ -87,16 +90,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 5344, 13)
     // D3DDevice_SetRenderState_TwoSidedLighting+0x7D : retn 0x04
     { 0x7D, 0xC2 },
     { 0x7E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LightEnable
 // ******************************************************************
-OOVPA_XREF(D3DDevice_LightEnable, 5344, 2 + 24,
+OOVPA_SIG_HEADER_XREF(D3DDevice_LightEnable,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefTwo) // PatrickvL : Also for 5558, 5659, 5788, 5849, 5933
-{
+                      XRefNoSaveIndex,
+                      XRefTwo) // PatrickvL : Also for 5558, 5659, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DDEVICE), // Derived
     XREF_ENTRY(0x67, XREF_D3DDevice_SetLight),
@@ -135,16 +140,18 @@ OOVPA_XREF(D3DDevice_LightEnable, 5344, 2 + 24,
     { 0x1D, 0x00 },
     { 0x1E, 0x8D },
     { 0x1F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetLightEnable
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetLightEnable, 5344, 1 + 26,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetLightEnable,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne) // PatrickvL : Also for 5558, 5659, 5788, 5849, 5933
-{
+                      XRefNoSaveIndex,
+                      XRefOne) // PatrickvL : Also for 5558, 5659, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DDEVICE), // Derived
 
@@ -186,13 +193,15 @@ OOVPA_XREF(D3DDevice_GetLightEnable, 5344, 1 + 26,
         { 0xDE, 0x00 },
         { 0xFE, 0x83 },
 */
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 5344, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
 
@@ -207,13 +216,15 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 5344, 11)
     { 0x22, 0x90 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetViewport, 5344, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x87 },
     { 0x3E, 0xC0 },
@@ -223,13 +234,15 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 5344, 8)
     { 0xBE, 0xC1 },
     { 0xDE, 0xC9 },
     { 0xFE, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTransform, 5344, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -248,13 +261,15 @@ OOVPA_NO_XREF(D3DDevice_SetTransform, 5344, 15)
 
     { 0x2F, 0x0B },
     { 0x35, 0x35 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetScissors, 5344, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x1D, 0x44 },
     { 0x3C, 0x8B },
@@ -264,7 +279,8 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 5344, 8)
     { 0xB8, 0xE8 },
     { 0xD7, 0x24 },
     { 0xF6, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
@@ -308,11 +324,12 @@ OOVPA_END;
 // ******************************************************************
 // * D3DDevice_CreateVertexBuffer2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateVertexBuffer2, 5344, 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateVertexBuffer2,
+                      5344,
 
-           XREF_D3DDevice_CreateVertexBuffer2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateVertexBuffer2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0xE8 },
     { 0x0E, 0xF0 },
@@ -323,13 +340,15 @@ OOVPA_XREF(D3DDevice_CreateVertexBuffer2, 5344, 9,
     { 0x2C, 0x85 },
     { 0x30, 0x68 },
     { 0x34, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePalette2
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreatePalette2, 5344, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreatePalette2,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0xE8 },
     { 0x10, 0xFF },
@@ -339,17 +358,19 @@ OOVPA_NO_XREF(D3DDevice_CreatePalette2, 5344, 8)
     { 0x14, 0xC2 },
     { 0x38, 0x85 },
     { 0x3C, 0x68 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVerticesUP
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(D3DDevice_DrawVerticesUP, 5344, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawVerticesUP,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawVerticesUP+0x09 : mov edi,[D3D__PDEVICE]
     XREF_ENTRY(0x0B, XREF_D3DDEVICE),
@@ -370,17 +391,19 @@ OOVPA_XREF(D3DDevice_DrawVerticesUP, 5344, 1 + 10,
     OV_MATCH(0x11, 0x89),
     OV_MATCH(0x13, 0xEC), // D3DDevice_DrawVerticesUP 0xEC vs D3DDevice_DrawIndexedVerticesUP 0xF8
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(D3DDevice_DrawIndexedVerticesUP, 5344, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawIndexedVerticesUP,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawIndexedVerticesUP+0x08 : mov edi,[D3D__PDEVICE]
     XREF_ENTRY(0x0A, XREF_D3DDEVICE),
@@ -401,14 +424,16 @@ OOVPA_XREF(D3DDevice_DrawIndexedVerticesUP, 5344, 1 + 10,
     OV_MATCH(0x11, 0x89),
     OV_MATCH(0x13, 0xF8), // D3DDevice_DrawIndexedVerticesUP 0xF8 vs D3DDevice_DrawVerticesUP 0xEC
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_End
 // ******************************************************************
 //Generic OOVPA as of 5344 and newer.
-OOVPA_NO_XREF(D3DDevice_End, 5344, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_End,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x06 },
     { 0x0A, 0x46 },
@@ -426,13 +451,15 @@ OOVPA_NO_XREF(D3DDevice_End, 5344, 14)
     { 0x3B, 0xE8 },
 
     { 0x40, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 5344, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreatePixelShader,
+                         5344)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_CreatePixelShader+0x05 : push 0xFC
     { 0x05, 0x68 },
@@ -452,13 +479,15 @@ OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 5344, 11)
     // D3DDevice_CreatePixelShader+0x42 : retn 0x08
     { 0x45, 0xC2 },
     { 0x46, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeleteVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DeleteVertexShader, 5344, 6)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeleteVertexShader,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0xFF },
@@ -468,13 +497,15 @@ OOVPA_NO_XREF(D3DDevice_DeleteVertexShader, 5344, 6)
     // D3DDevice_DeleteVertexShader+0x18 : retn 4
     { 0x18, 0xC2 },
     { 0x19, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeletePixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DeletePixelShader, 5344, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeletePixelShader,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x06, 0x75 },
@@ -483,13 +514,15 @@ OOVPA_NO_XREF(D3DDevice_DeletePixelShader, 5344, 7)
     { 0x12, 0x80 },
     { 0x1A, 0xC2 },
     { 0x1B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 5344, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -499,13 +532,15 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 5344, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 5344, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -515,13 +550,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 5344, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 5344, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
 
@@ -536,13 +573,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 5344, 11)
     { 0x22, 0x90 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetProjectionViewportMatrix
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 5344, 16) // Up to 5455
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetProjectionViewportMatrix,
+                         5344) // Up to 5455
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -562,16 +601,18 @@ OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 5344, 16) // Up to 5455
     { 0x19, 0x5F },
     { 0x1A, 0x5E },
     { 0x1B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateIndexBuffer2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateIndexBuffer2, 5344, 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateIndexBuffer2,
+                      5344,
 
-           XREF_D3DDevice_CreateIndexBuffer2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateIndexBuffer2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x00 },
     { 0x0C, 0x50 },
@@ -580,16 +621,18 @@ OOVPA_XREF(D3DDevice_CreateIndexBuffer2, 5344, 7,
     { 0x21, 0x04 },
     { 0x28, 0xC7 },
     { 0x2F, 0x48 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush
 // ******************************************************************
-OOVPA_XREF(D3DDevice_BeginPush, 5344, 1 + 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BeginPush,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x09, XREF_D3DDevice_LazySetStateVB),
 
@@ -605,13 +648,15 @@ OOVPA_XREF(D3DDevice_BeginPush, 5344, 1 + 9,
     { 0x13, 0x44 },
     { 0x14, 0x24 },
     { 0x15, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 5344, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         5344)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -630,13 +675,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 5344, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x20 },
     { 0x0F, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5344, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -655,7 +702,8 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5344, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTexture, named with 2 suffix to match EMUPATCH(D3DDevice_GetTexture2)

--- a/src/OOVPADatabase/D3D8/5455.inl
+++ b/src/OOVPADatabase/D3D8/5455.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 5455, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x1D, 0xBE },
@@ -43,13 +44,15 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 5455, 12)
 
     { 0x58, 0x8B },
     { 0x7B, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetViewport, 5455, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x86 },
     { 0x3E, 0x1B },
@@ -59,16 +62,18 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 5455, 8)
     { 0xBE, 0x0C },
     { 0xDE, 0x75 },
     { 0xFE, 0x85 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexBuffer2
 // ******************************************************************
-OOVPA_XREF(D3DDevice_CreateVertexBuffer2, 5455, 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_CreateVertexBuffer2,
+                      5455,
 
-           XREF_D3DDevice_CreateVertexBuffer2,
-           XRefZero)
-{
+                      XREF_D3DDevice_CreateVertexBuffer2,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0xE8 },
@@ -86,13 +91,15 @@ OOVPA_XREF(D3DDevice_CreateVertexBuffer2, 5455, 14,
     { 0x31, 0x33 },
     { 0x3A, 0xFF },
     { 0x44, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePalette2
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_CreatePalette2, 5455, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreatePalette2,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x0D, 0x8B },
     { 0x16, 0x00 },
@@ -101,16 +108,18 @@ OOVPA_NO_XREF(D3DDevice_CreatePalette2, 5455, 7)
     { 0x3D, 0x5E },
     { 0x46, 0x1E },
     { 0x52, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetVertexShader, 5455, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      5455,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived (confirmed)
 
@@ -122,16 +131,18 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 5455, 1 + 8,
     { 0xBE, 0x8B },
     { 0xDE, 0x04 },
     { 0xFE, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetViewport
 // ******************************************************************
-OOVPA_XREF(D3DDevice_GetViewport, 5455, 1 + 17,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetViewport,
+                      5455,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x01, XREF_D3DDEVICE), // Derived
 
@@ -155,13 +166,15 @@ OOVPA_XREF(D3DDevice_GetViewport, 5455, 1 + 17,
     { 0x2F, 0x14 },
     { 0x30, 0xC2 },
     { 0x31, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScreenSpaceOffset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetScreenSpaceOffset, 5455, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScreenSpaceOffset,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xD9 },
     { 0x01, 0x44 },
@@ -182,16 +195,18 @@ OOVPA_NO_XREF(D3DDevice_SetScreenSpaceOffset, 5455, 17)
 
     { 0x23, 0xD9 },
     { 0x29, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_SetTileNoWait
 // ******************************************************************
-OOVPA_XREF(D3D_SetTileNoWait, 5455, 16,
+OOVPA_SIG_HEADER_XREF(D3D_SetTileNoWait,
+                      5455,
 
-           XREF_D3D_SetTileNoWait,
-           XRefZero)
-{
+                      XREF_D3D_SetTileNoWait,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -211,13 +226,15 @@ OOVPA_XREF(D3D_SetTileNoWait, 5455, 16,
 
     { 0x88, 0x5F },
     { 0x9B, 0xCB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport::InitHardware
 // ******************************************************************
-OOVPA_NO_XREF(CMiniport_InitHardware, 5455, 24) // Also for 5558, 5659, 5788, 5849, 5933
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_InitHardware,
+                         5455) // Also for 5558, 5659, 5788, 5849, 5933
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -245,13 +262,15 @@ OOVPA_NO_XREF(CMiniport_InitHardware, 5455, 24) // Also for 5558, 5659, 5788, 58
     { 0x1D, 0x8D },
     { 0x1E, 0x86 },
     { 0x1F, 0xAC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTile
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetTile, 5455, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetTile,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
@@ -267,16 +286,18 @@ OOVPA_NO_XREF(D3DDevice_GetTile, 5455, 12)
 
     { 0x3A, 0xC2 },
     { 0x3B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::KickOff
 // ******************************************************************
-OOVPA_XREF(D3DDevice_KickOff, 5455, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_KickOff,
+                      5455,
 
-           XREF_D3D_CDevice_KickOff,
-           XRefOne)
-{
+                      XREF_D3D_CDevice_KickOff,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     // mov eax, XREF_D3DDEVICE
     XREF_ENTRY(0x1A, XREF_D3DDEVICE), // Derived
 
@@ -293,7 +314,8 @@ OOVPA_XREF(D3DDevice_KickOff, 5455, 1 + 12,
     // mov eax, XREF_D3DDEVICE
     OV_MATCH(0x19, 0xA1),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
@@ -338,8 +360,9 @@ OOVPA_END;
 // * D3D_AllocContiguousMemory
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer.
-OOVPA_NO_XREF(D3D_AllocContiguousMemory, 5455, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_AllocContiguousMemory,
+                         5455)
+OOVPA_SIG_MATCH(
 
     // D3D_AllocContiguousMemory+0x00 : cmp [esp+0x08],0x00001000
     OV_MATCH(0x00, 0x81, 0x7C), //, 0x24, 0x08
@@ -354,4 +377,5 @@ OOVPA_NO_XREF(D3D_AllocContiguousMemory, 5455, 14)
     // D3D_AllocContiguousMemory+0x31 : jmp XMemAlloc
     OV_MATCH(0x31, 0xE9),
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8/5558.inl
+++ b/src/OOVPADatabase/D3D8/5558.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * D3DDevice_LazySetStateVB
 // ******************************************************************
-OOVPA_XREF(D3DDevice_LazySetStateVB, 5558, 16,
+OOVPA_SIG_HEADER_XREF(D3DDevice_LazySetStateVB,
+                      5558,
 
-           XREF_D3DDevice_LazySetStateVB,
-           XRefZero)
-{
+                      XREF_D3DDevice_LazySetStateVB,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -51,13 +52,15 @@ OOVPA_XREF(D3DDevice_LazySetStateVB, 5558, 16,
 
     { 0x66, 0x3B },
     { 0x67, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::CDevice::LazySetStateUP
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_LazySetStateUP, 5558, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LazySetStateUP,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -76,13 +79,15 @@ OOVPA_NO_XREF(D3DDevice_LazySetStateUP, 5558, 14)
 
     { 0x4F, 0x3B },
     { 0x50, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 5558, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
 
@@ -97,13 +102,15 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 5558, 11)
     { 0x22, 0x90 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 5558, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -115,13 +122,15 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 5558, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetTransform, 5558, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x8B },
     { 0x05, 0x54 },
@@ -137,16 +146,18 @@ OOVPA_NO_XREF(D3DDevice_SetTransform, 5558, 12)
 
     { 0x9C, 0x00 },
     { 0x9D, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 5558, 9,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      5558,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x09, 0x3B },
@@ -158,16 +169,18 @@ OOVPA_XREF(D3D_SetFence, 5558, 9,
     { 0x16, 0x2C },
 
     { 0x39, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::BlockOnTime
 // ******************************************************************
-OOVPA_XREF(D3D_BlockOnTime, 5558, 12,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      5558,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -190,13 +203,15 @@ OOVPA_XREF(D3D_BlockOnTime, 5558, 12,
         { 0x9F, 0x20 },
         { 0xD3, 0x56 },
         { 0xE9, 0x57 },*/
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetScissors, 5558, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x1D, 0x44 },
     { 0x3C, 0x8B },
@@ -206,13 +221,15 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 5558, 8)
     { 0xB8, 0xE8 },
     { 0xD7, 0x24 },
     { 0xF6, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 5558, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         5558)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -231,13 +248,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 5558, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x34 },
     { 0x0F, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Reset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Reset, 5558, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x27, 0x8B },
@@ -252,13 +271,15 @@ OOVPA_NO_XREF(D3DDevice_Reset, 5558, 13)
     { 0x9A, 0xE8 },
     { 0x9F, 0x33 },
     { 0xA6, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetGammaRamp
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 5558, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetGammaRamp,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x0F, 0x68 },
     { 0x20, 0x34 },
@@ -267,13 +288,15 @@ OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 5558, 7)
     { 0x53, 0xF3 },
     { 0x64, 0xCA },
     { 0x75, 0x07 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 5558, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
 
@@ -288,13 +311,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 5558, 11)
     { 0x22, 0x90 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 5558, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -306,17 +331,19 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 5558, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::MakeRequestedSpace
 // ******************************************************************
 // Generic OOVPA as of 5558 and newer.
-OOVPA_XREF(D3D_MakeRequestedSpace_8, 5558, 12,
+OOVPA_SIG_HEADER_XREF(D3D_MakeRequestedSpace_8,
+                      5558,
 
-           XREF_D3D_MakeRequestedSpace,
-           XRefZero)
-{
+                      XREF_D3D_MakeRequestedSpace,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D::MakeRequestedSpace+0x00 : push ecx; push esi
     OV_MATCH(0x00, 0x51, 0x56),
@@ -330,13 +357,15 @@ OOVPA_XREF(D3D_MakeRequestedSpace_8, 5558, 12,
     // D3D::MakeRequestedSpace+0x32 : ret 0x08
     OV_MATCH(0x32, 0xC2, 0x08),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetViewportOffsetAndScale
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale, 5558, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetViewportOffsetAndScale,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0xD8 },
     { 0x40, 0xD8 },
@@ -346,13 +375,15 @@ OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale, 5558, 8)
     { 0xBE, 0xD8 },
     { 0xDD, 0x14 },
     { 0xFE, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetProjectionViewportMatrix
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 5558, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetProjectionViewportMatrix,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
     { 0x07, 0x57 },
@@ -369,13 +400,15 @@ OOVPA_NO_XREF(D3DDevice_GetProjectionViewportMatrix, 5558, 15)
     { 0x19, 0x5F },
     { 0x1A, 0x5E },
     { 0x1B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 5558, 6)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0xED },
     { 0x42, 0x18 },
@@ -383,13 +416,15 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 5558, 6)
     { 0x8D, 0x1C },
     { 0xAF, 0x0F },
     { 0xF6, 0x41 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5558, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -408,13 +443,15 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5558, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPixelShader, 5558, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPixelShader,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -433,13 +470,15 @@ OOVPA_NO_XREF(D3DDevice_GetPixelShader, 5558, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShader, 5558, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShader,
+                         5558)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -458,7 +497,8 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShader, 5558, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTexture, named with 2 suffix to match EMUPATCH(D3DDevice_GetTexture2)

--- a/src/OOVPADatabase/D3D8/5788.inl
+++ b/src/OOVPADatabase/D3D8/5788.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * D3D::RecordStateBlock
 // ******************************************************************
-OOVPA_XREF(D3D_RecordStateBlock, 5788, 10,
+OOVPA_SIG_HEADER_XREF(D3D_RecordStateBlock,
+                      5788,
 
-           XREF_D3D_RecordStateBlock,
-           XRefZero)
-{
+                      XREF_D3D_RecordStateBlock,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // D3D_RecordStateBlock+0x0F : mov eax, [edi+0x07A4]
     { 0x0F, 0x8B },
@@ -47,13 +48,15 @@ OOVPA_XREF(D3D_RecordStateBlock, 5788, 10,
     { 0xD6, 0x46 },
     { 0xD7, 0x0C },
     { 0xD8, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetMaterial, 5788, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetMaterial,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
 
@@ -68,13 +71,15 @@ OOVPA_NO_XREF(D3DDevice_SetMaterial, 5788, 11)
     { 0x22, 0x90 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetMaterial, 5788, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetMaterial,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -86,13 +91,15 @@ OOVPA_NO_XREF(D3DDevice_GetMaterial, 5788, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_AddRef
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_AddRef, 5788, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_AddRef,
+                         5788)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_AddRef+0x00 : mov eax, [addr]
     { 0x00, 0xA1 },
@@ -111,13 +118,15 @@ OOVPA_NO_XREF(D3DDevice_AddRef, 5788, 10)
     { 0x0D, 0x88 },
     { 0x0E, 0x38 },
     { 0x0F, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 5788, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetBackMaterial,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
 
@@ -132,13 +141,15 @@ OOVPA_NO_XREF(D3DDevice_SetBackMaterial, 5788, 11)
     { 0x22, 0x90 },
     { 0x2C, 0x5E },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackMaterial
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 5788, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackMaterial,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x56 },
     { 0x06, 0x57 },
@@ -150,13 +161,15 @@ OOVPA_NO_XREF(D3DDevice_GetBackMaterial, 5788, 8)
     { 0x12, 0x11 },
     { 0x16, 0xF3 },
     { 0x1A, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetVertexShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetVertexShader, 5788, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetVertexShader,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -175,13 +188,15 @@ OOVPA_NO_XREF(D3DDevice_GetVertexShader, 5788, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetPixelShader
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetPixelShader, 5788, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetPixelShader,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -200,13 +215,15 @@ OOVPA_NO_XREF(D3DDevice_GetPixelShader, 5788, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetShaderConstantMode
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5788, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetShaderConstantMode,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -225,7 +242,8 @@ OOVPA_NO_XREF(D3DDevice_GetShaderConstantMode, 5788, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTexture, named with 2 suffix to match EMUPATCH(D3DDevice_GetTexture2)

--- a/src/OOVPADatabase/D3D8/5849.inl
+++ b/src/OOVPADatabase/D3D8/5849.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 5849, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         5849)
+OOVPA_SIG_MATCH(
 
     { 0x12, 0x8B },
     { 0x24, 0x33 },
@@ -37,17 +38,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 5849, 8)
     { 0x70, 0xB9 },
     { 0x83, 0x40 },
     { 0x96, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // * SOURCE: Spiderman 2
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 5849, 7,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      5849,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x05 },
     { 0x17, 0xC7 },
@@ -56,13 +59,15 @@ OOVPA_XREF(D3D_SetFence, 5849, 7,
     { 0x87, 0x4E },
     { 0x98, 0x83 },
     { 0xA8, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 5849, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         5849)
+OOVPA_SIG_MATCH(
 
     { 0x0C, 0x89 },
     { 0x1E, 0x8B },
@@ -72,4 +77,5 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 5849, 8)
     { 0x52, 0xC7 },
     { 0x60, 0x04 },
     { 0x6E, 0x00 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/3911.inl
+++ b/src/OOVPADatabase/D3D8LTCG/3911.inl
@@ -27,8 +27,9 @@
 // * Direct3D_CreateDevice
 // ******************************************************************
 //85C9750AC705 ...C21000
-OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ebx_ppReturnedDeviceInterface, 2024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ebx_ppReturnedDeviceInterface,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -41,17 +42,19 @@ OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ebx_ppReturnedDev
 
     { 0x28, 0x56 },
     { 0x29, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_CullMode
 // ******************************************************************
 //C7000803040075
-OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1045, 2 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_CullMode,
+                      1045,
 
-           XREF_D3DDevice_SetRenderState_CullMode,
-           XRefTwo)
-{
+                      XREF_D3DDevice_SetRenderState_CullMode,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
     XREF_ENTRY(0x2D, XREF_D3DRS_CULLMODE), // Derived
@@ -65,14 +68,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1045, 2 + 8,
     { 0x1F, 0x04 },
     { 0x20, 0x00 },
     { 0x21, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_VertexBlend
 // ******************************************************************
 //C70028030400894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 1048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_VertexBlend,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -86,14 +91,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 1048, 11)
     { 0x2A, 0x89 },
     { 0x2B, 0x48 },
     { 0x2C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BumpEnv
 // ******************************************************************
 //000085C08BDF75 ...C20800
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv_8, 2024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BumpEnv_8,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -104,14 +111,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv_8, 2024, 8)
     { 0x18, 0x8B },
     { 0x19, 0xDF },
     { 0x1A, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
 //C9C7000C03040089480483
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -127,16 +136,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1024, 13)
     { 0x37, 0x48 },
     { 0x38, 0x04 },
     { 0x39, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TextureFactor
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_TextureFactor, 1036, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_TextureFactor,
+                      1036,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
 
@@ -153,16 +164,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_TextureFactor, 1036, 1 + 10,
 
     { 0x11, 0x8B },
     { 0x12, 0x06 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_YuvEnable
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_YuvEnable, 1024, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_YuvEnable,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_YUVENABLE),
 
@@ -173,17 +186,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_YuvEnable, 1024, 1 + 7,
     { 0x0B, 0xA3 },
     { 0x11, 0x06 },
     { 0x15, 0x72 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_OcclusionCullEnable
 // ******************************************************************
 //568BD0E8
-OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 1024, 1 + 2,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_OcclusionCullEnable,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_OCCLUSIONCULLENABLE),
 
@@ -194,17 +209,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_OcclusionCullEnable, 1024, 1 + 2,
     //{ 0x27, 0x8B },
     //{ 0x28, 0xD0 },
     //{ 0x29, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //538BD9C1E107 ...C3
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_0, 2039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex_0,
+                      2039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x08, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -219,14 +236,16 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_0, 2039, 1 + 10,
     { 0x14, 0x00 },
     { 0x15, 0x00 },
     { 0x16, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //C1..0681..241B040089 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_0, 2024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -241,14 +260,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_0, 2024, 12)
     { 0x23, 0x04 },
     { 0x24, 0x00 },
     { 0x25, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //83C008C1E707890689 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -261,14 +282,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0, 2024, 10)
     { 0x2C, 0x89 },
     { 0x2D, 0x06 },
     { 0x2E, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZBias
 // ******************************************************************
 //24..8BF07D06D805
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZBias,
+                         1048)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x6A, XREF_D3DRS_ZBIAS ),
 
@@ -283,14 +306,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1048, 9)
     { 0x1C, 0x06 },
     { 0x1D, 0xD8 },
     { 0x1E, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LineWidth
 // ******************************************************************
 //44240C57D88E
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LineWidth,
+                         1024)
+OOVPA_SIG_MATCH(
 
 
     // XREF_ENTRY( 0x5B, XREF_D3DRS_LINEWIDTH ),
@@ -303,16 +328,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LineWidth, 1024, 7)
     { 0x14, 0x57 },
     { 0x15, 0xD8 },
     { 0x16, 0x8E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilCullEnable
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_StencilCullEnable, 1024, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_StencilCullEnable,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_STENCILCULLENABLE),
 
@@ -323,16 +350,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_StencilCullEnable, 1024, 1 + 7,
     { 0x0B, 0xA3 },
     { 0x11, 0x06 },
     { 0x15, 0x72 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetRenderState_BackFillMode
 //******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_BackFillMode, 1024, 2 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_BackFillMode,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x06, XREF_D3DRS_FILLMODE),
     XREF_ENTRY(0x0B, XREF_D3DRS_BACKFILLMODE),
@@ -342,14 +371,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_BackFillMode, 1024, 2 + 5,
     { 0x10, 0x4C },
     { 0x11, 0x24 },
     { 0x12, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_EdgeAntiAlias
 // ******************************************************************
 //0020030800894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x12, 0x4C },
@@ -362,14 +393,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1024, 10)
     { 0x1F, 0x89 },
     { 0x20, 0x48 },
     { 0x21, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FillMode
 // ******************************************************************
 //C98B4C24087502
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FillMode,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0x06 },
@@ -381,14 +414,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1024, 9)
     { 0x26, 0x08 },
     { 0x27, 0x75 },
     { 0x28, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FogColor
 // ******************************************************************
 //54240E8BF981
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FogColor,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -398,17 +433,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1024, 7)
     { 0x1F, 0x8B },
     { 0x20, 0xF9 },
     { 0x21, 0x81 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
 //C1E11083E20F
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1024, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEANTIALIAS),
 
@@ -420,17 +457,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1024, 1 + 7,
     { 0x39, 0x83 },
     { 0x3A, 0xE2 },
     { 0x3B, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
 //83E10FC1E210
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1024, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEMASK),
 
@@ -443,14 +482,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1024, 1 + 8,
     { 0x39, 0xC1 },
     { 0x3A, 0xE2 },
     { 0x3B, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LogicOp
 // ******************************************************************
 //18C700BC1704
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LogicOp,
+                         1024)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x2D, XREF_D3DRS_LOGICOP ),
 
@@ -462,14 +503,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1024, 7)
     { 0x1F, 0xBC },
     { 0x20, 0x17 },
     { 0x21, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_NormalizeNormals
 // ******************************************************************
 //A4030400894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -480,14 +523,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1024, 8)
     { 0x1F, 0x89 },
     { 0x20, 0x48 },
     { 0x21, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
 //7003040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1B, 0x33 },
@@ -497,17 +542,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1024, 7)
     { 0x5B, 0x04 },
     { 0x5C, 0x00 },
     { 0x5D, 0x89 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetRenderState_TwoSidedLighting
 //******************************************************************
 //834808208B
-OOVPA_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1024, 1 + 6,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_D3DRS_TWOSIDEDLIGHTING),
 
@@ -518,14 +565,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1024, 1 + 6,
     { 0x07, 0x08 },
     { 0x08, 0x20 },
     { 0x09, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FrontFace
 // ******************************************************************
 //00A00304008948
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FrontFace,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -536,14 +585,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1024, 8)
     { 0x1E, 0x00 },
     { 0x1F, 0x89 },
     { 0x20, 0x48 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ShadowFunc
 // ******************************************************************
 //6C1E04008D91
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ShadowFunc,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -554,14 +605,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1024, 8)
     { 0x1E, 0x00 },
     { 0x1F, 0x8D },
     { 0x20, 0x91 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
 //018b54240885d2c700
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -574,14 +627,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1024, 10)
     { 0x4E, 0xD2 },
     { 0x4F, 0xC7 },
     { 0x50, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexShader
 // ******************************************************************
 //241833f685ed
-OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateVertexShader,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x6C },
     { 0x0C, 0x0F },
@@ -591,14 +646,16 @@ OOVPA_NO_XREF(D3DDevice_CreateVertexShader, 1024, 8)
     { 0x1D, 0xF6 },
     { 0x1E, 0x85 },
     { 0x1F, 0xED },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -615,14 +672,16 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2024, 13)
 
     { 0xEE, 0x5B },
     { 0xEF, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Clear
 // ******************************************************************
 //FFFDFFFF8944
-OOVPA_NO_XREF(D3DDevice_Clear, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Clear,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -633,14 +692,16 @@ OOVPA_NO_XREF(D3DDevice_Clear, 1036, 8)
     { 0x45, 0xFF },
     { 0x46, 0x89 },
     { 0x47, 0x44 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_Release
 // ******************************************************************
 //578B7C24088B078BC881E1FFFF0000
-OOVPA_NO_XREF(D3DResource_Release, 1036, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_Release,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x57 },
     { 0x01, 0x8B },
@@ -657,14 +718,16 @@ OOVPA_NO_XREF(D3DResource_Release, 1036, 15)
     { 0x0C, 0xFF },
     { 0x0D, 0x00 },
     { 0x0E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetTile
 //******************************************************************
 //C744242000000000C744241C ...C3
-OOVPA_NO_XREF(D3DDevice_SetTile_0, 2024, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x15 },
@@ -681,13 +744,15 @@ OOVPA_NO_XREF(D3DDevice_SetTile_0, 2024, 14)
     { 0x35, 0x44 },
     { 0x36, 0x24 },
     { 0x37, 0x1C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Present
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_Present, 1024, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Present,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -707,14 +772,16 @@ OOVPA_NO_XREF(D3DDevice_Present, 1024, 17)
     { 0x19, 0x8E },
     { 0x1C, 0x00 },
     { 0x1D, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
 //C700FC1704008B57
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVerticesUP,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x05, 0x14 },
@@ -727,13 +794,15 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1024, 10)
     { 0x34, 0x00 },
     { 0x35, 0x8B },
     { 0x36, 0x57 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1024, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVertices,
+                         1024)
+OOVPA_SIG_MATCH(
 
     // push ebp
     OV_MATCH(0x00, 0x55),
@@ -746,17 +815,19 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1024, 15)
 
     // lea ebx, [ebx+0]
     OV_MATCH(0x15A, 0x8D, 0x9B),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
 //F6C30155568B35 ...C3
-OOVPA_XREF(D3DDevice_SetVertexShader_0, 2024, 1 + 14,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader_0,
+                      2024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0D, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived (confirmed)
 
@@ -775,14 +846,16 @@ OOVPA_XREF(D3DDevice_SetVertexShader_0, 2024, 1 + 14,
     { 0x19, 0xFF },
     { 0x1A, 0xEB },
     { 0x1B, 0x0E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
 //75448B..000B00008B..080B00008B..040B0000
-OOVPA_NO_XREF(D3DDevice_SetScissors, 1024, 19)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -804,14 +877,16 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 1024, 19)
     { 0x24, 0x0B },
     { 0x25, 0x00 },
     { 0x26, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //8D7822C1E70603FBB910000000 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2024, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -829,14 +904,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2024, 15)
     { 0x13, 0x00 },
     { 0x14, 0x00 },
     { 0x15, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant
 // ******************************************************************
 //83C160C1E202A810 ...C3
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant_8, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstant_8,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -849,14 +926,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant_8, 2024, 10)
     { 0x18, 0x02 },
     { 0x19, 0xA8 },
     { 0x1A, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVerticesUP
 // ******************************************************************
 //894804C700FC1704008B ...C20C00
-OOVPA_NO_XREF(D3DDevice_DrawVerticesUP_12, 2024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVerticesUP_12,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -871,14 +950,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVerticesUP_12, 2024, 12)
     { 0x32, 0x04 },
     { 0x33, 0x00 },
     { 0x34, 0x8B },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_LoadVertexShader
 //******************************************************************
 //C7009C1E04008B ...C3
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_ecx_Handle, 2024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_ecx_Handle,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -890,14 +971,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_ecx_Handle, 2024, 9
     { 0x43, 0x04 },
     { 0x44, 0x00 },
     { 0x45, 0x8B },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SelectVertexShader
 //******************************************************************
 //C740040600000083 ...C20400
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_4, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_4,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x03, 0x8B },
@@ -910,7 +993,8 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_4, 2024, 10)
     { 0x4B, 0x00 },
     { 0x4C, 0x00 },
     { 0x4D, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
@@ -948,8 +1032,9 @@ OOVPA_END;
 // * D3DDevice_SetViewport
 // ******************************************************************
 //EB06894424088BF8
-OOVPA_NO_XREF(D3DDevice_SetViewport, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -962,14 +1047,16 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 1024, 10)
     { 0x2A, 0x08 },
     { 0x2B, 0x8B },
     { 0x2C, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTexture
 // ******************************************************************
 //81C10000F8FF89 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetTexture_4__LTCG_eax_pTexture, 2024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTexture_4__LTCG_eax_pTexture,
+                         2024)
+OOVPA_SIG_MATCH(
 
     // sub esp, ...
     OV_MATCH(0x00, 0x83, 0xEC),
@@ -979,17 +1066,19 @@ OOVPA_NO_XREF(D3DDevice_SetTexture_4__LTCG_eax_pTexture, 2024, 11)
 
     // add ecx, 0FFF80000h; mov ...
     OV_MATCH(0x27, 0x81, 0xC1, 0x00, 0x00, 0xF8, 0xFF, 0x89),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnResource
 // ******************************************************************
 //00007800750C85 ...C3
-OOVPA_XREF(D3D_BlockOnResource_0, 2024, 11,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnResource_0,
+                      2024,
 
-           XREF_D3D_BlockOnResource,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnResource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x15 },
@@ -1003,17 +1092,19 @@ OOVPA_XREF(D3D_BlockOnResource_0, 2024, 11,
     { 0x2E, 0x75 },
     { 0x2F, 0x0C },
     { 0x30, 0x85 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
 // ******************************************************************
 //7406810300000800
-OOVPA_XREF(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber, 1039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber,
+                      1039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x47, XREF_G_STREAM), // Derived
 
@@ -1029,14 +1120,16 @@ OOVPA_XREF(D3DDevice_SetStreamSource_8__LTCG_edx_StreamNumber, 1039, 1 + 11,
     { 0x3D, 0x08 },
     { 0x3E, 0x00 },
     { 0x3F, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2060, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -1053,18 +1146,20 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2060, 13)
     { 0x65, 0x08 },
 
     { 0x6A, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BlockUntilVerticalBlank
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
 // NOTE: Later XDK version start to use std signature.
-OOVPA_XREF(D3DDevice_BlockUntilVerticalBlank, 1024, 2 + 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_BlockUntilVerticalBlank,
+                      1024,
 
-           XREF_D3DDevice_BlockUntilVerticalBlank,
-           XRefTwo)
-{
+                      XREF_D3DDevice_BlockUntilVerticalBlank,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_BlockUntilVerticalBlank+0x00 : mov eax, [D3D__PDEVICE]
     XREF_ENTRY(0x01, XREF_D3DDEVICE),
@@ -1093,17 +1188,19 @@ OOVPA_XREF(D3DDevice_BlockUntilVerticalBlank, 1024, 2 + 15,
     // D3DDevice_BlockUntilVerticalBlank+0x23 : mov eax,[addr]
     OV_MATCH(0x23, 0xA1), // NOTE: std has a ret here and isn't a extended function.
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_DestroyResource
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(D3D_DestroyResource__LTCG, 3911, 1 + 21,
+OOVPA_SIG_HEADER_XREF(D3D_DestroyResource__LTCG,
+                      3911,
 
-           XREF_D3D_DestroyResource,
-           XRefOne)
-{
+                      XREF_D3D_DestroyResource,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3D_DestroyResource+0x19 : D3D_BlockOnResource
     XREF_ENTRY(0x1A, XREF_D3D_BlockOnResource),
@@ -1123,4 +1220,5 @@ OOVPA_XREF(D3D_DestroyResource__LTCG, 3911, 1 + 21,
     // relative to 0x00; LTCG offset 0x24 vs STD offset 0x22
     // D3D_DestroyResource+0x24 : cmp esi, $50000
     OV_MATCH(0x24, 0x81, 0xFE, 0x00, 0x00, 0x05, 0x00),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/4039.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4039.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_DrawIndexedVertices
 // ******************************************************************
 //558BEC83EC0853568B35
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVertices,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -40,14 +41,16 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVertices, 1036, 10)
     { 0x07, 0x56 },
     { 0x08, 0x8B },
     { 0x09, 0x35 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
 //EB06894424088BF8
-OOVPA_NO_XREF(D3DDevice_SetViewport, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -60,14 +63,16 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 1036, 10)
     { 0x28, 0x08 },
     { 0x29, 0x8B },
     { 0x2A, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetLight
 // ******************************************************************
 //83E0F0894424108D04C0
-OOVPA_NO_XREF(D3DDevice_SetLight, 1048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetLight,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -82,17 +87,19 @@ OOVPA_NO_XREF(D3DDevice_SetLight, 1048, 12)
     { 0x2D, 0x8D },
     { 0x2E, 0x04 },
     { 0x2F, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //51538B5C240C8BC6 ...C20400
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2040, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex_4,
+                      2040,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x14, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -107,14 +114,16 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2040, 1 + 10,
 
     { 0x12, 0x89 },
     { 0x18, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //8BCEC1E10681C1241B04 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_4, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -128,17 +137,19 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_4, 2048, 10)
     { 0x2A, 0x24 },
 
     { 0x44, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_CullMode
 // ******************************************************************
 //C7000803040075
-OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1049, 2 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_CullMode,
+                      1049,
 
-           XREF_D3DDevice_SetRenderState_CullMode,
-           XRefTwo)
-{
+                      XREF_D3DDevice_SetRenderState_CullMode,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
     XREF_ENTRY(0x31, XREF_D3DRS_CULLMODE), // Derived
@@ -152,15 +163,17 @@ OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1049, 2 + 8,
     { 0x23, 0x04 },
     { 0x24, 0x00 },
     { 0x25, 0x75 },
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_NormalizeNormals
 // ******************************************************************
 //A4030400894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -171,14 +184,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1036, 8)
     { 0x23, 0x89 },
     { 0x24, 0x48 },
     { 0x25, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
 //C7000C0304008950
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -191,14 +206,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1036, 10)
     { 0x3C, 0x00 },
     { 0x3D, 0x89 },
     { 0x3E, 0x50 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
 //018b54240885d2c700
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -211,14 +228,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1036, 10)
     { 0x52, 0xD2 },
     { 0x53, 0xC7 },
     { 0x54, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FillMode
 // ******************************************************************
 //C98B4C24087502
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FillMode,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0x06 },
@@ -230,14 +249,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1036, 9)
     { 0x2A, 0x08 },
     { 0x2B, 0x75 },
     { 0x2C, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FogColor
 // ******************************************************************
 //54240E8BF981
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FogColor,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -247,15 +268,17 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1036, 7)
     { 0x23, 0x8B },
     { 0x24, 0xF9 },
     { 0x25, 0x81 },
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ShadowFunc
 // ******************************************************************
 //6C1E04008D91
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ShadowFunc,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -266,14 +289,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1036, 8)
     { 0x22, 0x00 },
     { 0x23, 0x8D },
     { 0x24, 0x91 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_EdgeAntiAlias
 // ******************************************************************
 //0020030800894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1A, 0x4C },
@@ -286,7 +311,8 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1036, 10)
     { 0x23, 0x89 },
     { 0x24, 0x48 },
     { 0x25, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetLevelDesc
@@ -295,8 +321,9 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1036, 10)
 // *       GetLevelDesc Simply redirects to that function
 // ******************************************************************
 //7909C74608010000 ...C3
-OOVPA_NO_XREF(Get2DSurfaceDesc_0, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(Get2DSurfaceDesc_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x0F },
     { 0x01, 0xB6 },
@@ -309,14 +336,16 @@ OOVPA_NO_XREF(Get2DSurfaceDesc_0, 2024, 10)
     { 0x2F, 0x01 },
     { 0x30, 0x00 },
     { 0x31, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //E00A040089 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_4, 2048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -326,17 +355,19 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_4, 2048, 7)
     { 0x28, 0x04 },
     { 0x29, 0x00 },
     { 0x2A, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
 //F6C30155568B35
-OOVPA_XREF(D3DDevice_SetVertexShader, 1024, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x12, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived (unverified, yet should be align base on existing 4 bytes in signatures)
 
@@ -352,14 +383,16 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 1024, 1 + 12,
     { 0x09, 0x56 },
     { 0x0A, 0x8B },
     { 0x0B, 0x35 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
 //7505BB050000008B
-OOVPA_NO_XREF(D3DDevice_Swap, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -371,14 +404,16 @@ OOVPA_NO_XREF(D3DDevice_Swap, 1036, 9)
     { 0x13, 0x00 },
     { 0x14, 0x00 },
     { 0x15, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsFencePending
 // ******************************************************************
 //D12B4424043B
-OOVPA_NO_XREF(D3DDevice_IsFencePending, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_IsFencePending,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x8B },
@@ -389,14 +424,16 @@ OOVPA_NO_XREF(D3DDevice_IsFencePending, 1024, 8)
     { 0x13, 0x24 },
     { 0x14, 0x04 },
     { 0x15, 0x3B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_VertexBlend
 // ******************************************************************
 //81CA000200003BC1
-OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_VertexBlend,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x15 },
@@ -409,16 +446,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 1036, 10)
     { 0x17, 0x00 },
     { 0x18, 0x3B },
     { 0x19, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetRenderState_TwoSidedLighting
 //******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1036, 2 + 6,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                      1036,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x18, XREF_D3DRS_FILLMODE),
     XREF_ENTRY(0x1D, XREF_D3DRS_TWOSIDEDLIGHTING),
@@ -429,14 +468,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1036, 2 + 6,
     { 0x08, 0x24 },
     { 0x09, 0x04 },
     { 0x25, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LogicOp
 // ******************************************************************
 //18C700BC1704
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LogicOp,
+                         1036)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x34, XREF_D3DRS_LOGICOP ),
 
@@ -448,17 +489,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1036, 7)
     { 0x23, 0xBC },
     { 0x24, 0x17 },
     { 0x25, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
 //C1E11083E20F
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1036, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                      1036,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEANTIALIAS),
 
@@ -470,17 +513,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1036, 1 + 7,
     { 0x40, 0x83 },
     { 0x41, 0xE2 },
     { 0x42, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
 //83E10FC1E210
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1036, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                      1036,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEMASK),
 
@@ -493,16 +538,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1036, 1 + 8,
     { 0x40, 0xC1 },
     { 0x41, 0xE2 },
     { 0x42, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMode
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMode, 1024, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleMode,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DRS_MULTISAMPLEMODE),
 
@@ -514,16 +561,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMode, 1024, 1 + 5,
     { 0x19, 0x00 },
     { 0x1A, 0x00 },
     { 0x1B, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleRenderTargetMode
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleRenderTargetMode, 1024, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleRenderTargetMode,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DRS_MULTISAMPLERENDERTARGETMODE),
 
@@ -536,14 +585,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleRenderTargetMode, 1024, 1 + 5,
     { 0x1A, 0x00 },
     { 0x1B, 0x74 },
     //{ 0x1C, 0x0D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
 //7003040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1F, 0x33 },
@@ -553,14 +604,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1036, 7)
     { 0x5F, 0x04 },
     { 0x60, 0x00 },
     { 0x61, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FrontFace
 // ******************************************************************
 //00A00304008948
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FrontFace,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -571,14 +624,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1036, 8)
     { 0x22, 0x00 },
     { 0x23, 0x89 },
     { 0x24, 0x48 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateTexture2
 // ******************************************************************
 //F744241C0000010074
-OOVPA_NO_XREF(D3DDevice_CreateTexture2, 1036, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateTexture2,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x56 },
@@ -592,17 +647,19 @@ OOVPA_NO_XREF(D3DDevice_CreateTexture2, 1036, 11)
     { 0x3D, 0x01 },
     { 0x3E, 0x00 },
     { 0x3F, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
 // ******************************************************************
 //0F85..0100008B0D
-OOVPA_XREF(D3DDevice_SetRenderTarget, 1036, 1 + 11,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderTarget,
+                      1036,
 
-           XREF_D3DDevice_SetRenderTarget,
-           XRefOne)
-{
+                      XREF_D3DDevice_SetRenderTarget,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4F, XREF_D3DRS_MULTISAMPLEMODE),
 
@@ -620,14 +677,16 @@ OOVPA_XREF(D3DDevice_SetRenderTarget, 1036, 1 + 11,
     { 0x4E, 0x0D },
 
     { 0x53, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeleteVertexShader
 // ******************************************************************
 //FF08750D8B480485C9740650E8 ...C3
-OOVPA_NO_XREF(D3DDevice_DeleteVertexShader_0, 2024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeleteVertexShader_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x48 },
@@ -642,14 +701,16 @@ OOVPA_NO_XREF(D3DDevice_DeleteVertexShader_0, 2024, 12)
     { 0x0A, 0xE8 },
 
     { 0x0F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DSurface_GetDesc
 //******************************************************************
 //578B7C241033DBE8
-OOVPA_NO_XREF(D3DSurface_GetDesc, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DSurface_GetDesc,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -661,14 +722,16 @@ OOVPA_NO_XREF(D3DSurface_GetDesc, 1024, 9)
     { 0x0B, 0x33 },
     { 0x0C, 0xDB },
     { 0x0D, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* Lock2DSurface
 //******************************************************************
 //2418F6C320558B ...C21000
-OOVPA_NO_XREF(Lock2DSurface_16, 2048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(Lock2DSurface_16,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x53 },
     { 0x04, 0x24 },
@@ -678,14 +741,16 @@ OOVPA_NO_XREF(Lock2DSurface_16, 2048, 8)
     { 0x08, 0x20 },
     { 0x09, 0x55 },
     { 0x0A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* Lock3DSurface
 //******************************************************************
 //83EC08538A5C241CF6C32055 ...C21000
-OOVPA_NO_XREF(Lock3DSurface_16, 2048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(Lock3DSurface_16,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -699,14 +764,16 @@ OOVPA_NO_XREF(Lock3DSurface_16, 2048, 12)
     { 0x09, 0xC3 },
     { 0x0A, 0x20 },
     { 0x0B, 0x55 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //568BC8C1E106578DBC ...C3
-OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -723,14 +790,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2048, 13)
     { 0x10, 0x19 },
 
     { 0x103, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2072, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+                         2072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -747,14 +816,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2072, 13)
     { 0x74, 0x08 },
 
     { 0x79, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeletePixelShader
 // ******************************************************************
 //FF08750D8B480485C9740650E8 ...C3
-OOVPA_NO_XREF(D3DDevice_DeletePixelShader_0, 2024, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeletePixelShader_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xFF },
     { 0x01, 0x08 },
@@ -772,14 +843,16 @@ OOVPA_NO_XREF(D3DDevice_DeletePixelShader_0, 2024, 15)
 
     { 0x10, 0xFF },
     { 0x11, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_GetType
 // ******************************************************************
 //3D00000300772274 ...C3
-OOVPA_NO_XREF(D3DResource_GetType_0, 2024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_GetType_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x01 },
@@ -794,17 +867,19 @@ OOVPA_NO_XREF(D3DResource_GetType_0, 2024, 11)
     { 0x0E, 0x74 },
 
     { 0x0F, 0x1A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnResource
 // ******************************************************************
 //F7C20000780075 ...C3
-OOVPA_XREF(D3D_BlockOnResource_0, 2036, 9,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnResource_0,
+                      2036,
 
-           XREF_D3D_BlockOnResource,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnResource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x02, 0x35 },
@@ -816,14 +891,16 @@ OOVPA_XREF(D3D_BlockOnResource_0, 2036, 9,
     { 0x26, 0x78 },
     { 0x27, 0x00 },
     { 0x28, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Begin
 // ******************************************************************
 //814E08000800005EC204
-OOVPA_NO_XREF(D3DDevice_Begin, 1048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Begin,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -838,14 +915,16 @@ OOVPA_NO_XREF(D3DDevice_Begin, 1048, 12)
     { 0x37, 0x5E },
     { 0x38, 0xC2 },
     { 0x39, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer
 // ******************************************************************
 //7507B801000000EB07F7 ...C20800
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer_8, 2048, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer_8,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xF8 },
@@ -863,14 +942,16 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer_8, 2048, 14)
 
     { 0x4C, 0xC2 },
     { 0x4D, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2s
 // ******************************************************************
 //8D....00190400
-OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2s,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -882,14 +963,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 1024, 7)
     { 0x21, 0x19 },
     { 0x22, 0x04 },
     { 0x23, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2f
 // ******************************************************************
 //8D....801808008B
-OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2f,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1D, 0x8D },
@@ -899,14 +982,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 1024, 7)
     { 0x22, 0x08 },
     { 0x23, 0x00 },
     { 0x24, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
 //B918150000EB09 ...C21000
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f_16, 2024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f_16,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -918,14 +1003,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f_16, 2024, 9)
     { 0x22, 0x00 },
     { 0x23, 0xEB },
     { 0x24, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4s
 // ******************************************************************
 //801908000FBF
-OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4s,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -935,14 +1022,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 1024, 7)
     { 0x23, 0x00 },
     { 0x24, 0x0F },
     { 0x25, 0xBF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4ub
 // ******************************************************************
 //8D....4019040033
-OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4ub,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x1D, 0x8D },
@@ -952,14 +1041,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 1024, 7)
     { 0x22, 0x04 },
     { 0x23, 0x00 },
     { 0x24, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexDataColor
 // ******************************************************************
 //0C8D....40190400
-OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexDataColor,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -970,16 +1061,18 @@ OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1024, 8)
     { 0x26, 0x19 },
     { 0x27, 0x04 },
     { 0x28, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D::SetFence
 // ******************************************************************
-OOVPA_XREF(D3D_SetFence, 1024, 9,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      1024,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -991,14 +1084,16 @@ OOVPA_XREF(D3D_SetFence, 1024, 9,
     { 0x29, 0x48 },
     { 0x2A, 0x14 },
     { 0x2B, 0xC7 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_MultiplyTransform
 // ******************************************************************
 //558BEC83E4F081EC8800000056578BF0 ...C3
-OOVPA_NO_XREF(D3DDevice_MultiplyTransform_0, 2024, 23)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_MultiplyTransform_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1023,14 +1118,16 @@ OOVPA_NO_XREF(D3DDevice_MultiplyTransform_0, 2024, 23)
     { 0x14, 0x00 },
     { 0x15, 0x8D },
     { 0x16, 0x7C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetIndices
 // ******************************************************************
 //74108103000008008B
-OOVPA_NO_XREF(D3DDevice_SetIndices, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetIndices,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -1044,17 +1141,19 @@ OOVPA_NO_XREF(D3DDevice_SetIndices, 1024, 11)
     { 0x15, 0x08 },
     { 0x16, 0x00 },
     { 0x17, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
 // ******************************************************************
 //7406810300000800 ...C20800
-OOVPA_XREF(D3DDevice_SetStreamSource_8, 2040, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetStreamSource_8,
+                      2040,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x23, XREF_G_STREAM), // Derived
 
@@ -1069,14 +1168,16 @@ OOVPA_XREF(D3DDevice_SetStreamSource_8, 2040, 1 + 10,
     { 0x18, 0x00 },
     { 0x19, 0x08 },
     { 0x1A, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderInput
 // ******************************************************************
 //8B44240483EC4085C0538B1D
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderInput, 1024, 18)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderInput,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -1097,14 +1198,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderInput, 1024, 18)
     { 0x1D, 0xFF },
     { 0x1E, 0xBF },
     { 0x1F, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LightEnable_4
 // ******************************************************************
 //F64401680175 ...C20400
-OOVPA_NO_XREF(D3DDevice_LightEnable_4, 2024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LightEnable_4,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -1115,14 +1218,16 @@ OOVPA_NO_XREF(D3DDevice_LightEnable_4, 2024, 8)
     { 0x24, 0x68 },
     { 0x25, 0x01 },
     { 0x26, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
 //C700B402040089
-OOVPA_NO_XREF(D3DDevice_SetScissors, 1060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -1133,14 +1238,16 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 1060, 8)
     { 0x75, 0x02 },
     { 0x76, 0x04 },
     { 0x77, 0x00 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_DrawVerticesUP
 //******************************************************************
 //C1E21281C21818004081FF
-OOVPA_NO_XREF(D3DDevice_DrawVerticesUP, 1048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVerticesUP,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1156,14 +1263,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVerticesUP, 1048, 13)
     { 0xE3, 0x40 },
     { 0xE4, 0x81 },
     { 0xE5, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
 //8B4D148B560883
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1072, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVerticesUP,
+                         1072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0xF8 },
@@ -1175,14 +1284,16 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1072, 9)
     { 0x37, 0x56 },
     { 0x38, 0x08 },
     { 0x39, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
 //C7009C1E0400894804 ...C20400
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader_4, 2036, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader_4,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -1196,14 +1307,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader_4, 2036, 11)
     { 0x56, 0x89 },
     { 0x57, 0x48 },
     { 0x58, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShaderProgram
 // ******************************************************************
 //18C7009C1E0400
-OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShaderProgram,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x54 },
@@ -1215,14 +1328,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 1048, 9)
     { 0x66, 0x1E },
     { 0x67, 0x04 },
     { 0x68, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVertices
 // ******************************************************************
 //1018004081FF0001 ...C20800
-OOVPA_NO_XREF(D3DDevice_DrawVertices_8, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVertices_8,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -1235,14 +1350,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVertices_8, 2024, 10)
     { 0x62, 0xFF },
     { 0x63, 0x00 },
     { 0x64, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2036, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -1259,4 +1376,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2036, 13)
 
     { 0xFB, 0x5B },
     { 0xFC, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/4432.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4432.inl
@@ -27,11 +27,12 @@
 // * D3D_SetFence
 // ******************************************************************
 //460457720EA1
-OOVPA_XREF(D3D_SetFence, 1036, 8,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      1036,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x0D, 0x8B },
@@ -42,14 +43,16 @@ OOVPA_XREF(D3D_SetFence, 1036, 8,
     { 0x13, 0x72 },
     { 0x14, 0x0E },
     { 0x15, 0xA1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Direct3D_CreateDevice
 // ******************************************************************
 //00000800A1
-OOVPA_NO_XREF(Direct3D_CreateDevice, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x06, 0xC0 },
@@ -59,17 +62,19 @@ OOVPA_NO_XREF(Direct3D_CreateDevice, 1024, 7)
     { 0x11, 0x08 },
     { 0x12, 0x00 },
     { 0x13, 0xA1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
 // ******************************************************************
 //7406810300000800
-OOVPA_XREF(D3DDevice_SetStreamSource, 1044, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetStreamSource,
+                      1044,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x22, XREF_G_STREAM), // Derived
 
@@ -84,17 +89,19 @@ OOVPA_XREF(D3DDevice_SetStreamSource, 1044, 1 + 10,
     { 0x13, 0x00 },
     { 0x14, 0x08 },
     { 0x15, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //8BC3C1E007578B3D
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 1944, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex,
+                      1944,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -109,17 +116,19 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 1944, 1 + 10,
     { 0x10, 0x57 },
     { 0x11, 0x8B },
     { 0x12, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_CullMode
 // ******************************************************************
 //C7000803040075
-OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1052, 2 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_CullMode,
+                      1052,
 
-           XREF_D3DDevice_SetRenderState_CullMode,
-           XRefTwo)
-{
+                      XREF_D3DDevice_SetRenderState_CullMode,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
     XREF_ENTRY(0x34, XREF_D3DRS_CULLMODE), // Derived
@@ -133,14 +142,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1052, 2 + 8,
     { 0x26, 0x04 },
     { 0x27, 0x00 },
     { 0x28, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_NormalizeNormals
 // ******************************************************************
 //A4030400894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -151,14 +162,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1048, 8)
     { 0x26, 0x89 },
     { 0x27, 0x48 },
     { 0x28, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
 //C9C7000C0304008948048B
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -174,14 +187,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1048, 13)
     { 0x3E, 0x48 },
     { 0x3F, 0x04 },
     { 0x40, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
 //018b54240885d2c700
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -194,14 +209,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1048, 10)
     { 0x55, 0xD2 },
     { 0x56, 0xC7 },
     { 0x57, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FillMode
 // ******************************************************************
 //C98B4C24087502
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FillMode,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0x06 },
@@ -213,14 +230,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1048, 9)
     { 0x2D, 0x08 },
     { 0x2E, 0x75 },
     { 0x2F, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FogColor
 // ******************************************************************
 //54240E8BF981
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FogColor,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -230,14 +249,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1048, 7)
     { 0x26, 0x8B },
     { 0x27, 0xF9 },
     { 0x28, 0x81 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ShadowFunc
 // ******************************************************************
 //6C1E04008D91
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ShadowFunc,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -248,14 +269,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1048, 8)
     { 0x25, 0x00 },
     { 0x26, 0x8D },
     { 0x27, 0x91 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_EdgeAntiAlias
 // ******************************************************************
 //0020030800894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1D, 0x4C },
@@ -268,14 +291,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1048, 10)
     { 0x26, 0x89 },
     { 0x27, 0x48 },
     { 0x28, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //E00A040089
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1D, 0x4C },
@@ -285,14 +310,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 1036, 7)
     { 0x25, 0x04 },
     { 0x26, 0x00 },
     { 0x27, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_VertexBlend
 // ******************************************************************
 //81CA00020000568B35
-OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_VertexBlend,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x15 },
@@ -306,14 +333,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_VertexBlend, 1024, 11)
     { 0x0C, 0x56 },
     { 0x0D, 0x8B },
     { 0x0E, 0x35 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
 //81CA001000008915
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x15 },
 
@@ -325,14 +354,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1048, 9)
     { 0x16, 0x00 },
     { 0x17, 0x89 },
     { 0x18, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LogicOp
 // ******************************************************************
 //18C700BC1704
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LogicOp,
+                         1048)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x34, XREF_D3DRS_LOGICOP ),
 
@@ -344,17 +375,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1048, 7)
     { 0x26, 0xBC },
     { 0x27, 0x17 },
     { 0x28, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
 //C1E11083E20F
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1048, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                      1048,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEANTIALIAS),
 
@@ -366,17 +399,19 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1048, 1 + 7,
     { 0x3E, 0x83 },
     { 0x3F, 0xE2 },
     { 0x40, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
 //83E10FC1E210
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1048, 1 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                      1048,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEMASK),
 
@@ -389,14 +424,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1048, 1 + 8,
     { 0x3E, 0xC1 },
     { 0x3F, 0xE2 },
     { 0x40, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
 //7003040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x22, 0x33 },
@@ -406,14 +443,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1048, 7)
     { 0x62, 0x04 },
     { 0x63, 0x00 },
     { 0x64, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FrontFace
 // ******************************************************************
 //00A00304008948
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FrontFace,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -424,14 +463,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1048, 8)
     { 0x25, 0x00 },
     { 0x26, 0x89 },
     { 0x27, 0x48 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetRenderState_BackFillMode
 //******************************************************************
 //8B063B4604578B
-OOVPA_NO_XREF(D3DDevice_SetRenderState_BackFillMode, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_BackFillMode,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x44 },
 
@@ -442,14 +483,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_BackFillMode, 1036, 8)
     { 0x14, 0x04 },
     { 0x15, 0x57 },
     { 0x16, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateTexture
 // ******************************************************************
 //206A00508B44241451
-OOVPA_NO_XREF(D3DDevice_CreateTexture, 1024, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateTexture,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -467,14 +510,16 @@ OOVPA_NO_XREF(D3DDevice_CreateTexture, 1024, 14)
     { 0x29, 0x5F },
     { 0x2A, 0xC2 },
     { 0x2B, 0x1C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_End
 // ******************************************************************
 //816608FFE7FFFF5EC3
-OOVPA_NO_XREF(D3DDevice_End, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_End,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -487,7 +532,8 @@ OOVPA_NO_XREF(D3DDevice_End, 1036, 10)
     { 0x43, 0xFF },
     { 0x44, 0x5E },
     { 0x45, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetLevelDesc
@@ -496,8 +542,9 @@ OOVPA_NO_XREF(D3DDevice_End, 1036, 10)
 // *       GetLevelDesc Simply redirects to that function
 // ******************************************************************
 //7909C74608010000 ...C3
-OOVPA_NO_XREF(Get2DSurfaceDesc_0, 2036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(Get2DSurfaceDesc_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x0F },
     { 0x01, 0xB6 },
@@ -510,14 +557,16 @@ OOVPA_NO_XREF(Get2DSurfaceDesc_0, 2036, 10)
     { 0x2E, 0x01 },
     { 0x2F, 0x00 },
     { 0x30, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //8B442404A810538B1D
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -530,17 +579,19 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode, 1024, 10)
     { 0x08, 0x1D },
 
     { 0x1F, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
 //F6C30155568B35
-OOVPA_XREF(D3DDevice_SetVertexShader, 1036, 1 + 13,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader,
+                      1036,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived (OK, yet unverified)
 
@@ -557,14 +608,16 @@ OOVPA_XREF(D3DDevice_SetVertexShader, 1036, 1 + 13,
     { 0x0A, 0x56 },
     { 0x0B, 0x8B },
     { 0x0C, 0x35 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstant
 // ******************************************************************
 //83C160C1E202A810
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstant,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -577,14 +630,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstant, 1024, 10)
     { 0x19, 0x02 },
     { 0x1A, 0xA8 },
     { 0x1B, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVertices
 // ******************************************************************
 //56576A0053E8
-OOVPA_NO_XREF(D3DDevice_DrawVertices, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVertices,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -594,14 +649,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVertices, 1024, 7)
     { 0x0A, 0x00 },
     { 0x0B, 0x53 },
     { 0x0C, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Clear
 // ******************************************************************
 //FFFDFFFF8944
-OOVPA_NO_XREF(D3DDevice_Clear, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Clear,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -612,14 +669,16 @@ OOVPA_NO_XREF(D3DDevice_Clear, 1024, 8)
     { 0x43, 0xFF },
     { 0x44, 0x89 },
     { 0x45, 0x44 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDepthStencilSurface
 // ******************************************************************
 //B866087688..C20400
-OOVPA_NO_XREF(D3DDevice_GetDepthStencilSurface, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDepthStencilSurface,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -632,14 +691,16 @@ OOVPA_NO_XREF(D3DDevice_GetDepthStencilSurface, 1024, 9)
     { 0x46, 0xC2 },
     { 0x47, 0x04 },
     { 0x48, 0x00 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetTile
 //******************************************************************
 //B9060000008D7C2410F3 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTile_0, 2036, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -654,17 +715,19 @@ OOVPA_NO_XREF(D3DDevice_SetTile_0, 2036, 12)
     { 0x23, 0x24 },
     { 0x24, 0x10 },
     { 0x25, 0xF3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
 // ******************************************************************
 //5533ED3BD5565775
-OOVPA_XREF(D3DDevice_SetRenderTarget, 1048, 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderTarget,
+                      1048,
 
-           XREF_D3DDevice_SetRenderTarget,
-           XRefZero)
-{
+                      XREF_D3DDevice_SetRenderTarget,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x54 },
@@ -677,14 +740,16 @@ OOVPA_XREF(D3DDevice_SetRenderTarget, 1048, 10,
     { 0x13, 0x56 },
     { 0x14, 0x57 },
     { 0x15, 0x75 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_LoadVertexShader
 //******************************************************************
 //C7009C1E040089 ...C3
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_ecx_Handle, 2036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_ecx_Handle,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x55 },
@@ -696,14 +761,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_ecx_Handle, 2036, 9
     { 0x5D, 0x04 },
     { 0x5E, 0x00 },
     { 0x5F, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2f
 // ******************************************************************
 //8D....801808008B
-OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2f,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x20, 0x8D },
@@ -713,14 +780,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 1036, 7)
     { 0x25, 0x08 },
     { 0x26, 0x00 },
     { 0x27, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
 //B918150000EB09
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -732,14 +801,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 1024, 9)
     { 0x29, 0x00 },
     { 0x2A, 0xEB },
     { 0x2B, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DCubeTexture_GetCubeMapSurface2
 // ******************************************************************
 //83EC08578B7C24108D
-OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface2, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DCubeTexture_GetCubeMapSurface2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -750,14 +821,16 @@ OOVPA_NO_XREF(D3DCubeTexture_GetCubeMapSurface2, 1024, 9)
     { 0x06, 0x24 },
     { 0x07, 0x10 },
     { 0x08, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_GetType
 // ******************************************************************
 //7728741E85C0
-OOVPA_NO_XREF(D3DResource_GetType, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_GetType,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x4C },
@@ -768,14 +841,16 @@ OOVPA_NO_XREF(D3DResource_GetType, 1024, 8)
     { 0x13, 0x1E },
     { 0x14, 0x85 },
     { 0x15, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Begin
 // ******************************************************************
 //814E08000800005EC204
-OOVPA_NO_XREF(D3DDevice_Begin, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Begin,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -790,14 +865,16 @@ OOVPA_NO_XREF(D3DDevice_Begin, 1024, 12)
     { 0x3A, 0x5E },
     { 0x3B, 0xC2 },
     { 0x3C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderConstant
 // ******************************************************************
 //44242085C08974240C894C24
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 1024, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderConstant,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -814,14 +891,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 1024, 14)
     { 0x1D, 0x89 },
     { 0x1E, 0x4C },
     { 0x1F, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetViewportOffsetAndScale_0
 // ******************************************************************
 //000085F6577D06D805 ...C3
-OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale_0, 2024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetViewportOffsetAndScale_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0xDB },
@@ -835,14 +914,16 @@ OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale_0, 2024, 11)
     { 0x19, 0x06 },
     { 0x1A, 0xD8 },
     { 0x1B, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVerticesUP
 // ******************************************************************
 //8B4D08C700FC17040089
-OOVPA_NO_XREF(D3DDevice_DrawVerticesUP, 1060, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVerticesUP,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -857,14 +938,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVerticesUP, 1060, 12)
     { 0x31, 0x04 },
     { 0x32, 0x00 },
     { 0x33, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
 //C700B402040089
-OOVPA_NO_XREF(D3DDevice_SetScissors, 1072, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         1072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -875,14 +958,16 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 1072, 8)
     { 0x77, 0x02 },
     { 0x78, 0x04 },
     { 0x79, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //04C700941E080083 ...C3
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -898,14 +983,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2024, 12)
 
     { 0x84, 0x5E },
     { 0x85, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPushBuffer
 // ******************************************************************
 //008107000008008B
-OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPushBuffer,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -918,14 +1005,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 1036, 10)
     { 0x4D, 0x08 },
     { 0x4E, 0x00 },
     { 0x4F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndPushBuffer
 // ******************************************************************
 //B82908768859
-OOVPA_NO_XREF(D3DDevice_EndPushBuffer, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EndPushBuffer,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x56 },
@@ -938,14 +1027,16 @@ OOVPA_NO_XREF(D3DDevice_EndPushBuffer, 1036, 9)
     { 0x50, 0xFF },
     { 0x51, 0xFF },
     { 0x52, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
 //81E1FFFFFF0F4189 ...C20800
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -958,14 +1049,16 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 1024, 10)
     { 0x95, 0x0F },
     { 0x96, 0x41 },
     { 0x97, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PersistDisplay
 // ******************************************************************
 //85C0740F50FF15
-OOVPA_NO_XREF(D3DDevice_PersistDisplay, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_PersistDisplay,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x53 },
@@ -978,14 +1071,16 @@ OOVPA_NO_XREF(D3DDevice_PersistDisplay, 1024, 10)
     { 0x34, 0x5B },
     { 0x35, 0x59 },
     { 0x36, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetGammaRamp
 // ******************************************************************
 //C78498DC07000001000000
-OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 1036, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetGammaRamp,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
@@ -1000,4 +1095,5 @@ OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 1036, 12)
     { 0x35, 0x10 },
     { 0x36, 0x02 },
     { 0x37, 0x89 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/4531.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4531.inl
@@ -27,11 +27,12 @@
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //51538B5C240C8BC6C1E0 ...C20400
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2045, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex_4,
+                      2045,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x14, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -46,14 +47,16 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2045, 1 + 10,
     { 0x10, 0xE0 },
     { 0x11, 0x07 },
     { 0x12, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //8BCEC1E10681C1241B04 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_4, 2060, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor_4,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -67,14 +70,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_4, 2060, 10)
     { 0x2D, 0x24 },
 
     { 0x47, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //8D0CB5E00A0400 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_4, 2060, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_4,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -87,14 +92,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_4, 2060, 9)
     { 0x2C, 0x00 },
 
     { 0x43, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZBias
 // ******************************************************************
 //24..8BF07D06D805
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZBias,
+                         1036)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x6A, XREF_D3DRS_ZBIAS ),
 
@@ -109,14 +116,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1036, 9)
     { 0x1B, 0x06 },
     { 0x1C, 0xD8 },
     { 0x1D, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
 //7505BB050000008B ...C3
-OOVPA_NO_XREF(D3DDevice_Swap_0, 2024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -128,14 +137,16 @@ OOVPA_NO_XREF(D3DDevice_Swap_0, 2024, 9)
     { 0x11, 0x00 },
     { 0x12, 0x00 },
     { 0x13, 0x8B },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SelectVertexShader
 //******************************************************************
 //04C700941E080083 ...C20400
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_4, 2048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -151,14 +162,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_4, 2048, 12)
 
     { 0x95, 0xC2 },
     { 0x96, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMiniport_InitHardware
 // ******************************************************************
 //558BEC83EC1053578BF85768
-OOVPA_NO_XREF(CMiniport_InitHardware, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMiniport_InitHardware,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -172,14 +185,16 @@ OOVPA_NO_XREF(CMiniport_InitHardware, 1024, 12)
     { 0x09, 0xF8 },
     { 0x0A, 0x57 },
     { 0x0B, 0x68 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetFlickerFilter
 // ******************************************************************
 //6A00566A0B50FF15 ...C3
-OOVPA_NO_XREF(D3DDevice_SetFlickerFilter_0, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetFlickerFilter_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
@@ -192,14 +207,16 @@ OOVPA_NO_XREF(D3DDevice_SetFlickerFilter_0, 2024, 10)
     { 0x22, 0x50 },
     { 0x23, 0xFF },
     { 0x24, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -216,14 +233,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2024, 13)
     { 0x76, 0x08 },
 
     { 0x7B, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPushBuffer
 // ******************************************************************
 //008107000008008B
-OOVPA_NO_XREF(D3DDevice_BeginPushBuffer_0, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPushBuffer_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -236,14 +255,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPushBuffer_0, 2048, 10)
     { 0x48, 0x08 },
     { 0x49, 0x00 },
     { 0x4A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
 //00576A00568BF8E8 ...C20400
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer_4, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -256,14 +277,16 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer_4, 2048, 10)
     { 0x0F, 0x8B },
     { 0x10, 0xF8 },
     { 0x11, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVertices
 // ******************************************************************
 //81C2000200003BCA7223A1 ...C20800
-OOVPA_NO_XREF(D3DDevice_DrawVertices_8, 2048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVertices_8,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -279,14 +302,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVertices_8, 2048, 13)
     { 0x31, 0x72 },
     { 0x32, 0x23 },
     { 0x33, 0xA1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexDataColor
 // ******************************************************************
 //0C8D....40190400
-OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexDataColor,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -297,14 +322,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1036, 8)
     { 0x29, 0x19 },
     { 0x2A, 0x04 },
     { 0x2B, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -321,4 +348,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2048, 13)
 
     { 0xFE, 0x5B },
     { 0xFF, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/4627.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4627.inl
@@ -27,8 +27,9 @@
 // * Direct3D_CreateDevice
 // ******************************************************************
 //85C9750AC705 ...C21000
-OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDeviceInterface, 2036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDeviceInterface,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -40,7 +41,8 @@ OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDev
     { 0x0F, 0x05 },
 
     { 0x3A, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetLevelDesc
@@ -49,8 +51,9 @@ OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDev
 // *       GetLevelDesc Simply redirects to that function
 // ******************************************************************
 //7909C74608010000 ...C20400
-OOVPA_NO_XREF(Get2DSurfaceDesc_4, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(Get2DSurfaceDesc_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x0F },
     { 0x01, 0xB6 },
@@ -63,14 +66,16 @@ OOVPA_NO_XREF(Get2DSurfaceDesc_4, 2048, 10)
     { 0x34, 0x01 },
     { 0x35, 0x00 },
     { 0x36, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZBias
 // ******************************************************************
 //24..8BF07D06D805
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1060, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZBias,
+                         1060)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x6A, XREF_D3DRS_ZBIAS ),
 
@@ -85,16 +90,18 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1060, 9)
     { 0x1D, 0x06 },
     { 0x1E, 0xD8 },
     { 0x1F, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleAntiAlias
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1060, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias,
+                      1060,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0D, XREF_D3DRS_MULTISAMPLEANTIALIAS),
 
@@ -105,16 +112,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleAntiAlias, 1060, 1 + 7,
     { 0x04, 0x56 },
     { 0x05, 0x8B },
     { 0x06, 0x35 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1060, 1 + 6,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                      1060,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_MULTISAMPLEMASK),
 
@@ -124,16 +133,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1060, 1 + 6,
     { 0x04, 0x57 },
     { 0x05, 0x8B },
     { 0x06, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_MultiSampleMask
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1072, 1 + 6,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_MultiSampleMask,
+                      1072,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_D3DRS_MULTISAMPLEMASK),
 
@@ -143,16 +154,18 @@ OOVPA_XREF(D3DDevice_SetRenderState_MultiSampleMask, 1072, 1 + 6,
     { 0x11, 0x10 },
     { 0x12, 0x56 },
     { 0x13, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_SampleAlpha
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderState_SampleAlpha, 1024, 1 + 4,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_SampleAlpha,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_D3DRS_SAMPLEALPHA),
 
@@ -160,14 +173,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_SampleAlpha, 1024, 1 + 4,
     { 0x04, 0x57 },
     { 0x05, 0x8B },
     { 0x06, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_SampleAlpha
 // ******************************************************************
 //C1E610578B3D
-OOVPA_NO_XREF(D3DDevice_SetRenderState_SampleAlpha, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_SampleAlpha,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -178,14 +193,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_SampleAlpha, 1036, 8)
     { 0x0E, 0x57 },
     { 0x0F, 0x8B },
     { 0x10, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //088BD1C1E20681C2241B
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -199,14 +216,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 1024, 11)
     { 0x26, 0xC2 },
     { 0x27, 0x24 },
     { 0x28, 0x1B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BumpEnv
 // ******************************************************************
 //8d5e01f6c303
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BumpEnv,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x56 },
 
@@ -216,17 +235,19 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BumpEnv, 1024, 7)
     { 0x1D, 0xF6 },
     { 0x1E, 0xC3 },
     { 0x1F, 0x03 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //c1e0078998
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 1958, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex,
+                      1958,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -242,17 +263,19 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex, 1958, 1 + 10,
     { 0x1D, 0x8B },
     { 0x1E, 0x06 },
     { 0x1F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CommonSetRenderTarget
 // ******************************************************************
 //83FD0C742683FD0D7E
-OOVPA_XREF(D3D_CommonSetRenderTarget, 1036, 11,
+OOVPA_SIG_HEADER_XREF(D3D_CommonSetRenderTarget,
+                      1036,
 
-           XREF_D3D_CommonSetRenderTarget,
-           XRefZero)
-{
+                      XREF_D3D_CommonSetRenderTarget,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -266,14 +289,16 @@ OOVPA_XREF(D3D_CommonSetRenderTarget, 1036, 11,
     { 0x46, 0xFD },
     { 0x47, 0x0D },
     { 0x48, 0x7E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
 //C700B402040089
-OOVPA_NO_XREF(D3DDevice_SetScissors, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -284,14 +309,16 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 1036, 8)
     { 0x8B, 0x02 },
     { 0x8C, 0x04 },
     { 0x8D, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTexture
 // ******************************************************************
 //81C10000F8FF89
-OOVPA_NO_XREF(D3DDevice_SetTexture, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTexture,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -303,14 +330,16 @@ OOVPA_NO_XREF(D3DDevice_SetTexture, 1024, 9)
     { 0x2C, 0xF8 },
     { 0x2D, 0xFF },
     { 0x2E, 0x89 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_CopyRects
 //******************************************************************
 //81EC940100008B842498
-OOVPA_NO_XREF(D3DDevice_CopyRects, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x81 },
     { 0x01, 0xEC },
@@ -322,13 +351,15 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 1036, 10)
     { 0x07, 0x84 },
     { 0x08, 0x24 },
     { 0x09, 0x98 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_BeginVisibilityTest
 //******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginVisibilityTest,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x06 },
     { 0x1C, 0xC7 },
@@ -338,14 +369,16 @@ OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 1024, 8)
     { 0x20, 0x08 },
     { 0x21, 0x00 },
     { 0x22, 0xB9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateTexture2
 // ******************************************************************
 //F744241C0000010074
-OOVPA_NO_XREF(D3DDevice_CreateTexture2, 1048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateTexture2,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x57 },
@@ -359,14 +392,16 @@ OOVPA_NO_XREF(D3DDevice_CreateTexture2, 1048, 11)
     { 0x43, 0x01 },
     { 0x44, 0x00 },
     { 0x45, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DeleteStateBlock
 // ******************************************************************
 //535556578B7C241433ED33DB
-OOVPA_NO_XREF(D3DDevice_DeleteStateBlock, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeleteStateBlock,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x55 },
@@ -380,14 +415,16 @@ OOVPA_NO_XREF(D3DDevice_DeleteStateBlock, 1024, 12)
     { 0x09, 0xED },
     { 0x0A, 0x33 },
     { 0x0B, 0xDB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
 //8B4D148B560883
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVerticesUP,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0xF8 },
@@ -399,14 +436,16 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1036, 9)
     { 0x3A, 0x56 },
     { 0x3B, 0x08 },
     { 0x3C, 0x83 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_DrawVerticesUP
 //******************************************************************
 //8B8E7C0700008B
-OOVPA_NO_XREF(D3DDevice_DrawVerticesUP, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVerticesUP,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0xEC },
@@ -418,14 +457,16 @@ OOVPA_NO_XREF(D3DDevice_DrawVerticesUP, 1036, 9)
     { 0x3A, 0x00 },
     { 0x3B, 0x00 },
     { 0x3C, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndVisibilityTest
 // ******************************************************************
 //B80E0007805E
-OOVPA_NO_XREF(D3DDevice_EndVisibilityTest, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EndVisibilityTest,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -439,14 +480,16 @@ OOVPA_NO_XREF(D3DDevice_EndVisibilityTest, 1024, 10)
 
     { 0x16, 0xC2 },
     { 0x17, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndVisibilityTest
 // ******************************************************************
 //B80E0007805E ...C3
-OOVPA_NO_XREF(D3DDevice_EndVisibilityTest_0, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EndVisibilityTest_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0xE8 },
@@ -460,14 +503,16 @@ OOVPA_NO_XREF(D3DDevice_EndVisibilityTest_0, 2048, 10)
 
     { 0x12, 0xC3 },
     { 0x13, 0x57 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer2
 // ******************************************************************
 //7507B801000000EB07F7
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer2, 1036, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer2,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -485,14 +530,16 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer2, 1036, 14)
 
     { 0x4C, 0xC2 },
     { 0x4D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer2
 // ******************************************************************
 //7507B801000000EB07F7 ...C3
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer2_0, 2024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer2_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xF8 },
@@ -509,14 +556,16 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer2_0, 2024, 13)
     { 0x12, 0xF7 },
 
     { 0x48, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDepthStencilSurface2
 // ******************************************************************
 //85F6750433C05EC3
-OOVPA_NO_XREF(D3DDevice_GetDepthStencilSurface2, 1048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDepthStencilSurface2,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -529,13 +578,15 @@ OOVPA_NO_XREF(D3DDevice_GetDepthStencilSurface2, 1048, 10)
     { 0x11, 0xC0 },
     { 0x12, 0x5E },
     { 0x13, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_GetDisplayMode
 //******************************************************************
-OOVPA_NO_XREF(D3DDevice_GetDisplayMode, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDisplayMode,
+                         1024)
+OOVPA_SIG_MATCH(
     //8B90181A0000
     { 0x00, 0xA1 },
 
@@ -549,14 +600,16 @@ OOVPA_NO_XREF(D3DDevice_GetDisplayMode, 1024, 9)
     { 0x0E, 0x85 },
     { 0x12, 0x8B },
     { 0x13, 0x4A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetTransform
 // ******************************************************************
 //56C1E106578B7C24108DB4
-OOVPA_NO_XREF(D3DDevice_GetTransform, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetTransform,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -571,14 +624,16 @@ OOVPA_NO_XREF(D3DDevice_GetTransform, 1024, 12)
     { 0x11, 0x10 },
     { 0x12, 0x8D },
     { 0x13, 0xB4 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_IsBusy
 // ******************************************************************
 //8B88BC2300008B90
-OOVPA_NO_XREF(D3DDevice_IsBusy, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_IsBusy,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x8B },
@@ -589,14 +644,16 @@ OOVPA_NO_XREF(D3DDevice_IsBusy, 1024, 9)
     { 0x0A, 0x00 },
     { 0x0B, 0x8B },
     { 0x0C, 0x90 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LightEnable
 // ******************************************************************
 //F64401680175
-OOVPA_NO_XREF(D3DDevice_LightEnable, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LightEnable,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -607,14 +664,16 @@ OOVPA_NO_XREF(D3DDevice_LightEnable, 1024, 8)
     { 0x26, 0x68 },
     { 0x27, 0x01 },
     { 0x28, 0x75 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_LoadVertexShaderProgram
 //******************************************************************
 //8B542404530FB75A0255
-OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShaderProgram,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x54 },
@@ -626,14 +685,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 1036, 10)
     { 0x07, 0x5A },
     { 0x08, 0x02 },
     { 0x09, 0x55 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PersistDisplay
 // ******************************************************************
 //85C0740F50FF15
-OOVPA_NO_XREF(D3DDevice_PersistDisplay, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_PersistDisplay,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -645,14 +706,16 @@ OOVPA_NO_XREF(D3DDevice_PersistDisplay, 1048, 9)
     { 0x11, 0x50 },
     { 0x12, 0xFF },
     { 0x13, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Reset
 // ******************************************************************
 //803F6A006A036A006A00E8
-OOVPA_NO_XREF(D3DDevice_Reset, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -665,14 +728,16 @@ OOVPA_NO_XREF(D3DDevice_Reset, 1024, 10)
     { 0x9E, 0x80 },
     { 0x9F, 0x3F },
     { 0xA0, 0x6A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Reset
 // ******************************************************************
 //803F6A006A036A006A00E8 ...C3
-OOVPA_NO_XREF(D3DDevice_Reset_0, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -685,14 +750,16 @@ OOVPA_NO_XREF(D3DDevice_Reset_0, 2024, 10)
     { 0x97, 0x80 },
     { 0x98, 0x3F },
     { 0x99, 0x6A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunVertexStateShader
 // ******************************************************************
 //C740EC801E1000D9 ...C20400
-OOVPA_NO_XREF(D3DDevice_RunVertexStateShader_4, 2048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunVertexStateShader_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x57 },
 
@@ -704,14 +771,16 @@ OOVPA_NO_XREF(D3DDevice_RunVertexStateShader_4, 2048, 9)
     { 0x33, 0x10 },
     { 0x34, 0x00 },
     { 0x35, 0xD9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetGammaRamp
 // ******************************************************************
 //C78498DC07000001000000
-OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 1024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetGammaRamp,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x15 },
@@ -727,14 +796,16 @@ OOVPA_NO_XREF(D3DDevice_SetGammaRamp, 1024, 13)
     { 0x76, 0x00 },
     { 0x77, 0x00 },
     { 0x78, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008
-OOVPA_NO_XREF(D3DDevice_SetPixelShader, 1036, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x53 },
@@ -749,14 +820,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader, 1036, 12)
     { 0x7D, 0x83 },
     { 0x7E, 0xC0 },
     { 0x7F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2036, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x85 },
@@ -773,14 +846,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2036, 13)
     { 0x7B, 0x08 },
 
     { 0x80, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //568BC8C1E106578DBC
-OOVPA_NO_XREF(D3DDevice_SetTransform, 1024, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -798,14 +873,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform, 1024, 14)
 
     { 0x51, 0xDF },
     { 0x52, 0xE0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2s
 // ******************************************************************
 //8D....00190400
-OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2s,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -817,14 +894,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 1036, 7)
     { 0x24, 0x19 },
     { 0x25, 0x04 },
     { 0x26, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
 //B918150000EB09 ...C21000
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f_16, 2036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f_16,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -836,14 +915,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f_16, 2036, 9)
     { 0x25, 0x00 },
     { 0x26, 0xEB },
     { 0x27, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4s
 // ******************************************************************
 //801908000FBF
-OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4s,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -853,14 +934,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 1036, 7)
     { 0x26, 0x00 },
     { 0x27, 0x0F },
     { 0x28, 0xBF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4ub
 // ******************************************************************
 //8D....4019040033
-OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4ub,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x20, 0x8D },
@@ -870,14 +953,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 1036, 7)
     { 0x25, 0x04 },
     { 0x26, 0x00 },
     { 0x27, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
 //7505BB050000008B
-OOVPA_NO_XREF(D3DDevice_Swap, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -889,14 +974,16 @@ OOVPA_NO_XREF(D3DDevice_Swap, 1024, 9)
     { 0x2D, 0x00 },
     { 0x2E, 0x00 },
     { 0x2F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DPalette_Lock2
 //******************************************************************
 //F6442408A0568B74
-OOVPA_NO_XREF(D3DPalette_Lock2, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DPalette_Lock2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xF6 },
     { 0x01, 0x44 },
@@ -906,14 +993,16 @@ OOVPA_NO_XREF(D3DPalette_Lock2, 1024, 8)
     { 0x05, 0x56 },
     { 0x06, 0x8B },
     { 0x07, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_LockRect
 // ******************************************************************
 //8B4424148B4C24088B542404568B
-OOVPA_NO_XREF(D3DTexture_LockRect, 1024, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DTexture_LockRect,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -929,7 +1018,8 @@ OOVPA_NO_XREF(D3DTexture_LockRect, 1024, 14)
     { 0x0B, 0x04 },
     { 0x0C, 0x56 },
     { 0x0D, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // Verteks 11/03/2009
 // blueshogun96 7/17/2010
@@ -937,8 +1027,9 @@ OOVPA_NO_XREF(D3DTexture_LockRect, 1024, 14)
 // * D3DVertexBuffer_Lock2
 // ******************************************************************
 //0CF6C3105675
-OOVPA_NO_XREF(D3DVertexBuffer_Lock2, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DVertexBuffer_Lock2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8A },
     { 0x04, 0x0C },
@@ -948,17 +1039,19 @@ OOVPA_NO_XREF(D3DVertexBuffer_Lock2, 1024, 8)
     { 0x08, 0x56 },
     { 0x09, 0x75 },
     { 0x11, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnResource
 // ******************************************************************
 //F7C20000780075 ...C3
-OOVPA_XREF(D3D_BlockOnResource_0, 2048, 9,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnResource_0,
+                      2048,
 
-           XREF_D3D_BlockOnResource,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnResource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x02, 0x35 },
@@ -970,17 +1063,19 @@ OOVPA_XREF(D3D_BlockOnResource_0, 2048, 9,
     { 0x28, 0x78 },
     { 0x29, 0x00 },
     { 0x2A, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnTime
 // ******************************************************************
 //6A006A006A016A0656
-OOVPA_XREF(D3D_BlockOnTime, 1036, 10,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      1036,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     //{ 0x02, 0x5C }, (This value has changed, commented out to expand support for later revisions.)
@@ -994,7 +1089,8 @@ OOVPA_XREF(D3D_BlockOnTime, 1036, 10,
     { 0x116, 0x6A },
     { 0x117, 0x06 },
     { 0x118, 0x56 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CommonSetRenderTarget
@@ -1034,8 +1130,9 @@ OOVPA_END;
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
 //8B4C24088B442404E8
-OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle2, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_KickOffAndWaitForIdle2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -1051,14 +1148,16 @@ OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle2, 1024, 12)
 
     { 0x1D, 0xC2 },
     { 0x1E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_UpdateOverlay
 //******************************************************************
 //7707B800001000EB
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x08 },
 
@@ -1070,14 +1169,16 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1036, 9)
     { 0xCF, 0x10 },
     { 0xD0, 0x00 },
     { 0xD1, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderStateNotInline
 // ******************************************************************
 //C381FE880000007D1D8B0D ...C3
-OOVPA_NO_XREF(D3DDevice_SetRenderStateNotInline_0, 2048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderStateNotInline_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xFE },
@@ -1093,14 +1194,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderStateNotInline_0, 2048, 13)
     { 0x22, 0x1D },
     { 0x23, 0x8B },
     { 0x24, 0x0D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureStageStateNotInline
 // ******************************************************************
 //1BC981E1F1BFFFFF81C1
-OOVPA_NO_XREF(D3DDevice_SetTextureStageStateNotInline, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureStageStateNotInline,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -1114,14 +1217,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureStageStateNotInline, 1024, 11)
     { 0x4D, 0xFF },
     { 0x4E, 0x81 },
     { 0x4F, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureStageStateNotInline
 // ******************************************************************
 //1BC025F1BFFFFF050F48
-OOVPA_NO_XREF(D3DDevice_SetTextureStageStateNotInline_0, 2024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureStageStateNotInline_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
 
@@ -1135,13 +1240,15 @@ OOVPA_NO_XREF(D3DDevice_SetTextureStageStateNotInline_0, 2024, 11)
     { 0x3D, 0x05 },
     { 0x3E, 0x0F },
     { 0x3F, 0x48 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginPush, 1024, 18)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPush,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -1162,14 +1269,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPush, 1024, 18)
     { 0x1C, 0x00 },
     { 0x1D, 0x00 },
     { 0x1E, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetIndices
 // ******************************************************************
 //74108103000008008B
-OOVPA_NO_XREF(D3DDevice_SetIndices, 1036, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetIndices,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -1183,14 +1292,16 @@ OOVPA_NO_XREF(D3DDevice_SetIndices, 1036, 11)
     { 0x1A, 0x08 },
     { 0x1B, 0x00 },
     { 0x1C, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetIndices_4
 // ******************************************************************
 //74108103000008008B ...C20400
-OOVPA_NO_XREF(D3DDevice_SetIndices_4, 2024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetIndices_4,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xDB },
@@ -1205,17 +1316,19 @@ OOVPA_NO_XREF(D3DDevice_SetIndices_4, 2024, 12)
     { 0x15, 0x08 },
     { 0x16, 0x00 },
     { 0x17, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetRenderTarget2
 // ******************************************************************
 //8B88041A000085
-OOVPA_XREF(D3DDevice_GetRenderTarget2, 1036, 1 + 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetRenderTarget2,
+                      1036,
 
-           XREF_D3DDevice_GetRenderTarget2,
-           XRefOne)
-{
+                      XREF_D3DDevice_GetRenderTarget2,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2E, XREF_D3DResource_AddRef),
 
@@ -1232,14 +1345,16 @@ OOVPA_XREF(D3DDevice_GetRenderTarget2, 1036, 1 + 9,
 
     { 0x32, 0xFF },
     { 0x33, 0x06 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //04C700941E080083 ...C20400
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_4, 2060, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_4,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -1255,14 +1370,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_4, 2060, 12)
 
     { 0x8B, 0xC2 },
     { 0x8C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //04C700941E080083
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 1036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -1275,14 +1392,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 1036, 10)
     { 0x45, 0x08 },
     { 0x46, 0x00 },
     { 0x47, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetSoftDisplayFilter
 // ******************************************************************
 //6A00566A0E52FF15 ...C3
-OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter_0, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetSoftDisplayFilter_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
@@ -1295,14 +1414,16 @@ OOVPA_NO_XREF(D3DDevice_SetSoftDisplayFilter_0, 2048, 10)
     { 0x1B, 0x52 },
     { 0x1C, 0xFF },
     { 0x1D, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2060, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -1319,14 +1440,16 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2060, 13)
 
     { 0xF4, 0x5B },
     { 0xF5, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2072, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -1343,4 +1466,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2072, 13)
 
     { 0x219, 0x5B },
     { 0x21A, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/4721.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4721.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_Swap
 // ******************************************************************
 //7505BB050000008B ...C3
-OOVPA_NO_XREF(D3DDevice_Swap_0, 2036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x56 },
 
@@ -40,14 +41,16 @@ OOVPA_NO_XREF(D3DDevice_Swap_0, 2036, 9)
     { 0x2B, 0x00 },
     { 0x2C, 0x00 },
     { 0x2D, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTile
 // ******************************************************************
 //C744242000000000C744241C ...C3
-OOVPA_NO_XREF(D3DDevice_SetTile_0, 2048, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -64,14 +67,16 @@ OOVPA_NO_XREF(D3DDevice_SetTile_0, 2048, 14)
     { 0x36, 0x44 },
     { 0x37, 0x24 },
     { 0x38, 0x1C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTexture
 // ******************************************************************
 //81C10000F8FF89 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetTexture_4, 2036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTexture_4,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -83,14 +88,16 @@ OOVPA_NO_XREF(D3DDevice_SetTexture_4, 2036, 9)
     { 0x2F, 0xF8 },
     { 0x30, 0xFF },
     { 0x31, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVertices
 // ******************************************************************
 //0056576A00558B ...C20400
-OOVPA_NO_XREF(D3DDevice_DrawVertices_4, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawVertices_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x55 },
@@ -103,4 +110,5 @@ OOVPA_NO_XREF(D3DDevice_DrawVertices_4, 2048, 10)
     { 0x0B, 0x00 },
     { 0x0C, 0x55 },
     { 0x0D, 0x8B },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/4928.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4928.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_CopyRects
 // ******************************************************************
 //81EC940100005355568B
-OOVPA_NO_XREF(D3DDevice_CopyRects, 1048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x81 },
     { 0x01, 0xEC },
@@ -40,14 +41,16 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 1048, 10)
     { 0x07, 0x55 },
     { 0x08, 0x56 },
     { 0x09, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateTexture2
 // ******************************************************************
 //F744241C0000010074
-OOVPA_NO_XREF(D3DDevice_CreateTexture2, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreateTexture2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x57 },
@@ -61,14 +64,16 @@ OOVPA_NO_XREF(D3DDevice_CreateTexture2, 1024, 11)
     { 0x48, 0x01 },
     { 0x49, 0x00 },
     { 0x4A, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPushBuffer
 // ******************************************************************
 //008107000008008B
-OOVPA_NO_XREF(D3DDevice_BeginPushBuffer_0, 2060, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPushBuffer_0,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -81,14 +86,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPushBuffer_0, 2060, 10)
     { 0x4B, 0x08 },
     { 0x4C, 0x00 },
     { 0x4D, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EndPushBuffer
 // ******************************************************************
 //B82908768859
-OOVPA_NO_XREF(D3DDevice_EndPushBuffer, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EndPushBuffer,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x56 },
@@ -99,14 +106,16 @@ OOVPA_NO_XREF(D3DDevice_EndPushBuffer, 1024, 8)
     { 0x7F, 0x76 },
     { 0x80, 0x88 },
     { 0x81, 0x59 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer2
 // ******************************************************************
 //7507B801000000EB07F7
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer2, 1024, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -124,14 +133,16 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer2, 1024, 14)
 
     { 0x4A, 0xC2 },
     { 0x4B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetDepthStencilSurface2
 // ******************************************************************
 //000085C9750333C0C38B01A9
-OOVPA_NO_XREF(D3DDevice_GetDepthStencilSurface2, 1024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetDepthStencilSurface2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -147,17 +158,19 @@ OOVPA_NO_XREF(D3DDevice_GetDepthStencilSurface2, 1024, 13)
     { 0x12, 0x8B },
     { 0x13, 0x01 },
     { 0x14, 0xA9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetRenderTarget2
 // ******************************************************************
 //8B88041A000085
-OOVPA_XREF(D3DDevice_GetRenderTarget2, 1024, 1 + 7,
+OOVPA_SIG_HEADER_XREF(D3DDevice_GetRenderTarget2,
+                      1024,
 
-           XREF_D3DDevice_GetRenderTarget2,
-           XRefOne)
-{
+                      XREF_D3DDevice_GetRenderTarget2,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2D, XREF_D3DResource_AddRef),
 
@@ -173,14 +186,16 @@ OOVPA_XREF(D3DDevice_GetRenderTarget2, 1024, 1 + 7,
 
     { 0x34, 0xC1 },
     { 0x35, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_PersistDisplay
 // ******************************************************************
 //85C0740F50FF15
-OOVPA_NO_XREF(D3DDevice_PersistDisplay, 1060, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_PersistDisplay,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x55 },
@@ -192,14 +207,16 @@ OOVPA_NO_XREF(D3DDevice_PersistDisplay, 1060, 9)
     { 0x12, 0x50 },
     { 0x13, 0xFF },
     { 0x14, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderConstant
 // ******************************************************************
 //450C8B451085
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderConstant,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x07, 0x15 },
@@ -210,14 +227,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant, 1036, 8)
     { 0x1C, 0x45 },
     { 0x1D, 0x10 },
     { 0x1E, 0x85 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
 //7707B800001000EB
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0xA1 },
 
@@ -229,14 +248,16 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1048, 9)
     { 0x102, 0x10 },
     { 0x103, 0x00 },
     { 0x104, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetSurfaceLevel2
 // ******************************************************************
 //7C24148D442418508D
-OOVPA_NO_XREF(D3DTexture_GetSurfaceLevel2, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DTexture_GetSurfaceLevel2,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
 
@@ -252,14 +273,16 @@ OOVPA_NO_XREF(D3DTexture_GetSurfaceLevel2, 1024, 12)
 
     { 0x45, 0xC2 },
     { 0x46, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShaderDirect
 // ******************************************************************
 //B940000000BF ...C3
-OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect_0, 2024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShaderDirect_0,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -273,4 +296,5 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect_0, 2024, 10)
     { 0x16, 0xBF },
 
     { 0x25, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5028.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5028.inl
@@ -27,8 +27,9 @@
 // * Direct3D_CreateDevice
 // ******************************************************************
 //85C9750AC705 ...C21000
-OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDeviceInterface, 2048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDeviceInterface,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -40,17 +41,19 @@ OOVPA_NO_XREF(Direct3D_CreateDevice_16__LTCG_eax_BehaviorFlags_ecx_ppReturnedDev
     { 0x12, 0x05 },
 
     { 0x1B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 // ...C20400
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2058, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex_4,
+                      2058,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x14, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -66,14 +69,16 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2058, 1 + 10,
     { 0x0F, 0xC1 },
     { 0x10, 0xE0 },
     { 0x11, 0x07 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_LoadVertexShader
 //******************************************************************
 //C7009C1E040089 ...C20400
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader_4, 2024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader_4,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x55 },
@@ -85,17 +90,19 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader_4, 2024, 9)
     { 0x62, 0x04 },
     { 0x63, 0x00 },
     { 0x64, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CommonSetRenderTarget
 // ******************************************************************
 //8B490CC1E91483E10FB801
-OOVPA_XREF(D3D_CommonSetRenderTarget, 1048, 13,
+OOVPA_SIG_HEADER_XREF(D3D_CommonSetRenderTarget,
+                      1048,
 
-           XREF_D3D_CommonSetRenderTarget,
-           XRefZero)
-{
+                      XREF_D3D_CommonSetRenderTarget,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -111,4 +118,5 @@ OOVPA_XREF(D3D_CommonSetRenderTarget, 1048, 13,
     { 0x5F, 0x0F },
     { 0x60, 0xB8 },
     { 0x61, 0x01 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5120.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5120.inl
@@ -27,8 +27,9 @@
 // * Direct3D_CreateDevice
 // ******************************************************************
 //00000800A1
-OOVPA_NO_XREF(Direct3D_CreateDevice, 1036, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x09, 0xC0 },
@@ -38,14 +39,16 @@ OOVPA_NO_XREF(Direct3D_CreateDevice, 1036, 7)
     { 0x14, 0x08 },
     { 0x15, 0x00 },
     { 0x16, 0xA1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Reset
 // ******************************************************************
 //803F6A006A036A006A00E8
-OOVPA_NO_XREF(D3DDevice_Reset, 1036, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -59,14 +62,16 @@ OOVPA_NO_XREF(D3DDevice_Reset, 1036, 11)
     { 0xAC, 0x6A },
     { 0xAD, 0x00 },
     { 0xAE, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPalette
 // ******************************************************************
 //000085C05774258B4E
-OOVPA_NO_XREF(D3DDevice_SetPalette, 1048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPalette,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -80,4 +85,5 @@ OOVPA_NO_XREF(D3DDevice_SetPalette, 1048, 11)
     { 0x17, 0x25 },
     { 0x18, 0x8B },
     { 0x19, 0x4E },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5233.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5233.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_BeginPush
 // ******************************************************************
 //24088B49048D
-OOVPA_NO_XREF(D3DDevice_BeginPush, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPush,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x06, 0x6A },
@@ -39,14 +40,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPush, 1036, 8)
     { 0x1B, 0x49 },
     { 0x1C, 0x04 },
     { 0x1D, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetBackBuffer2
 // ******************************************************************
 //7507B801000000EB07F7 ...C3
-OOVPA_NO_XREF(D3DDevice_GetBackBuffer2_0, 2048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetBackBuffer2_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xF8 },
@@ -63,17 +66,19 @@ OOVPA_NO_XREF(D3DDevice_GetBackBuffer2_0, 2048, 13)
     { 0x12, 0xF7 },
 
     { 0x46, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //81E30000FFFFB901 ...C20400
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2052, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex_4,
+                      2052,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -88,14 +93,16 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, 2052, 1 + 10,
     { 0x45, 0xFF },
     { 0x46, 0xB9 },
     { 0x47, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //8BCEC1E10681C1241B04 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_0, 2036, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -109,14 +116,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_0, 2036, 10)
     { 0x28, 0x24 },
 
     { 0x41, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //8D0CB5E00A0400 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0, 2036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -129,17 +138,19 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0, 2036, 9)
     { 0x27, 0x00 },
 
     { 0x3D, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShader
 // ******************************************************************
 //F6C30155568B35 ...C3
-OOVPA_XREF(D3DDevice_SetVertexShader_0, 2036, 1 + 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetVertexShader_0,
+                      2036,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0E, XREF_OFFSET_D3DDEVICE_M_VERTEXSHADER), // Derived (unverified, yet should be align base on existing 4 bytes in signatures)
 
@@ -160,14 +171,16 @@ OOVPA_XREF(D3DDevice_SetVertexShader_0, 2036, 1 + 15,
     { 0x21, 0xFF },
     { 0x22, 0xEB },
     { 0x23, 0x0E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexShaderConstantNotInline
 // ******************************************************************
 //56578BFBC1E704 ...C3
-OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline_0, 2048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xF6 },
     { 0x01, 0x05 },
@@ -179,13 +192,15 @@ OOVPA_NO_XREF(D3DDevice_SetVertexShaderConstantNotInline_0, 2048, 9)
     { 0x0D, 0xC1 },
     { 0x0E, 0xE7 },
     { 0x0F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPush
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_BeginPush, 1048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPush,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -198,14 +213,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPush, 1048, 10)
     { 0x1A, 0x8B },
     { 0x1B, 0x49 },
     { 0x1C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPalette
 // ******************************************************************
 //000085C05774258B4E
-OOVPA_NO_XREF(D3DDevice_SetPalette, 1036, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPalette,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -219,14 +236,16 @@ OOVPA_NO_XREF(D3DDevice_SetPalette, 1036, 11)
     { 0x1C, 0x25 },
     { 0x1D, 0x8B },
     { 0x1E, 0x4E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //04C700941E080083 ...C3
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -242,14 +261,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2048, 12)
 
     { 0x8E, 0x5E },
     { 0x8F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShaderDirect
 // ******************************************************************
 //53568BF185F68BD8741E57B8 ...C3
-OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect_0, 2048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShaderDirect_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x56 },
@@ -263,17 +284,19 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect_0, 2048, 12)
     { 0x09, 0x1E },
     { 0x0A, 0x57 },
     { 0x0B, 0xB8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_CommonSetRenderTarget
 // ******************************************************************
 //8B490CC1E91483E10FB801
-OOVPA_XREF(D3D_CommonSetRenderTarget, 1060, 13,
+OOVPA_SIG_HEADER_XREF(D3D_CommonSetRenderTarget,
+                      1060,
 
-           XREF_D3D_CommonSetRenderTarget,
-           XRefZero)
-{
+                      XREF_D3D_CommonSetRenderTarget,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -289,16 +312,18 @@ OOVPA_XREF(D3D_CommonSetRenderTarget, 1060, 13,
     { 0x62, 0x0F },
     { 0x63, 0xB8 },
     { 0x64, 0x01 },
-} OOVPA_END;
+    //
+);
 
 //******************************************************************
 //* D3DDevice_SetRenderTarget
 //******************************************************************
-OOVPA_XREF(D3DDevice_SetRenderTarget_0, 2048, 1 + 5,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderTarget_0,
+                      2048,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x08, XREF_D3D_CommonSetRenderTarget),
 
@@ -307,14 +332,16 @@ OOVPA_XREF(D3DDevice_SetRenderTarget_0, 2048, 1 + 5,
     { 0x06, 0x51 },
     { 0x07, 0xE8 },
     { 0x0C, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2084, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2084)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -331,4 +358,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2084, 13)
 
     { 0x121, 0x5B },
     { 0x122, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5344.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5344.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_DeleteVertexShader
 // ******************************************************************
 //8B48FF4849890875 ...C3
-OOVPA_NO_XREF(D3DDevice_DeleteVertexShader_0, 2036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DeleteVertexShader_0,
+                         2036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x48 },
@@ -40,14 +41,16 @@ OOVPA_NO_XREF(D3DDevice_DeleteVertexShader_0, 2036, 9)
     { 0x07, 0x75 },
 
     { 0x14, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShaderDirect
 // ******************************************************************
 //B940000000BF
-OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShaderDirect,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -62,14 +65,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShaderDirect, 1024, 11)
 
     { 0x2B, 0xC2 },
     { 0x2C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
 //558BEC83EC1453568B35 ...C700FC17040089
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1048, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVerticesUP,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -89,16 +94,18 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1048, 17)
     { 0x33, 0x04 },
     { 0x34, 0x00 },
     { 0x35, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawVerticesUP
 // ******************************************************************
-OOVPA_XREF(D3DDevice_DrawVerticesUP, 1024, 1 + 9,
+OOVPA_SIG_HEADER_XREF(D3DDevice_DrawVerticesUP,
+                      1024,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // D3DDevice_DrawVerticesUP+0x08 : mov esi,[D3D__PDEVICE]
     XREF_ENTRY(0x0A, XREF_D3DDEVICE),
@@ -119,13 +126,15 @@ OOVPA_XREF(D3DDevice_DrawVerticesUP, 1024, 1 + 9,
     OV_MATCH(0x0F, 0x89),
     OV_MATCH(0x11, 0xEC),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_End
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_End, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_End,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x13, 0x50 },
@@ -134,14 +143,16 @@ OOVPA_NO_XREF(D3DDevice_End, 1048, 7)
     { 0x2B, 0x08 },
     { 0x34, 0xE1 },
     { 0x49, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetLight
 // ******************************************************************
 //83E0F0894424108D04C0
-OOVPA_NO_XREF(D3DDevice_SetLight, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetLight,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -156,14 +167,16 @@ OOVPA_NO_XREF(D3DDevice_SetLight, 1024, 12)
     { 0x29, 0x8D },
     { 0x2A, 0x04 },
     { 0x2B, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
 //C700C417040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -174,14 +187,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1060, 8)
     { 0x24, 0x04 },
     { 0x25, 0x00 },
     { 0x26, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
 //C700C417040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1072, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         1072)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -192,14 +207,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1072, 8)
     { 0x25, 0x04 },
     { 0x26, 0x00 },
     { 0x27, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
 // ******************************************************************
 //A900007800751925000007003D
-OOVPA_NO_XREF(D3DDevice_SetRenderTarget, 1072, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderTarget,
+                         1072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -217,14 +234,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderTarget, 1072, 15)
     { 0x30, 0x07 },
     { 0x31, 0x00 },
     { 0x32, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScissors
 // ******************************************************************
 //55894424088B430489
-OOVPA_NO_XREF(D3DDevice_SetScissors, 1048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScissors,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0xEC },
 
@@ -237,14 +256,16 @@ OOVPA_NO_XREF(D3DDevice_SetScissors, 1048, 10)
     { 0x1C, 0x43 },
     { 0x1D, 0x04 },
     { 0x1E, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //56578D7821C1E706
-OOVPA_NO_XREF(D3DDevice_SetTransform, 1048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -260,14 +281,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform, 1048, 12)
 
     { 0x107, 0xC2 },
     { 0x108, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //56578D7821C1E706 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2060, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform_0,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -282,14 +305,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2060, 11)
     { 0x0E, 0x06 },
 
     { 0xFF, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LightEnable
 // ******************************************************************
 //F64401680175 ...C20400
-OOVPA_NO_XREF(D3DDevice_LightEnable_4, 2048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LightEnable_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -300,14 +325,16 @@ OOVPA_NO_XREF(D3DDevice_LightEnable_4, 2048, 8)
     { 0x25, 0x68 },
     { 0x26, 0x01 },
     { 0x27, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
 //005D6A006A006A00E8
-OOVPA_NO_XREF(D3DDevice_SetViewport, 1060, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -321,4 +348,5 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 1060, 11)
     { 0x142, 0x6A },
     { 0x143, 0x00 },
     { 0x144, 0xE8 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5455.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5455.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_CopyRects
 // ******************************************************************
 //83EC345355568B7424440F
-OOVPA_NO_XREF(D3DDevice_CopyRects, 1024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CopyRects,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -41,14 +42,16 @@ OOVPA_NO_XREF(D3DDevice_CopyRects, 1024, 11)
     { 0x08, 0x24 },
     { 0x09, 0x44 },
     { 0x0A, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //00008B4904578D ...C3
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2060, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_0,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x02, 0x56 },
@@ -64,13 +67,15 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2060, 12)
 
     { 0x9E, 0x5E },
     { 0x9F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetScreenSpaceOffset
 // ******************************************************************
-OOVPA_NO_XREF(D3DDevice_SetScreenSpaceOffset, 1024, 6)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetScreenSpaceOffset,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xD9 },
     { 0x01, 0x44 },
@@ -78,14 +83,16 @@ OOVPA_NO_XREF(D3DDevice_SetScreenSpaceOffset, 1024, 6)
     { 0x03, 0x04 },
     { 0x04, 0x56 },
     { 0x05, 0xD8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTile
 // ******************************************************************
 //85C9538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetTile_0, 2060, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile_0,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -98,14 +105,16 @@ OOVPA_NO_XREF(D3DDevice_SetTile_0, 2060, 9)
 
     { 0x0B, 0x00 },
     { 0x0C, 0x56 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetViewport
 // ******************************************************************
 //8B4C240483EC0C85C9568B
-OOVPA_NO_XREF(D3DDevice_SetViewport, 1048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetViewport,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x4C },
@@ -118,14 +127,16 @@ OOVPA_NO_XREF(D3DDevice_SetViewport, 1048, 11)
     { 0x08, 0xC9 },
     { 0x09, 0x56 },
     { 0x0A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
 //7707B800001000EB
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x08 },
 
@@ -137,17 +148,19 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1024, 9)
     { 0xD0, 0x10 },
     { 0xD1, 0x00 },
     { 0xD2, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnResource
 // ******************************************************************
 //F7C20000780075 ...C3
-OOVPA_XREF(D3D_BlockOnResource_0, 2060, 9,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnResource_0,
+                      2060,
 
-           XREF_D3D_BlockOnResource,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnResource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x02, 0x35 },
@@ -159,14 +172,16 @@ OOVPA_XREF(D3D_BlockOnResource_0, 2060, 9,
     { 0x2C, 0x78 },
     { 0x2D, 0x00 },
     { 0x2E, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
 //8B4C24088B442404E8
-OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle2, 1048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_KickOffAndWaitForIdle2,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -182,17 +197,19 @@ OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle2, 1048, 12)
 
     { 0x20, 0xC2 },
     { 0x21, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTarget
 // ******************************************************************
 //A900007800751925000007003D
-OOVPA_XREF(D3DDevice_SetRenderTarget, 1084, 15,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderTarget,
+                      1084,
 
-           XREF_D3DDevice_SetRenderTarget,
-           XRefZero)
-{
+                      XREF_D3DDevice_SetRenderTarget,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -210,14 +227,16 @@ OOVPA_XREF(D3DDevice_SetRenderTarget, 1084, 15,
     { 0x2F, 0x07 },
     { 0x30, 0x00 },
     { 0x31, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LightEnable
 // ******************************************************************
 //F64401680175
-OOVPA_NO_XREF(D3DDevice_LightEnable, 1036, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LightEnable,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -228,14 +247,16 @@ OOVPA_NO_XREF(D3DDevice_LightEnable, 1036, 8)
     { 0x27, 0x68 },
     { 0x28, 0x01 },
     { 0x29, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //56578D7821C1E706 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2084, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform_0,
+                         2084)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -250,14 +271,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2084, 11)
     { 0x0E, 0x06 },
 
     { 0x109, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2096, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2096)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -274,4 +297,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2096, 13)
 
     { 0x23B, 0x5B },
     { 0x23C, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5788.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5788.inl
@@ -27,8 +27,9 @@
 // * D3DDevice_SetPalette
 // ******************************************************************
 //85C05774258B4E2C8948088BBC
-OOVPA_NO_XREF(D3DDevice_SetPalette, 1024, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPalette,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -46,14 +47,16 @@ OOVPA_NO_XREF(D3DDevice_SetPalette, 1024, 15)
     { 0x1D, 0x08 },
     { 0x1E, 0x8B },
     { 0x1F, 0xBC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPalette
 // ******************************************************************
 //000085C05774258B4E ...C20400
-OOVPA_NO_XREF(D3DDevice_SetPalette_4, 2024, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPalette_4,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x55 },
@@ -67,14 +70,16 @@ OOVPA_NO_XREF(D3DDevice_SetPalette_4, 2024, 11)
     { 0x1A, 0x25 },
     { 0x1B, 0x8B },
     { 0x1C, 0x4E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008
-OOVPA_NO_XREF(D3DDevice_SetPixelShader, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x53 },
@@ -89,14 +94,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader, 1024, 12)
     { 0x7E, 0x83 },
     { 0x7F, 0xC0 },
     { 0x80, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreateVertexShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2048, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x85 },
@@ -113,14 +120,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader_0, 2048, 13)
     { 0x7C, 0x08 },
 
     { 0x81, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderConstant
 // ******************************************************************
 //F30F2DC0C1E0100FC6C039 ...C20400
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant_4, 2024, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderConstant_4,
+                         2024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x04, 0xEC },
@@ -136,14 +145,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderConstant_4, 2024, 13)
     { 0x54, 0xC6 },
     { 0x55, 0xC0 },
     { 0x56, 0x39 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShaderProgram
 // ******************************************************************
 //C780280900
-OOVPA_NO_XREF(D3DDevice_SetPixelShaderProgram, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShaderProgram,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x06, 0xA1 },
     { 0x0B, 0x74 },
@@ -154,17 +165,19 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShaderProgram, 1024, 8)
     { 0x1C, 0x09 },
     { 0x1D, 0x00 },
     { 0x1E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_CullMode
 // ******************************************************************
 //C7000803040075
-OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1053, 2 + 8,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetRenderState_CullMode,
+                      1053,
 
-           XREF_D3DDevice_SetRenderState_CullMode,
-           XRefTwo)
-{
+                      XREF_D3DDevice_SetRenderState_CullMode,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x03, XREF_D3DDEVICE), // Derived
     XREF_ENTRY(0x35, XREF_D3DRS_CULLMODE), // Derived
@@ -178,14 +191,16 @@ OOVPA_XREF(D3DDevice_SetRenderState_CullMode, 1053, 2 + 8,
     { 0x27, 0x04 },
     { 0x28, 0x00 },
     { 0x29, 0x75 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_EdgeAntiAlias
 // ******************************************************************
 //0020030800894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1060, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x1E, 0x4C },
@@ -198,14 +213,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_EdgeAntiAlias, 1060, 10)
     { 0x27, 0x89 },
     { 0x28, 0x48 },
     { 0x29, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FillMode
 // ******************************************************************
 //C98B4C24087502
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1060, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FillMode,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x08, 0x06 },
@@ -217,14 +234,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FillMode, 1060, 9)
     { 0x2E, 0x08 },
     { 0x2F, 0x75 },
     { 0x30, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FogColor
 // ******************************************************************
 //54240E8BF981
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1060, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FogColor,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -234,14 +253,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FogColor, 1060, 7)
     { 0x27, 0x8B },
     { 0x28, 0xF9 },
     { 0x29, 0x81 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_FrontFace
 // ******************************************************************
 //00a0A0304008948
-OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_FrontFace,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -252,14 +273,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_FrontFace, 1060, 8)
     { 0x26, 0x00 },
     { 0x27, 0x89 },
     { 0x28, 0x48 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_LogicOp
 // ******************************************************************
 //18C700BC1704
-OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1060, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_LogicOp,
+                         1060)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x34, XREF_D3DRS_LOGICOP ),
 
@@ -271,14 +294,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_LogicOp, 1060, 7)
     { 0x27, 0xBC },
     { 0x28, 0x17 },
     { 0x29, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_NormalizeNormals
 // ******************************************************************
 //A4030400894804
-OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -289,14 +314,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_NormalizeNormals, 1060, 8)
     { 0x27, 0x89 },
     { 0x28, 0x48 },
     { 0x29, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ShadowFunc
 // ******************************************************************
 //6C1E04008D91
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ShadowFunc,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x8B },
@@ -307,14 +334,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ShadowFunc, 1060, 8)
     { 0x26, 0x00 },
     { 0x27, 0x8D },
     { 0x28, 0x91 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
 //018b54240885d2c700
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1060, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x35 },
 
@@ -327,14 +356,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1060, 10)
     { 0x56, 0xD2 },
     { 0x57, 0xC7 },
     { 0x58, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
 //7003040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1060, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x23, 0x33 },
@@ -344,14 +375,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1060, 7)
     { 0x63, 0x04 },
     { 0x64, 0x00 },
     { 0x65, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZEnable
 // ******************************************************************
 //C9C7000C0304008948048B
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1060, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZEnable,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -367,14 +400,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZEnable, 1060, 13)
     { 0x3F, 0x48 },
     { 0x40, 0x04 },
     { 0x41, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //088BD1C1E20681C2241B
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 1048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -388,14 +423,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor, 1048, 11)
     { 0x27, 0xC2 },
     { 0x28, 0x24 },
     { 0x29, 0x1B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_BorderColor
 // ******************************************************************
 //891089580483 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_0, 2048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_BorderColor_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x57 },
 
@@ -405,14 +442,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_BorderColor_0, 2048, 7)
     { 0x30, 0x58 },
     { 0x31, 0x04 },
     { 0x32, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //E00A040089
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x18, 0xE8 },
@@ -423,14 +462,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor, 1024, 8)
     { 0x26, 0x04 },
     { 0x27, 0x00 },
     { 0x28, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_ColorKeyColor
 // ******************************************************************
 //E00A040089 ...C3
-OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0, 2048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x57 },
     { 0x0B, 0x8B },
@@ -441,14 +482,16 @@ OOVPA_NO_XREF(D3DDevice_SetTextureState_ColorKeyColor_0, 2048, 8)
     { 0x27, 0x04 },
     { 0x28, 0x00 },
     { 0x29, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderTargetFast
 // ******************************************************************
 //A900007800578B
-OOVPA_NO_XREF(D3DDevice_SetRenderTargetFast, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderTargetFast,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -460,17 +503,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderTargetFast, 1024, 9)
     { 0x0B, 0x00 },
     { 0x0C, 0x57 },
     { 0x0D, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnTime
 // ******************************************************************
 //C747101001040089
-OOVPA_XREF(D3D_BlockOnTime, 1024, 10,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      1024,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -483,17 +528,19 @@ OOVPA_XREF(D3D_BlockOnTime, 1024, 10,
     { 0xB9, 0x04 },
     { 0xBA, 0x00 },
     { 0xBB, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnTime
 // ******************************************************************
 //C747101001040089 ...C20400
-OOVPA_XREF(D3D_BlockOnTime_4, 2048, 9,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime_4,
+                      2048,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -505,14 +552,16 @@ OOVPA_XREF(D3D_BlockOnTime_4, 2048, 9,
     { 0xBD, 0x04 },
     { 0xBE, 0x00 },
     { 0xBF, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_MakeRequestedSpace
 // ******************************************************************
 //81C5004000003BE9 ...C20400
-OOVPA_NO_XREF(D3D_MakeRequestedSpace, 2048, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_MakeRequestedSpace,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -525,17 +574,19 @@ OOVPA_NO_XREF(D3D_MakeRequestedSpace, 2048, 10)
     { 0x5F, 0x00 },
     { 0x60, 0x3B },
     { 0x61, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_SetFence
 // ******************************************************************
 //C70010A304008BCF
-OOVPA_XREF(D3D_SetFence, 1048, 10,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      1048,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -548,17 +599,19 @@ OOVPA_XREF(D3D_SetFence, 1048, 10,
     { 0x26, 0x00 },
     { 0x27, 0x8B },
     { 0x28, 0xCF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_SetFence
 // ******************************************************************
 //C70010A304008B
-OOVPA_XREF(D3D_SetFence, 1060, 9,
+OOVPA_SIG_HEADER_XREF(D3D_SetFence,
+                      1060,
 
-           XREF_D3D_SetFence,
-           XRefZero)
-{
+                      XREF_D3D_SetFence,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8A },
@@ -570,14 +623,16 @@ OOVPA_XREF(D3D_SetFence, 1060, 9,
     { 0x29, 0x04 },
     { 0x2A, 0x00 },
     { 0x2B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_DrawIndexedVerticesUP
 // ******************************************************************
 //558BEC83EC1453568B35 ...C700FC17040089
-OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1060, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_DrawIndexedVerticesUP,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -597,14 +652,16 @@ OOVPA_NO_XREF(D3DDevice_DrawIndexedVerticesUP, 1060, 17)
     { 0x34, 0x04 },
     { 0x35, 0x00 },
     { 0x36, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTransform
 // ******************************************************************
 //568BC8C1E106578DBC ...C3
-OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2072, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTransform_0,
+                         2072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x8B },
@@ -621,14 +678,16 @@ OOVPA_NO_XREF(D3DDevice_SetTransform_0, 2072, 13)
     { 0x10, 0x19 },
 
     { 0x10D, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_RunPushBuffer
 // ******************************************************************
 //C7442410000000208B
-OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 1048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_RunPushBuffer,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -642,14 +701,16 @@ OOVPA_NO_XREF(D3DDevice_RunPushBuffer, 1048, 11)
     { 0x51, 0x00 },
     { 0x52, 0x20 },
     { 0x53, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexDataColor
 // ******************************************************************
 //0C8D....40190400
-OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexDataColor,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -660,14 +721,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1048, 8)
     { 0x2A, 0x19 },
     { 0x2B, 0x04 },
     { 0x2C, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2108, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2108)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -684,14 +747,16 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2108, 13)
 
     { 0x122, 0x5B },
     { 0x123, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2120, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2120)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -708,14 +773,16 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2120, 13)
 
     { 0x118, 0x5B },
     { 0x119, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2132, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2132)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -732,4 +799,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2132, 13)
 
     { 0x122, 0x5B },
     { 0x123, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/D3D8LTCG/5849.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5849.inl
@@ -27,8 +27,9 @@
 // * Direct3D_CreateDevice
 // ******************************************************************
 //85C9750AC705 ...C20400
-OOVPA_NO_XREF(Direct3D_CreateDevice_4, 2048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -40,14 +41,16 @@ OOVPA_NO_XREF(Direct3D_CreateDevice_4, 2048, 8)
     { 0x0F, 0x05 },
 
     { 0x3A, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * Direct3D_CreateDevice
 // ******************************************************************
 //85C9750AC705 ...C20400
-OOVPA_NO_XREF(Direct3D_CreateDevice_4, 2060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(Direct3D_CreateDevice_4,
+                         2060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -59,14 +62,16 @@ OOVPA_NO_XREF(Direct3D_CreateDevice_4, 2060, 8)
     { 0x10, 0x05 },
 
     { 0x3B, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C70001000000C7812809
-OOVPA_NO_XREF(D3DDevice_SetPixelShader, 1048, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x54 },
@@ -81,14 +86,16 @@ OOVPA_NO_XREF(D3DDevice_SetPixelShader, 1048, 12)
     { 0x1B, 0x81 },
     { 0x1C, 0x28 },
     { 0x1D, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
 //85FFC700841D0400
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1072, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         1072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x02, 0x35 },
@@ -100,14 +107,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1072, 9)
     { 0x60, 0x84 },
     { 0x61, 0x1D },
     { 0x62, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilEnable
 // ******************************************************************
 //85FFC700841D0400
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1084, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilEnable,
+                         1084)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x02, 0x35 },
@@ -119,7 +128,8 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1084, 9)
     { 0x5F, 0x84 },
     { 0x60, 0x1D },
     { 0x61, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DTexture_GetLevelDesc
@@ -128,8 +138,9 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilEnable, 1084, 9)
 // *       GetLevelDesc Simply redirects to that function
 // ******************************************************************
 //7909C74608010000
-OOVPA_NO_XREF(Get2DSurfaceDesc, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(Get2DSurfaceDesc,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -142,14 +153,16 @@ OOVPA_NO_XREF(Get2DSurfaceDesc, 1024, 10)
     { 0x3D, 0x01 },
     { 0x3E, 0x00 },
     { 0x3F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DResource_Release
 // ******************************************************************
 //068BC881E1FFFF000083F90175
-OOVPA_NO_XREF(D3DResource_Release, 1024, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DResource_Release,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -168,17 +181,19 @@ OOVPA_NO_XREF(D3DResource_Release, 1024, 15)
     { 0x12, 0x75 },
 
     { 0x17, 0x07 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnTime
 // ******************************************************************
 //C747101001040089
-OOVPA_XREF(D3D_BlockOnTime, 1048, 10,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime,
+                      1048,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -191,17 +206,19 @@ OOVPA_XREF(D3D_BlockOnTime, 1048, 10,
     { 0xF5, 0x04 },
     { 0xF6, 0x00 },
     { 0xF7, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_BlockOnTime
 // ******************************************************************
 //C747101001040089 ...C20400
-OOVPA_XREF(D3D_BlockOnTime_4, 2060, 9,
+OOVPA_SIG_HEADER_XREF(D3D_BlockOnTime_4,
+                      2060,
 
-           XREF_D3D_BlockOnTime,
-           XRefZero)
-{
+                      XREF_D3D_BlockOnTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -213,14 +230,16 @@ OOVPA_XREF(D3D_BlockOnTime_4, 2060, 9,
     { 0xF9, 0x04 },
     { 0xFA, 0x00 },
     { 0xFB, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_KickOffAndWaitForIdle
 // ******************************************************************
 //8B4C24088B442404E8
-OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle2, 1036, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3D_KickOffAndWaitForIdle2,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -236,14 +255,16 @@ OOVPA_NO_XREF(D3D_KickOffAndWaitForIdle2, 1036, 12)
 
     { 0x1C, 0xC2 },
     { 0x1D, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_TwoSidedLighting
 // ******************************************************************
 //C700C417040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1084, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting,
+                         1084)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -254,14 +275,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_TwoSidedLighting, 1084, 8)
     { 0x26, 0x04 },
     { 0x27, 0x00 },
     { 0x28, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_ZBias
 // ******************************************************************
 //241485FF0F95C085
-OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_ZBias,
+                         1024)
+OOVPA_SIG_MATCH(
 
     // XREF_ENTRY( 0x6A, XREF_D3DRS_ZBIAS ),
 
@@ -275,14 +298,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_ZBias, 1024, 9)
     { 0x0D, 0x95 },
     { 0x0E, 0xC0 },
     { 0x0F, 0x85 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
 //7003040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1072, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         1072)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x2E, 0x33 },
@@ -292,14 +317,16 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1072, 7)
     { 0x6A, 0x04 },
     { 0x6B, 0x00 },
     { 0x6C, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetRenderState_StencilFail
 // ******************************************************************
 //7003040089
-OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1084, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetRenderState_StencilFail,
+                         1084)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x2D, 0x33 },
@@ -309,17 +336,19 @@ OOVPA_NO_XREF(D3DDevice_SetRenderState_StencilFail, 1084, 7)
     { 0x69, 0x04 },
     { 0x6A, 0x00 },
     { 0x6B, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTextureState_TexCoordIndex
 // ******************************************************************
 //81E30000FFFFB901 ...C3
-OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_0, 2058, 1 + 10,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetTextureState_TexCoordIndex_0,
+                      2058,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_D3DTSS_TEXCOORDINDEX), // Derived
 
@@ -334,14 +363,16 @@ OOVPA_XREF(D3DDevice_SetTextureState_TexCoordIndex_0, 2058, 1 + 10,
     { 0x46, 0xFF },
     { 0x47, 0xB9 },
     { 0x48, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Release
 // ******************************************************************
 //8B873809000083
-OOVPA_NO_XREF(D3DDevice_Release, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Release,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x3D },
     { 0x07, 0x8B },
@@ -351,14 +382,16 @@ OOVPA_NO_XREF(D3DDevice_Release, 1024, 8)
     { 0x0B, 0x00 },
     { 0x0C, 0x00 },
     { 0x0D, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetTile
 // ******************************************************************
 //83EC1885C05356578B3D ...C3
-OOVPA_NO_XREF(D3DDevice_SetTile_0, 2072, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTile_0,
+                         2072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -370,14 +403,16 @@ OOVPA_NO_XREF(D3DDevice_SetTile_0, 2072, 10)
     { 0x07, 0x57 },
     { 0x08, 0x8B },
     { 0x09, 0x3D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShaderProgram
 // ******************************************************************
 //B75802558B2D
-OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 1024, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShaderProgram,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x44 },
 
@@ -387,14 +422,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShaderProgram, 1024, 7)
     { 0x09, 0x55 },
     { 0x0A, 0x8B },
     { 0x0B, 0x2D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //00008B4904578D
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -406,14 +443,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader, 1024, 9)
     { 0x17, 0x04 },
     { 0x18, 0x57 },
     { 0x19, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //00008B4904578D
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2084, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_0,
+                         2084)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -429,14 +468,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2084, 12)
 
     { 0xA0, 0x5E },
     { 0xA1, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SelectVertexShader
 // ******************************************************************
 //04C700941E080083 ...C3
-OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2072, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SelectVertexShader_0,
+                         2072)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x85 },
     { 0x01, 0xC0 },
@@ -452,14 +493,16 @@ OOVPA_NO_XREF(D3DDevice_SelectVertexShader_0, 2072, 12)
 
     { 0xA4, 0x5E },
     { 0xA5, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
 //C7009C1E040089 ...C3
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_edx_Handle, 2048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_edx_Handle,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
@@ -471,14 +514,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader_0__LTCG_eax_Address_edx_Handle, 2048, 9
     { 0x64, 0x04 },
     { 0x65, 0x00 },
     { 0x66, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_LoadVertexShader
 // ******************************************************************
 //C7009C1E040089 ...C20400
-OOVPA_NO_XREF(D3DDevice_LoadVertexShader_4, 2048, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_LoadVertexShader_4,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x55 },
 
@@ -489,14 +534,16 @@ OOVPA_NO_XREF(D3DDevice_LoadVertexShader_4, 2048, 8)
     { 0x33, 0x04 },
     { 0x34, 0x00 },
     { 0x35, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginVisibilityTest
 // ******************************************************************
 //C700C8170800B9
-OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginVisibilityTest,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -508,14 +555,16 @@ OOVPA_NO_XREF(D3DDevice_BeginVisibilityTest, 1048, 9)
     { 0x21, 0x08 },
     { 0x22, 0x00 },
     { 0x23, 0xB9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_GetViewportOffsetAndScale
 // ******************************************************************
 //8B88E00E0000DB
-OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale, 1024, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_GetViewportOffsetAndScale,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x8B },
     { 0x06, 0x88 },
@@ -526,14 +575,16 @@ OOVPA_NO_XREF(D3DDevice_GetViewportOffsetAndScale, 1024, 8)
     { 0x0B, 0xDB },
 
     { 0x19, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2f
 // ******************************************************************
 //8D....801808008B
-OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2f,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x21, 0x8D },
@@ -543,14 +594,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2f, 1048, 7)
     { 0x26, 0x08 },
     { 0x27, 0x00 },
     { 0x28, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData2s
 // ******************************************************************
 //8D....00190400
-OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData2s,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -562,14 +615,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData2s, 1048, 7)
     { 0x25, 0x19 },
     { 0x26, 0x04 },
     { 0x27, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
 //B918150000EB09
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 1036, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -581,14 +636,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f, 1036, 9)
     { 0x2A, 0x00 },
     { 0x2B, 0xEB },
     { 0x2C, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4s
 // ******************************************************************
 //801908000FBF
-OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4s,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -598,14 +655,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4s, 1048, 7)
     { 0x37, 0x00 },
     { 0x38, 0x0F },
     { 0x39, 0xBF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4ub
 // ******************************************************************
 //8D....4019040033
-OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 1048, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4ub,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x21, 0x8D },
@@ -615,14 +674,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4ub, 1048, 7)
     { 0x26, 0x04 },
     { 0x27, 0x00 },
     { 0x28, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexData4f
 // ******************************************************************
 //B918150000EB09 ...C21000
-OOVPA_NO_XREF(D3DDevice_SetVertexData4f_16, 2048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexData4f_16,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -634,14 +695,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexData4f_16, 2048, 9)
     { 0x26, 0x00 },
     { 0x27, 0xEB },
     { 0x28, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_End
 // ******************************************************************
 //108956085E74076A
-OOVPA_NO_XREF(D3DDevice_End, 1024, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_End,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -653,14 +716,16 @@ OOVPA_NO_XREF(D3DDevice_End, 1024, 9)
     { 0x41, 0x74 },
     { 0x42, 0x07 },
     { 0x43, 0x6A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_BeginPushBuffer
 // ******************************************************************
 //008107000008008B
-OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 1024, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_BeginPushBuffer,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -673,14 +738,16 @@ OOVPA_NO_XREF(D3DDevice_BeginPushBuffer, 1024, 10)
     { 0x4A, 0x08 },
     { 0x4B, 0x00 },
     { 0x4C, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Begin
 // ******************************************************************
 //814E08000800005EC204
-OOVPA_NO_XREF(D3DDevice_Begin, 1036, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Begin,
+                         1036)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -695,17 +762,19 @@ OOVPA_NO_XREF(D3DDevice_Begin, 1036, 12)
     { 0x3B, 0x5E },
     { 0x3C, 0xC2 },
     { 0x3D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3D_MakeRequestedSpace
 // ******************************************************************
 //81C5004000003BE9
-OOVPA_XREF(D3D_MakeRequestedSpace_8, 1036, 10,
+OOVPA_SIG_HEADER_XREF(D3D_MakeRequestedSpace_8,
+                      1036,
 
-           XREF_D3D_MakeRequestedSpace,
-           XRefZero)
-{
+                      XREF_D3D_MakeRequestedSpace,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x53 },
@@ -718,14 +787,16 @@ OOVPA_XREF(D3D_MakeRequestedSpace_8, 1036, 10,
     { 0x5D, 0x00 },
     { 0x5E, 0x3B },
     { 0x5F, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_CreatePixelShader
 // ******************************************************************
 //85C07508B80E000780C2
-OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 1024, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_CreatePixelShader,
+                         1024)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x0D },
@@ -740,16 +811,18 @@ OOVPA_NO_XREF(D3DDevice_CreatePixelShader, 1024, 12)
     { 0x29, 0x07 },
     { 0x2A, 0x80 },
     { 0x2B, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
 // ******************************************************************
-OOVPA_XREF(D3DDevice_SetStreamSource_0__LTCG_eax_StreamNumber_edi_pStreamData_ebx_Stride, 2058, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetStreamSource_0__LTCG_eax_StreamNumber_edi_pStreamData_ebx_Stride,
+                      2058,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_G_STREAM), // Derived
 
@@ -758,17 +831,19 @@ OOVPA_XREF(D3DDevice_SetStreamSource_0__LTCG_eax_StreamNumber_edi_pStreamData_eb
 
     // jz ...; add dword ptr [edi], 80000h
     OV_MATCH(0x08, 0x74, 0x06, 0x81, 0x07, 0x00, 0x00, 0x08, 0x00),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetStreamSource
 // ******************************************************************
 //7406810300000800 ...C20400
-OOVPA_XREF(D3DDevice_SetStreamSource_4, 2058, 1 + 12,
+OOVPA_SIG_HEADER_XREF(D3DDevice_SetStreamSource_4,
+                      2058,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1E, XREF_G_STREAM), // Derived
 
@@ -785,14 +860,16 @@ OOVPA_XREF(D3DDevice_SetStreamSource_4, 2058, 1 + 12,
     { 0x13, 0x00 },
     { 0x14, 0x08 },
     { 0x15, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
 //7707B800001000EB
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1060, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -804,14 +881,16 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay, 1060, 9)
     { 0x10B, 0x10 },
     { 0x10C, 0x00 },
     { 0x10D, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_UpdateOverlay
 // ******************************************************************
 //7707B800001000EB ...C21000
-OOVPA_NO_XREF(D3DDevice_UpdateOverlay_16, 2048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_UpdateOverlay_16,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x83 },
     { 0x01, 0xEC },
@@ -825,14 +904,16 @@ OOVPA_NO_XREF(D3DDevice_UpdateOverlay_16, 2048, 11)
     { 0xCE, 0x10 },
     { 0xCF, 0x00 },
     { 0xD0, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_EnableOverlay
 // ******************************************************************
 //00010000003990 ...C3
-OOVPA_NO_XREF(D3DDevice_EnableOverlay_0, 2048, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_EnableOverlay_0,
+                         2048)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x05, 0x8B },
@@ -847,14 +928,16 @@ OOVPA_NO_XREF(D3DDevice_EnableOverlay_0, 2048, 11)
     { 0x22, 0x90 },
 
     { 0x60, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_Swap
 // ******************************************************************
 //7505BB050000008B
-OOVPA_NO_XREF(D3DDevice_Swap, 1048, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Swap,
+                         1048)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
 
@@ -866,14 +949,16 @@ OOVPA_NO_XREF(D3DDevice_Swap, 1048, 9)
     { 0x2C, 0x00 },
     { 0x2D, 0x00 },
     { 0x2E, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetVertexDataColor
 // ******************************************************************
 //0C8D....40190400
-OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1060, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetVertexDataColor,
+                         1060)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -884,14 +969,16 @@ OOVPA_NO_XREF(D3DDevice_SetVertexDataColor, 1060, 8)
     { 0x2C, 0x00 },
     { 0x2D, 0x0F },
     { 0x2E, 0xB6 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2144, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2144)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -908,14 +995,16 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2144, 13)
 
     { 0x23C, 0x5B },
     { 0x23D, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * D3DDevice_SetShaderConstantMode
 // ******************************************************************
 //A810538B1D ...C3
-OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2156, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetShaderConstantMode_0,
+                         2156)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA8 },
     { 0x01, 0x10 },
@@ -932,4 +1021,5 @@ OOVPA_NO_XREF(D3DDevice_SetShaderConstantMode_0, 2156, 13)
 
     { 0x23B, 0x5B },
     { 0x23C, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/3911.inl
+++ b/src/OOVPADatabase/DSound/3911.inl
@@ -5577,7 +5577,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetVolume
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetVolume has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetVolume,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetVolume,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5609,7 +5609,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetVolume
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetVolume has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetVolume,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetVolume,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5641,7 +5641,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetPitch
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetPitch has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetPitch,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetPitch,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5673,7 +5673,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetPitch
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetPitch has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetPitch,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetPitch,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5705,7 +5705,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetLFO
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetLFO has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetLFO,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetLFO,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5737,7 +5737,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetLFO
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetLFO has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetLFO,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetLFO,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5769,7 +5769,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetEG
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetEG has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetEG,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetEG,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5801,7 +5801,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetEG
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetEG has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetEG,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetEG,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5833,7 +5833,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetFilter
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetFilter has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetFilter,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetFilter,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5864,7 +5864,7 @@ OOVPA_SIG_MATCH(
 // ******************************************************************
 // * IDirectSoundStream_SetFilter
 // ******************************************************************
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetFilter,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetFilter,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5896,7 +5896,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetHeadroom
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetHeadroom has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetHeadroom,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetHeadroom,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5928,7 +5928,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetHeadroom
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetHeadroom has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetHeadroom,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetHeadroom,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5960,7 +5960,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetFrequency
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetFrequency has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetFrequency,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetFrequency,
                              3911,
 
                              XRefNoSaveIndex,
@@ -5992,7 +5992,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetFrequency
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetFrequency has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetFrequency,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetFrequency,
                              3911,
 
                              XRefNoSaveIndex,
@@ -6024,7 +6024,7 @@ OOVPA_SIG_MATCH(
 // * CDirectSoundStream_SetMixBins
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetMixBins has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetMixBins,
+OOVPA_SIG_HEADER_XREF_DETECT(CDirectSoundStream_SetMixBins,
                              3911,
 
                              XRefNoSaveIndex,
@@ -6056,7 +6056,7 @@ OOVPA_SIG_MATCH(
 // * IDirectSoundStream_SetMixBins
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetMixBins has the same asm code as this function.
-OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetMixBins,
+OOVPA_SIG_HEADER_XREF_DETECT(IDirectSoundStream_SetMixBins,
                              3911,
 
                              XRefNoSaveIndex,

--- a/src/OOVPADatabase/DSound/3911.inl
+++ b/src/OOVPADatabase/DSound/3911.inl
@@ -27,11 +27,12 @@
 // * DirectSoundEnterCriticalSection
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(DirectSoundEnterCriticalSection, 3911, 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundEnterCriticalSection,
+                      3911,
 
-           XREF_DirectSoundEnterCriticalSection,
-           XRefZero)
-{
+                      XREF_DirectSoundEnterCriticalSection,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xB6 },
     { 0x06, 0x00 },
@@ -40,13 +41,15 @@ OOVPA_XREF(DirectSoundEnterCriticalSection, 3911, 7,
     { 0x14, 0xFF },
     { 0x1A, 0x33 },
     { 0x1B, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreate
 // ******************************************************************
-OOVPA_NO_XREF(DirectSoundCreate, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(DirectSoundCreate,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreate+0x23 : add eax, 8
     { 0x23, 0x83 },
@@ -64,16 +67,18 @@ OOVPA_NO_XREF(DirectSoundCreate, 3911, 9)
     // DirectSoundCreate+0x9B : retn 0x0C
     { 0x9B, 0xC2 },
     { 0x9C, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU_ServiceDeferredCommandsLow
 // ******************************************************************
-OOVPA_XREF(CMcpxAPU_ServiceDeferredCommandsLow, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_ServiceDeferredCommandsLow,
+                      3911,
 
-           XREF_CMcpxAPU_ServiceDeferredCommandsLow,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_ServiceDeferredCommandsLow,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_ServiceDeferredCommandsLow+0x00 : push ebx; push ebp
     OV_MATCH(0x00, 0x53, 0x55),
@@ -87,16 +92,18 @@ OOVPA_XREF(CMcpxAPU_ServiceDeferredCommandsLow, 3911, 13,
     // CMcpxAPU_ServiceDeferredCommandsLow+0x33 : add edi, 4; dec ebp
     OV_MATCH(0x33, 0x83, 0xC7, 0x04, 0x4D),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_DoWork
 // ******************************************************************
-OOVPA_XREF(CDirectSound_DoWork, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_DoWork,
+                      3911,
 
-           XREF_CDirectSound_DoWork,
-           XRefOne)
-{
+                      XREF_CDirectSound_DoWork,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_DoWork+0x0F : call [CMcpxAPU_ServiceDeferredCommandsLow]
     XREF_ENTRY(0x10, XREF_CMcpxAPU_ServiceDeferredCommandsLow),
@@ -114,16 +121,18 @@ OOVPA_XREF(CDirectSound_DoWork, 3911, 1 + 8,
     // CDirectSound_DoWork+0x24 : retn 0x04
     { 0x24, 0xC2 },
     { 0x25, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundDoWork
 // ******************************************************************
-OOVPA_XREF(DirectSoundDoWork, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(DirectSoundDoWork,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundDoWork+0x12 : call [CDirectSound_DoWork]
     XREF_ENTRY(0x13, XREF_CDirectSound_DoWork),
@@ -141,16 +150,18 @@ OOVPA_XREF(DirectSoundDoWork, 3911, 1 + 8,
 
     // DirectSoundDoWork+0x27 : retn
     { 0x27, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CreateSoundBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CreateSoundBuffer, 3911, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CreateSoundBuffer,
+                      3911,
 
-           XREF_CDirectSound_CreateSoundBuffer,
-           XRefZero)
-{
+                      XREF_CDirectSound_CreateSoundBuffer,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CreateSoundBuffer+0x00 : push ebp
     { 0x00, 0x55 },
@@ -178,17 +189,19 @@ OOVPA_XREF(CDirectSound_CreateSoundBuffer, 3911, 17,
     // CDirectSound_CreateSoundBuffer+0x7D : retn 0x10
     { 0x7D, 0xC2 },
     { 0x7E, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_CreateSoundBuffer
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_CreateSoundBuffer, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSound_CreateSoundBuffer,
+                      3911,
 
-           XREF_IDirectSound_CreateSoundBuffer,
-           XRefOne)
-{
+                      XREF_IDirectSound_CreateSoundBuffer,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_CreateSoundBuffer+0x1C : call [CDirectSound::CreateSoundBuffer]
     XREF_ENTRY(0x1D, XREF_CDirectSound_CreateSoundBuffer),
@@ -211,16 +224,18 @@ OOVPA_XREF(IDirectSound_CreateSoundBuffer, 3911, 1 + 11,
     // IDirectSound_CreateSoundBuffer+0x21 : retn 0x10
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreateBuffer
 // ******************************************************************
-OOVPA_XREF(DirectSoundCreateBuffer, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(DirectSoundCreateBuffer,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreateBuffer+0x27 : call [IDirectSound::CreateSoundBuffer]
     XREF_ENTRY(0x28, XREF_IDirectSound_CreateSoundBuffer),
@@ -242,16 +257,18 @@ OOVPA_XREF(DirectSoundCreateBuffer, 3911, 1 + 11,
     // DirectSoundCreateBuffer+0x3B : retn 0x08
     { 0x3B, 0xC2 },
     { 0x3C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CreateSoundStream
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CreateSoundStream, 3911, 16,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CreateSoundStream,
+                      3911,
 
-           XREF_CDirectSound_CreateSoundStream,
-           XRefZero)
-{
+                      XREF_CDirectSound_CreateSoundStream,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CreateSoundStream+0x2D : and esi, 0x7FF8FFF2
     { 0x2D, 0x81 },
@@ -276,17 +293,19 @@ OOVPA_XREF(CDirectSound_CreateSoundStream, 3911, 16,
     // CDirectSound_CreateSoundStream+0x72 : retn 0x10
     { 0x72, 0xC2 },
     { 0x73, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_CreateSoundStream
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_CreateSoundStream, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSound_CreateSoundStream,
+                      3911,
 
-           XREF_IDirectSound_CreateSoundStream,
-           XRefOne)
-{
+                      XREF_IDirectSound_CreateSoundStream,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_CreateSoundStream+0x1C : call [CDirectSound::CreateSoundStream]
     XREF_ENTRY(0x1D, XREF_CDirectSound_CreateSoundStream),
@@ -305,16 +324,18 @@ OOVPA_XREF(IDirectSound_CreateSoundStream, 3911, 1 + 9,
     // IDirectSound_CreateSoundStream+0x21 : retn 0x10
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreateStream
 // ******************************************************************
-OOVPA_XREF(DirectSoundCreateStream, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(DirectSoundCreateStream,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreateStream+0x27 : call [IDirectSound::CreateSoundStream]
     XREF_ENTRY(0x28, XREF_IDirectSound_CreateSoundStream),
@@ -336,14 +357,16 @@ OOVPA_XREF(DirectSoundCreateStream, 3911, 1 + 11,
     // DirectSoundCreateStream+0x3B : retn 0x08
     { 0x3B, 0xC2 },
     { 0x3C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_AddRef
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(IDirectSoundBuffer_AddRef, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(IDirectSoundBuffer_AddRef,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_AddRef+0x04 : lea ecx, [eax-0x1C]
     { 0x04, 0x8D },
@@ -363,14 +386,16 @@ OOVPA_NO_XREF(IDirectSoundBuffer_AddRef, 3911, 11)
 
     // IDirectSoundBuffer_AddRef+0x13 : ret 4
     { 0x13, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_Release
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(IDirectSoundBuffer_Release, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(IDirectSoundBuffer_Release,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_Release+0x04 : lea ecx, [eax-0x1C]
     { 0x04, 0x8D },
@@ -390,14 +415,16 @@ OOVPA_NO_XREF(IDirectSoundBuffer_Release, 3911, 11)
 
     // IDirectSoundBuffer_Release+0x13 : ret 4
     { 0x13, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_Unlock
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(IDirectSoundBuffer_Unlock, 3911, 5)
-{
+OOVPA_SIG_HEADER_NO_XREF(IDirectSoundBuffer_Unlock,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_Unlock+0x00 : xor eax, eax
     { 0x00, 0x33 },
@@ -407,35 +434,39 @@ OOVPA_NO_XREF(IDirectSoundBuffer_Unlock, 3911, 5)
     { 0x02, 0xC2 },
     { 0x03, 0x14 },
     { 0x04, 0x00 },
-} OOVPA_END;
+    //
+);
 
 #if 0 // Cannot be used since this OOVPA does produce false detection. Use it only for as a model understanding.
 // ******************************************************************
 // * IDirectSound_SetCooperativeLevel
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(IDirectSound_SetCooperativeLevel, 3911, 5)
-{
+OOVPA_SIG_HEADER_NO_XREF(IDirectSound_SetCooperativeLevel,
+                         3911)
+OOVPA_SIG_MATCH(
 
-        // IDirectSound_SetCooperativeLevel+0x00 : xor eax, eax
-        { 0x00, 0x33 },
-        { 0x01, 0xC0 },
+    // IDirectSound_SetCooperativeLevel+0x00 : xor eax, eax
+    { 0x00, 0x33 },
+    { 0x01, 0xC0 },
 
-        // IDirectSound_SetCooperativeLevel+0x02 : ret 0Ch
-        { 0x02, 0xC2 },
-        { 0x03, 0x0C },
-        { 0x04, 0x00 }
-} OOVPA_END;
+    // IDirectSound_SetCooperativeLevel+0x02 : ret 0Ch
+    { 0x02, 0xC2 },
+    { 0x03, 0x0C },
+    { 0x04, 0x00 }
+    //
+);
 #endif
 
 // ******************************************************************
 // * CMcpxVoiceClient_SetVolume
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetVolume, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetVolume,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetVolume,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetVolume+0x26 : mov ecx, [esi+0xE0]
     { 0x26, 0x8B },
@@ -453,16 +484,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetVolume, 3911, 11,
     { 0x35, 0x49 },
     { 0x36, 0xD1 },
     { 0x37, 0xF9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetVolume, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVolume,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1E, XREF_CMcpxVoiceClient_SetVolume),
 
@@ -485,16 +518,18 @@ OOVPA_XREF(CDirectSoundVoice_SetVolume, 3911, 1 + 10,
     //CDirectSoundVoice_SetVolume+0x37 : ret 8
     { 0x37, 0xC2 },
     { 0x38, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetVolume
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetVolume, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetVolume,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetVolume+0x15 : call [CDirectSoundVoice_SetVolume]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetVolume),
@@ -513,16 +548,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetVolume, 3911, 1 + 9,
     // IDirectSoundBuffer_SetVolume+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_Stop
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Stop, 3911, 10,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Stop,
+                      3911,
 
-           XREF_CMcpxBuffer_Stop,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Stop,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Stop+0x08 : or eax, dword ptr [esp+10h]
     { 0x08, 0x0B },
@@ -541,16 +578,18 @@ OOVPA_XREF(CMcpxBuffer_Stop, 3911, 10,
     // CMcpxBuffer_Stop+0x31 : retn 0x08
     { 0x31, 0xC2 },
     { 0x32, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_StopEx
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_StopEx, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_StopEx,
+                      3911,
 
-           XREF_CDirectSoundBuffer_StopEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_StopEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x39, XREF_CMcpxBuffer_Stop),
 
@@ -571,17 +610,19 @@ OOVPA_XREF(CDirectSoundBuffer_StopEx, 3911, 1 + 10,
     // CDirectSoundBuffer_StopEx+0x53 : retn 0x10
     { 0x53, 0xC2 },
     { 0x54, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_StopEx
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_StopEx, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_StopEx,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_StopEx+0x1D : call [CDirectSoundBuffer::StopEx]
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_StopEx),
@@ -594,16 +635,18 @@ OOVPA_XREF(IDirectSoundBuffer_StopEx, 3911, 1 + 8,
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Stop
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Stop, 3911, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Stop,
+                      3911,
 
-           XREF_CDirectSoundBuffer_Stop,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Stop,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x14, XREF_CDirectSoundBuffer_StopEx),
 
@@ -624,17 +667,19 @@ OOVPA_XREF(CDirectSoundBuffer_Stop, 3911, 1 + 12,
     // CDirectSoundBuffer_Stop+0x2D : retn 0x04
     { 0x2D, 0xC2 },
     { 0x2E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_Stop
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_Stop, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_Stop,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_Stop+0x11 : call [CDirectSoundBuffer::Stop]
     XREF_ENTRY(0x11, XREF_CDirectSoundBuffer_Stop),
@@ -657,16 +702,18 @@ OOVPA_XREF(IDirectSoundBuffer_Stop, 3911, 1 + 11,
     // IDirectSoundBuffer_Stop+0x15 : retn 4
     { 0x16, 0x04 },
     { 0x17, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetLoopRegion
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetLoopRegion, 3911, 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetLoopRegion,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetLoopRegion,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetLoopRegion,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetLoopRegion+0x20 : cmp edx, [ecx+0x54]
     { 0x20, 0x3B },
@@ -685,17 +732,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetLoopRegion, 3911, 10,
     // CDirectSoundBuffer_SetLoopRegion+0x4A : retn 0x0C
     { 0x4A, 0xC2 },
     { 0x4B, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetLoopRegion
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetLoopRegion, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetLoopRegion,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetLoopRegion+0x19 : call [CDirectSoundBuffer_SetLoopRegion]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetLoopRegion),
@@ -714,16 +763,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetLoopRegion, 3911, 1 + 9,
     // IDirectSoundBuffer_SetLoopRegion+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_Play
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Play, 3911, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play,
+                      3911,
 
-           XREF_CMcpxBuffer_Play,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x06, 0x56 },
     { 0x0E, 0xF1 },
@@ -734,16 +785,18 @@ OOVPA_XREF(CMcpxBuffer_Play, 3911, 9,
     { 0x26, 0x75 },
     { 0x2F, 0x8B },
     { 0x36, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_PlayEx
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_PlayEx, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_PlayEx,
+                      3911,
 
-           XREF_CDirectSoundBuffer_PlayEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_PlayEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x21, XREF_CMcpxBuffer_Play),
 
@@ -758,16 +811,18 @@ OOVPA_XREF(CDirectSoundBuffer_PlayEx, 3911, 1 + 8,
 
     { 0x3A, 0xC2 },
     { 0x3B, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Play
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Play, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Play,
+                      3911,
 
-           XREF_CDirectSoundBuffer_Play,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Play,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x16, XREF_CDirectSoundBuffer_PlayEx),
 
@@ -778,17 +833,19 @@ OOVPA_XREF(CDirectSoundBuffer_Play, 3911, 1 + 7,
     { 0x25, 0xFF },
     { 0x2B, 0x8B },
     { 0x2F, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_Play
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_Play, 3911, 1 + 15,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_Play,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_Play+0x1D : call CDirectSoundBuffer::Play
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_Play),
@@ -817,17 +874,19 @@ OOVPA_XREF(IDirectSoundBuffer_Play, 3911, 1 + 15,
     // IDirectSoundBuffer_Play+0x21 : retn 0x10
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_PlayEx
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_PlayEx, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_PlayEx,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_PlayEx),
 
@@ -838,16 +897,18 @@ OOVPA_XREF(IDirectSoundBuffer_PlayEx, 3911, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_GetCurrentPosition, 3911, 15,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_GetCurrentPosition,
+                      3911,
 
-           XREF_CMcpxBuffer_GetCurrentPosition,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_GetCurrentPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_GetCurrentPosition+0x12 : mov eax, [esi+XX]
     { 0x12, 0x8B },
@@ -876,16 +937,18 @@ OOVPA_XREF(CMcpxBuffer_GetCurrentPosition, 3911, 15,
     { 0xC8, 0xC2 },
     { 0xC9, 0x08 },
     { 0xCA, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_GetCurrentPosition, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetCurrentPosition,
+                      3911,
 
-           XREF_CDirectSoundBuffer_GetCurrentPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetCurrentPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_GetCurrentPosition+0x19 : call [CMcpxBuffer::GetCurrentPosition]
     XREF_ENTRY(0x19, XREF_CMcpxBuffer_GetCurrentPosition),
@@ -903,17 +966,19 @@ OOVPA_XREF(CDirectSoundBuffer_GetCurrentPosition, 3911, 1 + 8,
     // CDirectSoundBuffer_GetCurrentPosition+0x32 : retn 0x0C
     { 0x32, 0xC2 },
     { 0x33, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_GetCurrentPosition
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_GetCurrentPosition, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_GetCurrentPosition,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_GetCurrentPosition+0x19 : call [CDirectSoundBuffer::GetCurrentPosition]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_GetCurrentPosition),
@@ -930,16 +995,18 @@ OOVPA_XREF(IDirectSoundBuffer_GetCurrentPosition, 3911, 1 + 7,
     // IDirectSoundBuffer_GetCurrentPosition+0x15 : and ecx, eax
     { 0x15, 0x23 },
     { 0x16, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_GetStatus, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_GetStatus,
+                      3911,
 
-           XREF_CMcpxBuffer_GetStatus,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_GetStatus,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_GetStatus+0x10 : mov eax, [ebp+0x08]
     { 0x10, 0x8B },
@@ -963,16 +1030,18 @@ OOVPA_XREF(CMcpxBuffer_GetStatus, 3911, 13,
     // CMcpxBuffer_GetStatus+0x48 : retn 0x04
     { 0x48, 0xC2 },
     { 0x49, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetStatus
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_GetStatus, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetStatus,
+                      3911,
 
-           XREF_CDirectSoundBuffer_GetStatus,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetStatus,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_GetStatus+0x15 : call [CMcpxBuffer::GetStatus]
     XREF_ENTRY(0x15, XREF_CMcpxBuffer_GetStatus),
@@ -991,17 +1060,19 @@ OOVPA_XREF(CDirectSoundBuffer_GetStatus, 3911, 1 + 9,
     // CDirectSoundBuffer_GetStatus+0x2E : retn 0x08
     { 0x2E, 0xC2 },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_GetStatus
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_GetStatus, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_GetStatus,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_GetStatus+0x15 : call [CDirectSoundBuffer::GetStatus]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_GetStatus),
@@ -1020,16 +1091,18 @@ OOVPA_XREF(IDirectSoundBuffer_GetStatus, 3911, 1 + 9,
     // IDirectSoundBuffer_GetStatus+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetFilter
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetFilter, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetFilter,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetFilter,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetFilter,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0xE8 },
     { 0x1F, 0x6A },
@@ -1045,16 +1118,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetFilter, 3911, 12,
 
     { 0xA6, 0x8B },
     { 0xA7, 0xE0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetFilter
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetFilter, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetFilter,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CMcpxVoiceClient_SetFilter),
 
@@ -1067,16 +1142,18 @@ OOVPA_XREF(CDirectSoundVoice_SetFilter, 3911, 1 + 9,
     { 0x12, 0x48 },
     { 0x2E, 0xC2 },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetFilter
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetFilter, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetFilter,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetFilter+0x15 : call [CDirectSoundVoice_SetFilter]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetFilter),
@@ -1095,16 +1172,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetFilter, 3911, 1 + 9,
     // IDirectSoundBuffer_SetFilter+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetLFO
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetLFO, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetLFO,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetLFO,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetLFO,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x10, 0x8B },
     { 0x21, 0xEB },
@@ -1120,16 +1199,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetLFO, 3911, 12,
 
     { 0xA1, 0x89 },
     { 0xB7, 0x6C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetLFO
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetLFO, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetLFO,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CMcpxVoiceClient_SetLFO),
 
@@ -1143,16 +1224,18 @@ OOVPA_XREF(CDirectSoundVoice_SetLFO, 3911, 1 + 9,
 
     { 0x2E, 0xC2 },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetLFO
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetLFO, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetLFO,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetLFO),
 
@@ -1163,16 +1246,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetLFO, 3911, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetEG
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetEG, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetEG,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetEG,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetEG,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x10, 0x8B },
     { 0x21, 0xEB },
@@ -1188,16 +1273,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetEG, 3911, 12,
     { 0x9A, 0x00 },
     { 0x9B, 0x89 },
     { 0x9C, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetEG
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetEG, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetEG,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CMcpxVoiceClient_SetEG),
 
@@ -1210,16 +1297,18 @@ OOVPA_XREF(CDirectSoundVoice_SetEG, 3911, 1 + 9,
     { 0x12, 0x48 },
     { 0x2E, 0xC2 },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetEG
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetEG, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetEG,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetEG),
 
@@ -1230,17 +1319,19 @@ OOVPA_XREF(IDirectSoundBuffer_SetEG, 3911, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetOutputBuffer
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetOutputBuffer, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetOutputBuffer,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetOutputBuffer),
 
@@ -1251,16 +1342,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetOutputBuffer, 3911, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMixBinVolumes
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMixBinVolumes, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMixBinVolumes,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetMixBinVolumes,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMixBinVolumes,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x54, XREF_CMcpxVoiceClient_SetVolume),
 
@@ -1271,16 +1364,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMixBinVolumes, 3911, 1 + 7,
     { 0x49, 0xFC },
     { 0x58, 0x83 },
     { 0x67, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMixBinVolumes_12
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetMixBinVolumes_12, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMixBinVolumes_12,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSoundVoice_SetMixBinVolumes),
 
@@ -1292,16 +1387,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMixBinVolumes_12, 3911, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetMixBinVolumes
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMixBinVolumes_12, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMixBinVolumes_12,
+                      3911,
 
-           XREF_CDirectSoundStream_SetMixBinVolumes_12,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMixBinVolumes_12,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetMixBinVolumes),
 
@@ -1313,17 +1410,19 @@ OOVPA_XREF(CDirectSoundStream_SetMixBinVolumes_12, 3911, 1 + 8,
     { 0x10, 0xE8 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU_Commit3dSettings
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_Commit3dSettings, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Commit3dSettings,
+                      3911,
 
-           XREF_CMcpxAPU_Commit3dSettings,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Commit3dSettings,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_Commit3dSettings+0x56 : fld dword ptr [eax+0x174]
     { 0x56, 0xD9 },
@@ -1341,16 +1440,18 @@ OOVPA_XREF(CMcpxAPU_Commit3dSettings, 3911, 11,
     { 0xD4, 0xBE },
     { 0xD5, 0x18 },
     { 0xD6, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_CommitDeferredSettings
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CommitDeferredSettings, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitDeferredSettings,
+                      3911,
 
-           XREF_CDirectSound_CommitDeferredSettings,
-           XRefOne)
-{
+                      XREF_CDirectSound_CommitDeferredSettings,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CommitDeferredSettings+0x12 : call [CMcpxAPU_Commit3dSettings]
     XREF_ENTRY(0x12, XREF_CMcpxAPU_Commit3dSettings),
@@ -1371,17 +1472,19 @@ OOVPA_XREF(CDirectSound_CommitDeferredSettings, 3911, 1 + 9,
     // CDirectSound_CommitDeferredSettings+0x28 : retn 0x04
     { 0x28, 0xC2 },
     { 0x29, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_CommitDeferredSettings
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSound_CommitDeferredSettings, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound_CommitDeferredSettings,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_CommitDeferredSettings+0x11 : call [CDirectSound_CommitDeferredSettings]
     XREF_ENTRY(0x11, XREF_CDirectSound_CommitDeferredSettings),
@@ -1398,16 +1501,18 @@ OOVPA_XREF(IDirectSound_CommitDeferredSettings, 3911, 1 + 7,
     // IDirectSound_CommitDeferredSettings+0x15 : retn 0x04
     { 0x15, 0xC2 },
     { 0x16, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetOrientation, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetOrientation,
+                      3911,
 
-           XREF_CDirectSound_SetOrientation,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetOrientation+0x00 : push ebp
     { 0x00, 0x55 },
@@ -1424,17 +1529,19 @@ OOVPA_XREF(CDirectSound_SetOrientation, 3911, 13,
     { 0x29, 0x1C },
     { 0x2D, 0x8B },
     { 0x2F, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetOrientation
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSound_SetOrientation, 3911, 1 + 14,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetOrientation,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_CommitDeferredSettings+0x11 : call [CDirectSound_CommitDeferredSettings]
     XREF_ENTRY(0x42, XREF_CDirectSound_SetOrientation),
@@ -1464,14 +1571,16 @@ OOVPA_XREF(IDirectSound_SetOrientation, 3911, 1 + 14,
     // IDirectSound_SetOrientation+0x47 : retn 0x20
     { 0x47, 0xC2 },
     { 0x48, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_AddRef
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_NO_XREF(IDirectSound_AddRef, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(IDirectSound_AddRef,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_AddRef+0x04 : lea ecx, [eax-8]
     { 0x04, 0x8D },
@@ -1494,14 +1603,16 @@ OOVPA_NO_XREF(IDirectSound_AddRef, 3911, 12)
     { 0x10, 0xFF },
     { 0x11, 0x51 },
     { 0x12, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_Release
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_NO_XREF(IDirectSound_Release, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(IDirectSound_Release,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_Release+0x04 : lea ecx, [eax-8]
     { 0x04, 0x8D },
@@ -1520,16 +1631,18 @@ OOVPA_NO_XREF(IDirectSound_Release, 3911, 10)
     // IDirectSound_Release+0x13 : retn 0x04
     { 0x13, 0xC2 },
     { 0x14, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_SetPitch
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetPitch, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetPitch,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetPitch,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetPitch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetPitch+0x21 : lea edi, [esi+0xB4]
     { 0x21, 0x8D },
@@ -1547,16 +1660,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetPitch, 3911, 11,
     { 0x5E, 0x48 },
     { 0x5F, 0xD1 },
     { 0x60, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetPitch
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetPitch, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetPitch,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetPitch+0x1B : call [CMcpxVoiceClient_SetPitch]
     XREF_ENTRY(0x1B, XREF_CMcpxVoiceClient_SetPitch),
@@ -1579,16 +1694,18 @@ OOVPA_XREF(CDirectSoundVoice_SetPitch, 3911, 1 + 11,
     // CDirectSoundVoice_SetPitch+0x34 : retn 0x08
     { 0x34, 0xC2 },
     { 0x35, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetPitch
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetPitch, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetPitch,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetPitch+0x15 : call [CDirectSoundVoice_SetPitch]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetPitch),
@@ -1607,16 +1724,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetPitch, 3911, 1 + 9,
     // IDirectSoundBuffer_SetPitch+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioCalculatePitch
 // ******************************************************************
-OOVPA_XREF(XAudioCalculatePitch, 3911, 12,
+OOVPA_SIG_HEADER_XREF(XAudioCalculatePitch,
+                      3911,
 
-           XREF_XAudioCalculatePitch,
-           XRefZero)
-{
+                      XREF_XAudioCalculatePitch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -1638,13 +1757,15 @@ OOVPA_XREF(XAudioCalculatePitch, 3911, 12,
     // XAudioCalculatePitch+0x4E : retn 0x04
     { 0x4E, 0xC2 },
     { 0x4F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundGetSampleTime
 // ******************************************************************
-OOVPA_NO_XREF(DirectSoundGetSampleTime, 3911, 6)
-{
+OOVPA_SIG_HEADER_NO_XREF(DirectSoundGetSampleTime,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x01, 0x0C },
@@ -1652,16 +1773,18 @@ OOVPA_NO_XREF(DirectSoundGetSampleTime, 3911, 6)
     { 0x03, 0x80 },
     { 0x04, 0xFE },
     { 0x05, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CSensaura3d::GetFullHRTFFilterPair
 // ******************************************************************
-OOVPA_XREF(CSensaura3d_GetFullHRTFFilterPair, 3911, 7,
+OOVPA_SIG_HEADER_XREF(CSensaura3d_GetFullHRTFFilterPair,
+                      3911,
 
-           XREF_CSensaura3d_GetFullHRTFFilterPair,
-           XRefZero)
-{
+                      XREF_CSensaura3d_GetFullHRTFFilterPair,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0xEB },
     { 0x2E, 0x6A },
@@ -1670,16 +1793,18 @@ OOVPA_XREF(CSensaura3d_GetFullHRTFFilterPair, 3911, 7,
     { 0x7E, 0x1E },
     { 0xA2, 0xD9 },
     { 0xBE, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseFullHRTF
 // ******************************************************************
-OOVPA_XREF(DirectSoundUseFullHRTF, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseFullHRTF,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0D, XREF_CSensaura3d_GetFullHRTFFilterPair),
 
@@ -1690,17 +1815,19 @@ OOVPA_XREF(DirectSoundUseFullHRTF, 3911, 1 + 7,
     { 0x13, 0x68 },
     { 0x18, 0xFF },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CSensaura3d_GetLiteHRTFFilterPair
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(CSensaura3d_GetLiteHRTFFilterPair, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CSensaura3d_GetLiteHRTFFilterPair,
+                      3911,
 
-           XREF_CSensaura3d_GetLiteHRTFFilterPair,
-           XRefZero)
-{
+                      XREF_CSensaura3d_GetLiteHRTFFilterPair,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -1718,16 +1845,18 @@ OOVPA_XREF(CSensaura3d_GetLiteHRTFFilterPair, 3911, 11,
 
     // idiv eax, ecx
     OV_MATCH(0x22, 0xF7, 0xF9),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseLightHRTF
 // ******************************************************************
-OOVPA_XREF(DirectSoundUseLightHRTF, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseLightHRTF,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0D, XREF_CSensaura3d_GetLiteHRTFFilterPair),
 
@@ -1738,16 +1867,18 @@ OOVPA_XREF(DirectSoundUseLightHRTF, 3911, 1 + 7,
     { 0x13, 0x68 },
     { 0x18, 0xFF },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetFrequency
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetFrequency, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetFrequency,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetFrequency,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetFrequency,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetFrequency+0x1F : call [XAudioCalculatePitch]
     XREF_ENTRY(0x20, XREF_XAudioCalculatePitch),
@@ -1765,16 +1896,18 @@ OOVPA_XREF(CDirectSoundVoice_SetFrequency, 3911, 1 + 8,
     // CDirectSoundVoice_SetFrequency+0x40 : retn 0x08
     { 0x40, 0xC2 },
     { 0x41, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetFrequency
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetFrequency, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetFrequency,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetFrequency+0x14 : call [CDirectSoundVoice_SetFrequency]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetFrequency),
@@ -1791,16 +1924,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetFrequency, 3911, 1 + 7,
     // IDirectSoundBuffer_SetFrequency+0x11 : and ecx, eax
     { 0x11, 0x23 },
     { 0x12, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetMixBins
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetMixBins, 3911, 16,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetMixBins,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetMixBins,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetMixBins,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetMixBins+0x1D : lea eax, [esi+0x84]
     { 0x1D, 0x86 },
@@ -1829,16 +1964,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetMixBins, 3911, 16,
 
     // CMcpxVoiceClient_SetMixBins+0xD6 : retn
     { 0xD6, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMixBins
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMixBins, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMixBins,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetMixBins,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMixBins,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMixBins+0x28 : call [CMcpxVoiceClient::SetMixBins]
     XREF_ENTRY(0x29, XREF_CMcpxVoiceClient_SetMixBins),
@@ -1856,16 +1993,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMixBins, 3911, 1 + 8,
     // CDirectSoundVoice_SetMixBins+0x55 : retn 0x08
     { 0x55, 0xC2 },
     { 0x56, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMixBins
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetMixBins, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMixBins,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetMixBins+0x14 : call [CDirectSoundVoice::SetMixBins]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetMixBins),
@@ -1882,16 +2021,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMixBins, 3911, 1 + 7,
     // IDirectSoundBuffer_SetMixBins+0x11 : and ecx, eax
     { 0x11, 0x23 },
     { 0x12, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetOutputBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetOutputBuffer, 3911, 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetOutputBuffer,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetOutputBuffer,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetOutputBuffer,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0xF7 },
     { 0x19, 0x8B },
@@ -1900,16 +2041,18 @@ OOVPA_XREF(CDirectSoundVoice_SetOutputBuffer, 3911, 7,
     { 0x35, 0x8B },
     { 0x46, 0x74 },
     { 0x51, 0xD8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetOutputBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetOutputBuffer, 3911, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetOutputBuffer,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetOutputBuffer,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetOutputBuffer,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetOutputBuffer+0x11 : call [XREF_CDirectSoundVoice_SetOutputBuffer]
     XREF_ENTRY(0x12, XREF_CDirectSoundVoice_SetOutputBuffer),
@@ -1935,16 +2078,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetOutputBuffer, 3911, 1 + 12,
     // CDirectSoundBuffer_SetOutputBuffer+0x2B : retn 0x08
     { 0x2B, 0xC2 },
     { 0x2C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetBufferData
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetBufferData, 3911, 2 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetBufferData,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetBufferData,
-           XRefTwo)
-{
+                      XREF_CDirectSoundBuffer_SetBufferData,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetBufferData+0x3C : call [CDirectSoundBufferSettings::SetBufferData]
     XREF_ENTRY(0x3D, XREF_CDirectSoundBufferSettings_SetBufferData),
@@ -1969,17 +2114,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetBufferData, 3911, 2 + 10,
     { 0x71, 0xC9 },
     { 0x72, 0xC2 },
     { 0x73, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetBufferData
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetBufferData, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetBufferData,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetBufferData+0x18 : call [CDirectSoundBuffer_SetBufferData]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetBufferData),
@@ -1998,16 +2145,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetBufferData, 3911, 1 + 9,
     // IDirectSoundBuffer_SetBufferData+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetNotificationPositions
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 3911, 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetNotificationPositions,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetNotificationPositions,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetNotificationPositions,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x24 },
     { 0x14, 0x24 },
@@ -2016,17 +2165,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 3911, 7,
     { 0x35, 0xF6 },
     { 0x40, 0x07 },
     { 0x4D, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetNotificationPositions
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetNotificationPositions, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetNotificationPositions,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetNotificationPositions),
 
@@ -2038,16 +2189,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetNotificationPositions, 3911, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetHeadroom
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetHeadroom, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetHeadroom,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetHeadroom+0x22 : call [CMcpxVoiceClient::SetVolume]
     XREF_ENTRY(0x23, XREF_CMcpxVoiceClient_SetVolume),
@@ -2070,16 +2223,18 @@ OOVPA_XREF(CDirectSoundVoice_SetHeadroom, 3911, 1 + 11,
     // CDirectSoundVoice_SetHeadroom+0x3C : retn 0x08
     { 0x3C, 0xC2 },
     { 0x3D, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetHeadroom
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetHeadroom, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetHeadroom,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetHeadroom+0x15 : call [CDirectSoundVoice_SetHeadroom]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetHeadroom),
@@ -2098,16 +2253,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetHeadroom, 3911, 1 + 9,
     // IDirectSoundBuffer_SetHeadroom+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Pause
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Pause, 3911, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Pause,
+                      3911,
 
-           XREF_CDirectSoundStream_Pause,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_Pause,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_CMcpxStream_Pause),
 
@@ -2117,13 +2274,15 @@ OOVPA_XREF(CDirectSoundStream_Pause, 3911, 1 + 6,
     { 0x0A, 0x24 },
     { 0x10, 0xC2 },
     { 0x11, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Process
 // ******************************************************************
-OOVPA_NO_XREF(CDirectSoundStream_Process, 3911, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_Process,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x8B },
     { 0x04, 0x08 },
@@ -2148,13 +2307,15 @@ OOVPA_NO_XREF(CDirectSoundStream_Process, 3911, 16)
 
     { 0x25, 0xC2 },
     { 0x26, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetStatus
 // ******************************************************************
-OOVPA_NO_XREF(CDirectSoundStream_GetStatus, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_GetStatus,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 }, //Prevent false detection & check if is at beginning of function.
 
@@ -2177,16 +2338,18 @@ OOVPA_NO_XREF(CDirectSoundStream_GetStatus, 3911, 14)
 
     { 0x32, 0xC2 },
     { 0x33, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Flush, 3911, 15,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Flush,
+                      3911,
 
-           XREF_CMcpxStream_Flush,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Flush,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0D, 0x03 },
     { 0x0F, 0x03 },
@@ -2210,16 +2373,18 @@ OOVPA_XREF(CMcpxStream_Flush, 3911, 15,
 
     { 0x9D, 0xC9 },
     { 0x9E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Flush
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Flush, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Flush,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream::Flush+0x10 : call [CMcpxStream::Flush]
     XREF_ENTRY(0x11, XREF_CMcpxStream_Flush),
@@ -2238,16 +2403,18 @@ OOVPA_XREF(CDirectSoundStream_Flush, 3911, 1 + 8,
     // CDirectSoundStream::Flush+0x2A : ret 4
     { 0x2A, 0xC2 },
     { 0x2B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Discontinuity, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Discontinuity,
+                      3911,
 
-           XREF_CMcpxStream_Discontinuity,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Discontinuity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CMcpxStream_Discontinuity+0x66 : call [CMcpxStream_Flush]
     XREF_ENTRY(0x67, XREF_CMcpxStream_Flush),
@@ -2268,16 +2435,18 @@ OOVPA_XREF(CMcpxStream_Discontinuity, 3911, 1 + 11,
 
     { 0x6E, 0xC9 },
     { 0x6F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Discontinuity, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Discontinuity,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream_Discontinuity+0x10 : call [CMcpxStream_Discontinuity]
     XREF_ENTRY(0x11, XREF_CMcpxStream_Discontinuity),
@@ -2296,13 +2465,15 @@ OOVPA_XREF(CDirectSoundStream_Discontinuity, 3911, 1 + 8,
     //CDirectSoundStream_Discontinuity+0x2A : ret 4
     { 0x2A, 0xC2 },
     { 0x2B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetInfo
 // ******************************************************************
-OOVPA_NO_XREF(CDirectSoundStream_GetInfo, 3911, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_GetInfo,
+                         3911)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream_GetInfo+0x00 : push ebx
     { 0x00, 0x53 },
@@ -2332,17 +2503,19 @@ OOVPA_NO_XREF(CDirectSoundStream_GetInfo, 3911, 17)
     //CDirectSoundStream_GetInfo+0x48 : ret 8
     { 0x48, 0xC2 },
     { 0x49, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dMaxDistance
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dMaxDistance, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dMaxDistance,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dMaxDistance,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dMaxDistance,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dMaxDistance+0x04 : or byte ptr [ecx+0x80], 0x04
     { 0x04, 0x83 },
@@ -2361,16 +2534,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dMaxDistance, 3911, 12,
     // CMcpxVoiceClient_Set3dMaxDistance+0x1E : retn 0x08
     { 0x1E, 0xC2 },
     { 0x1F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 3911, 1 + 14,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMaxDistance,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMaxDistance+0x23 : call [CMcpxVoiceClient_Set3dMaxDistance]
     XREF_ENTRY(0x23, XREF_CMcpxVoiceClient_Set3dMaxDistance),
@@ -2398,16 +2573,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 3911, 1 + 14,
     // CDirectSoundVoice_SetMaxDistance+0x3C : retn 0x0C
     { 0x3C, 0xC2 },
     { 0x3D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMaxDistance, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMaxDistance,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetMaxDistance),
 
@@ -2419,17 +2596,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMaxDistance, 3911, 1 + 8,
     { 0x10, 0xE8 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMaxDistance
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetMaxDistance, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMaxDistance,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetMaxDistance),
 
@@ -2440,16 +2619,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMaxDistance, 3911, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMaxDistance, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMaxDistance,
+                      3911,
 
-           XREF_CDirectSoundStream_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetMaxDistance+0x15 : call [CDirectSoundVoice_SetMaxDistance]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetMaxDistance),
@@ -2468,17 +2649,19 @@ OOVPA_XREF(CDirectSoundStream_SetMaxDistance, 3911, 1 + 9,
     // CDirectSoundStream_SetMaxDistance+0x19 : retn 0x0C
     { 0x19, 0xC2 },
     { 0x1A, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMaxDistance
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundStream_SetMaxDistance, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetMaxDistance,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetMaxDistance+0x11 : call [CDirectSoundStream_SetMaxDistance]
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_SetMaxDistance),
@@ -2498,17 +2681,19 @@ OOVPA_XREF(IDirectSoundStream_SetMaxDistance, 3911, 1 + 10,
     // CDirectSoundStream_SetMaxDistance+0x15 : retn 0x0C
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dMinDistance
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dMinDistance, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dMinDistance,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dMinDistance,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dMinDistance,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dMinDistance+0x04 : or byte ptr [ecx+0x80], 0x04
     { 0x04, 0x83 },
@@ -2527,16 +2712,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dMinDistance, 3911, 12,
     // CMcpxVoiceClient_Set3dMinDistance+0x1E : retn 0x08
     { 0x1E, 0xC2 },
     { 0x1F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 3911, 1 + 14,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMinDistance,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMinDistance+0x23 : call [CMcpxVoiceClient_Set3dMinDistance]
     XREF_ENTRY(0x23, XREF_CMcpxVoiceClient_Set3dMinDistance),
@@ -2564,16 +2751,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 3911, 1 + 14,
     // CDirectSoundVoice_SetMinDistance+0x3C : retn 0x0C
     { 0x3C, 0xC2 },
     { 0x3D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMinDistance, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMinDistance,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetMinDistance),
 
@@ -2585,17 +2774,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMinDistance, 3911, 1 + 8,
     { 0x10, 0xE8 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMinDistance
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetMinDistance, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMinDistance,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetMinDistance),
 
@@ -2606,16 +2797,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMinDistance, 3911, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMinDistance, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMinDistance,
+                      3911,
 
-           XREF_CDirectSoundStream_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetMinDistance+0x15 : call [CDirectSoundVoice_SetMinDistance]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetMinDistance),
@@ -2634,17 +2827,19 @@ OOVPA_XREF(CDirectSoundStream_SetMinDistance, 3911, 1 + 9,
     // CDirectSoundStream_SetMinDistance+0x19 : retn 0x0C
     { 0x19, 0xC2 },
     { 0x1A, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMinDistance
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundStream_SetMinDistance, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetMinDistance,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetMinDistance+0x11 : call [CDirectSoundStream_SetMinDistance]
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_SetMinDistance),
@@ -2664,17 +2859,19 @@ OOVPA_XREF(IDirectSoundStream_SetMinDistance, 3911, 1 + 10,
     // CDirectSoundStream_SetMinDistance+0x15 : retn 0x0C
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dConeOutsideVolume
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dConeOutsideVolume, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dConeOutsideVolume,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dConeOutsideVolume,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dConeOutsideVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dConeOutsideVolume+0x04 : or dword ptr [eax+0x80], 0x10
     { 0x04, 0x83 },
@@ -2693,16 +2890,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dConeOutsideVolume, 3911, 12,
     // CMcpxVoiceClient_Set3dConeOutsideVolume+0x1E : retn 0x08
     { 0x1E, 0xC2 },
     { 0x1F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOutsideVolume,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOutsideVolume+0x1F : call [CMcpxVoiceClient_Set3dConeOutsideVolume]
     XREF_ENTRY(0x1F, XREF_CMcpxVoiceClient_Set3dConeOutsideVolume),
@@ -2723,32 +2922,36 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 3911, 1 + 11,
     // CDirectSoundVoice_SetConeOutsideVolume+0x38 : retn 0x0C
     { 0x38, 0xC2 },
     { 0x39, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetConeOutsideVolume, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeOutsideVolume,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetConeOutsideVolume+0x00 : jmp CDirectSoundVoice::SetConeOutsideVolume
     XREF_ENTRY(0x1, XREF_CDirectSoundVoice_SetConeOutsideVolume),
 
     // CDirectSoundBuffer::SetConeOutsideVolume+0x00 : jmp
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetConeOutsideVolume, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetConeOutsideVolume,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetConeOutsideVolume+0x18 : call [CDirectSoundVoice_SetConeOutsideVolume]
     XREF_ENTRY(0x19, XREF_CDirectSoundVoice_SetConeOutsideVolume),
@@ -2766,16 +2969,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetConeOutsideVolume, 3911, 1 + 8,
     // IDirectSoundBuffer_SetConeOutsideVolume+0x1D : retn 0Ch
     { 0x1E, 0x0C },
     { 0x1F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetConeOutsideVolume, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeOutsideVolume,
+                      3911,
 
-           XREF_CDirectSoundStream_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetConeOutsideVolume+0x11 : call [CDirectSoundVoice_SetConeOutsideVolume]
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetConeOutsideVolume),
@@ -2794,16 +2999,18 @@ OOVPA_XREF(CDirectSoundStream_SetConeOutsideVolume, 3911, 1 + 9,
     // CDirectSoundStream_SetConeOutsideVolume+0x15 : retn 0x0C
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 3911, 2 + 11,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefTwo)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient::Commit3dSettings+0x65 : call [CMcpxVoiceClient_SetVolume]
     XREF_ENTRY(0x66, XREF_CMcpxVoiceClient_SetVolume),
@@ -2827,17 +3034,19 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 3911, 2 + 11,
     { 0x3D, 0x0F },
     { 0x3E, 0xB1 },
     { 0x3F, 0x11 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dParameters
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dParameters, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dParameters,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dParameters,
-           XRefOne)
-{
+                      XREF_CMcpxVoiceClient_Set3dParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x25, XREF_CMcpxVoiceClient_Commit3dSettings),
 
@@ -2852,16 +3061,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dParameters, 3911, 1 + 11,
     { 0x14, 0x00 },
     { 0x18, 0x7C },
     { 0x1F, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetAllParameters, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetAllParameters,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetAllParameters+0x25 : call [CMcpxVoiceClient_Set3dParameters]
     XREF_ENTRY(0x1F, XREF_CMcpxVoiceClient_Set3dParameters),
@@ -2882,16 +3093,18 @@ OOVPA_XREF(CDirectSoundVoice_SetAllParameters, 3911, 1 + 11,
     // CDirectSoundVoice_SetAllParameters+0x38 : retn 0x0C
     { 0x38, 0xC2 },
     { 0x39, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetAllParameters, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetAllParameters,
+                      3911,
 
-           XREF_CDirectSoundStream_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetAllParameters+0x11 : call [CDirectSoundVoice_SetAllParameters]
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetAllParameters),
@@ -2910,16 +3123,18 @@ OOVPA_XREF(CDirectSoundStream_SetAllParameters, 3911, 1 + 9,
     // CDirectSoundStream_SetAllParameters+0x15 : retn 0x0C
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetAllParameters
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetAllParameters, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetAllParameters,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSoundVoice_SetAllParameters),
 
@@ -2931,16 +3146,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetAllParameters, 3911, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeAngles
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 3911, 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeAngles,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetConeAngles,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeAngles,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0E, 0xD0 },
@@ -2950,16 +3167,18 @@ OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 3911, 8,
     { 0x32, 0xFF },
     { 0x38, 0x8B },
     { 0x3E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetConeAngles
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetConeAngles, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetConeAngles,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSoundVoice_SetConeAngles),
 
@@ -2970,16 +3189,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetConeAngles, 3911, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeAngles
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetConeAngles, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeAngles,
+                      3911,
 
-           XREF_CDirectSoundStream_SetConeAngles,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeAngles,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetConeAngles+0x15 : call [CDirectSoundVoice_SetConeAngles]
     XREF_ENTRY(0x15, XREF_CDirectSoundVoice_SetConeAngles),
@@ -2998,17 +3219,19 @@ OOVPA_XREF(CDirectSoundStream_SetConeAngles, 3911, 1 + 9,
     // CDirectSoundStream_SetConeAngles+0x19 : retn 0x10
     { 0x19, 0xC2 },
     { 0x1A, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dConeOrientation
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dConeOrientation, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dConeOrientation,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dConeOrientation,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dConeOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dConeOrientation+0x0C : or byte ptr [ecx+0x80], 0x18
     { 0x0C, 0x83 },
@@ -3026,16 +3249,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dConeOrientation, 3911, 11,
     // CMcpxVoiceClient_Set3dConeOrientation+0x25 : retn 0x08
     { 0x25, 0xC2 },
     { 0x26, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 3911, 1 + 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOrientation,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOrientation+0x34 : call [CMcpxVoiceClient_Set3dConeOrientation]
     XREF_ENTRY(0x35, XREF_CMcpxVoiceClient_Set3dConeOrientation),
@@ -3062,16 +3287,18 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 3911, 1 + 13,
     // CDirectSoundVoice_SetConeOrientation+0x4F : retn 0x14
     { 0x4F, 0xC2 },
     { 0x50, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetConeOrientation, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeOrientation,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x21, XREF_CDirectSoundVoice_SetConeOrientation),
 
@@ -3090,17 +3317,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeOrientation, 3911, 1 + 10,
     { 0x26, 0xC2 },
     { 0x27, 0x14 },
     { 0x28, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetConeOrientation
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetConeOrientation, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetConeOrientation,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetConeOrientation+0x2C : call [CDirectSoundBuffer::SetConeOrientation]
     XREF_ENTRY(0x2D, XREF_CDirectSoundBuffer_SetConeOrientation),
@@ -3118,16 +3347,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetConeOrientation, 3911, 1 + 8,
     // IDirectSoundBuffer_SetConeOrientation+0x32 : retn 14h
     { 0x33, 0x14 },
     { 0x34, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetConeOrientation, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeOrientation,
+                      3911,
 
-           XREF_CDirectSoundStream_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetConeOrientation+0x25 : call [CDirectSoundVoice_SetConeOrientation]
     XREF_ENTRY(0x25, XREF_CDirectSoundVoice_SetConeOrientation),
@@ -3145,16 +3376,18 @@ OOVPA_XREF(CDirectSoundStream_SetConeOrientation, 3911, 1 + 8,
     // CDirectSoundStream_SetConeOrientation+0x2A : retn 0x14
     { 0x2A, 0xC2 },
     { 0x2B, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetConeOrientation, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetConeOrientation,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetConeOrientation+0x21 : call [CDirectSoundStream_SetConeOrientation]
     XREF_ENTRY(0x21, XREF_CDirectSoundStream_SetConeOrientation),
@@ -3172,17 +3405,19 @@ OOVPA_XREF(IDirectSoundStream_SetConeOrientation, 3911, 1 + 8,
     // IDirectSoundStream_SetConeOrientation+0x26 : retn 0x14
     { 0x26, 0xC2 },
     { 0x27, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Set3dMode
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dMode, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dMode,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dMode,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dMode,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dMode+0x04 : or byte ptr [ecx+0x80], 0xFF
     { 0x04, 0x80 },
@@ -3201,16 +3436,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dMode, 3911, 12,
     // CMcpxVoiceClient_Set3dMode+0x1E : retn 0x08
     { 0x1E, 0xC2 },
     { 0x1F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMode, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMode,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMode+0x1E : call [CMcpxVoiceClient::Set3dMode]
     XREF_ENTRY(0x1F, XREF_CMcpxVoiceClient_Set3dMode),
@@ -3229,16 +3466,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMode, 3911, 1 + 9,
     // CDirectSoundVoice_SetMode+0x38 : retn 0x0C
     { 0x38, 0xC2 },
     { 0x39, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMode
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetMode, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMode,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetMode+0x18 : call [CDirectSoundVoice::SetMode]
     XREF_ENTRY(0x19, XREF_CDirectSoundVoice_SetMode),
@@ -3257,16 +3496,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMode, 3911, 1 + 9,
     // IDirectSoundBuffer_SetMode+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMode, 3911, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMode,
+                      3911,
 
-           XREF_CDirectSoundStream_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetMode+0x10 : call [CDirectSoundVoice::SetMode]
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetMode),
@@ -3282,17 +3523,19 @@ OOVPA_XREF(CDirectSoundStream_SetMode, 3911, 1 + 6,
     // CDirectSoundBuffer8_SetMode+0x15 : retn 0x0C
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dPosition
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(CMcpxVoiceClient_Set3dPosition, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dPosition,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dPosition,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dPosition+0x0C : or byte ptr [ecx+0x80], 0xFF
     { 0x0C, 0x80 },
@@ -3310,16 +3553,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dPosition, 3911, 11,
     // CMcpxVoiceClient_Set3dPosition+0x25 : retn 0x08
     { 0x25, 0xC2 },
     { 0x26, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetPosition, 3911, 1 + 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetPosition,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetPosition+0x35 : call [CMcpxVoiceClient_Set3dPosition]
     XREF_ENTRY(0x35, XREF_CMcpxVoiceClient_Set3dPosition),
@@ -3346,16 +3591,18 @@ OOVPA_XREF(CDirectSoundVoice_SetPosition, 3911, 1 + 13,
     // CDirectSoundVoice_SetPosition+0x4F : retn 0x14
     { 0x4F, 0xC2 },
     { 0x50, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetPosition, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetPosition,
+                      3911,
 
-           XREF_CDirectSoundStream_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetPosition+0x24 : call [CDirectSoundVoice_SetPosition]
     XREF_ENTRY(0x25, XREF_CDirectSoundVoice_SetPosition),
@@ -3373,16 +3620,18 @@ OOVPA_XREF(CDirectSoundStream_SetPosition, 3911, 1 + 8,
     // CDirectSoundStream_SetPosition+0x2A : retn 0x14
     { 0x2A, 0xC2 },
     { 0x2B, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetPosition
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetPosition, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetPosition,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetPosition+0x20 : call [CDirectSoundStream_SetPosition]
     XREF_ENTRY(0x21, XREF_CDirectSoundStream_SetPosition),
@@ -3400,16 +3649,18 @@ OOVPA_XREF(IDirectSoundStream_SetPosition, 3911, 1 + 8,
     // IDirectSoundStream_SetPosition+0x26 : retn 0x14
     { 0x26, 0xC2 },
     { 0x27, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetPosition, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPosition,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetPosition+0x20 : call [CDirectSoundVoice_SetPosition]
     XREF_ENTRY(0x21, XREF_CDirectSoundVoice_SetPosition),
@@ -3427,17 +3678,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetPosition, 3911, 1 + 8,
     // CDirectSoundBuffer_SetPosition+0x26 : retn 0x14
     { 0x27, 0x14 },
     { 0x28, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetPosition
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetPosition, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetPosition,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetPosition+0x2C : call [CDirectSoundBuffer::SetPosition]
     XREF_ENTRY(0x2D, XREF_CDirectSoundBuffer_SetPosition),
@@ -3455,17 +3708,19 @@ OOVPA_XREF(IDirectSoundBuffer_SetPosition, 3911, 1 + 8,
     // IDirectSoundBuffer_SetPosition+0x32 : retn 0x14
     { 0x33, 0x14 },
     { 0x34, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::Set3dPosition
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_Set3dPosition, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Set3dPosition,
+                      3911,
 
-           XREF_CMcpxAPU_Set3dPosition,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Set3dPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_Set3dPosition+0x0C : movsd; movsd; movsd
     { 0x0C, 0xA5 },
@@ -3484,16 +3739,18 @@ OOVPA_XREF(CMcpxAPU_Set3dPosition, 3911, 12,
     // CMcpxAPU_Set3dPosition+0x28 : retn 0x08
     { 0x28, 0xC2 },
     { 0x29, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetPosition, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetPosition,
+                      3911,
 
-           XREF_CDirectSound_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetPosition+0x35 : call [CMcpxAPU_Set3dPosition]
     XREF_ENTRY(0x35, XREF_CMcpxAPU_Set3dPosition),
@@ -3512,17 +3769,19 @@ OOVPA_XREF(CDirectSound_SetPosition, 3911, 1 + 9,
     // CDirectSound_SetPosition+0x4F : retn 0x14
     { 0x4F, 0xC2 },
     { 0x50, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetPosition
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetPosition, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetPosition,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_SetPosition+0x2D : call [CDirectSound_SetPosition]
     XREF_ENTRY(0x2D, XREF_CDirectSound_SetPosition),
@@ -3544,17 +3803,19 @@ OOVPA_XREF(IDirectSound_SetPosition, 3911, 1 + 10,
     // IDirectSound_SetPosition+0x32 : retn 0x14
     { 0x32, 0xC2 },
     { 0x33, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_Set3dVelocity
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_Set3dVelocity, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Set3dVelocity,
+                      3911,
 
-           XREF_CMcpxVoiceClient_Set3dVelocity,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Set3dVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_Set3dVelocity+0x09 : movsd; movsd; movsd
     { 0x09, 0xA5 },
@@ -3573,16 +3834,18 @@ OOVPA_XREF(CMcpxVoiceClient_Set3dVelocity, 3911, 12,
     // CMcpxVoiceClient_Set3dVelocity+0x25 : retn 0x08
     { 0x25, 0xC2 },
     { 0x26, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetVelocity, 3911, 1 + 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVelocity,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetVelocity+0x35 : call [CMcpxVoiceClient_Set3dVelocity]
     XREF_ENTRY(0x35, XREF_CMcpxVoiceClient_Set3dVelocity),
@@ -3609,16 +3872,18 @@ OOVPA_XREF(CDirectSoundVoice_SetVelocity, 3911, 1 + 13,
     // CDirectSoundVoice_SetVelocity+0x4F : retn 0x14
     { 0x4F, 0xC2 },
     { 0x50, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetVelocity, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetVelocity,
+                      3911,
 
-           XREF_CDirectSoundStream_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetVelocity+0x24 : call [CDirectSoundVoice_SetVelocity]
     XREF_ENTRY(0x25, XREF_CDirectSoundVoice_SetVelocity),
@@ -3636,16 +3901,18 @@ OOVPA_XREF(CDirectSoundStream_SetVelocity, 3911, 1 + 8,
     // CDirectSoundStream_SetVelocity+0x2A : retn 0x14
     { 0x2A, 0xC2 },
     { 0x2B, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVelocity
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetVelocity, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetVelocity,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetVelocity+0x21 : call [CDirectSoundStream_SetVelocity]
     XREF_ENTRY(0x21, XREF_CDirectSoundStream_SetVelocity),
@@ -3663,16 +3930,18 @@ OOVPA_XREF(IDirectSoundStream_SetVelocity, 3911, 1 + 8,
     // CDirectSoundStream_SetVelocity+0x26 : retn 0x14
     { 0x26, 0xC2 },
     { 0x27, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetVelocity, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetVelocity,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetVelocity+0x20 : call [CDirectSoundVoice_SetVelocity]
     XREF_ENTRY(0x21, XREF_CDirectSoundVoice_SetVelocity),
@@ -3690,17 +3959,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetVelocity, 3911, 1 + 8,
     // CDirectSoundBuffer_SetVelocity+0x26 : retn 0x14
     { 0x27, 0x14 },
     { 0x28, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetVelocity, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetVelocity,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetVelocity+0x2C : call [CDirectSoundBuffer::SetVelocity]
     XREF_ENTRY(0x2D, XREF_CDirectSoundBuffer_SetVelocity),
@@ -3718,16 +3989,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetVelocity, 3911, 1 + 8,
     // IDirectSoundBuffer_SetVelocity+0x32 : retn 0x14
     { 0x33, 0x14 },
     { 0x34, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetOutputBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetOutputBuffer, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetOutputBuffer,
+                      3911,
 
-           XREF_CDirectSoundStream_SetOutputBuffer,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetOutputBuffer,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetOutputBuffer+0x22 : call [CDirectSoundVoice_SetOutputBuffer]
     XREF_ENTRY(0x23, XREF_CDirectSoundVoice_SetOutputBuffer),
@@ -3750,17 +4023,19 @@ OOVPA_XREF(CDirectSoundStream_SetOutputBuffer, 3911, 1 + 11,
     // CDirectSoundStream_SetOutputBuffer+0x3D : retn 0x14
     { 0x3D, 0xC2 },
     { 0x3E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetI3DL2Source
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(CMcpxVoiceClient_SetI3DL2Source, 3911, 7,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetI3DL2Source,
+                      3911,
 
-           XREF_CMcpxVoiceClient_SetI3DL2Source,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetI3DL2Source,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x08 },
     { 0x0A, 0x59 },
@@ -3769,16 +4044,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetI3DL2Source, 3911, 7,
     { 0x1C, 0x5F },
     { 0x22, 0x8B },
     { 0x29, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetI3DL2Source,
+                      3911,
 
-           XREF_CDirectSoundVoice_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_CMcpxVoiceClient_SetI3DL2Source),
 
@@ -3790,16 +4067,18 @@ OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 3911, 1 + 8,
     { 0x26, 0xF8 },
     { 0x2E, 0xFF },
     { 0x36, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetI3DL2Source, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetI3DL2Source,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSoundVoice_SetI3DL2Source),
 
@@ -3811,16 +4090,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetI3DL2Source, 3911, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetI3DL2Source, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetI3DL2Source,
+                      3911,
 
-           XREF_CDirectSoundStream_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundVoice_SetI3DL2Source),
 
@@ -3832,16 +4113,18 @@ OOVPA_XREF(CDirectSoundStream_SetI3DL2Source, 3911, 1 + 8,
     { 0x10, 0xE8 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Lock
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Lock, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Lock,
+                      3911,
 
-           XREF_CDirectSoundBuffer_Lock,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Lock,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x23, XREF_CDirectSoundBuffer_GetCurrentPosition),
 
@@ -3862,17 +4145,19 @@ OOVPA_XREF(CDirectSoundBuffer_Lock, 3911, 1 + 11,
     { 0x85, 0x83 },
     { 0x86, 0x22 },
     { 0x87, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_Lock
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundBuffer_Lock, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_Lock,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_Lock+0x28 : call [CDirectSoundBuffer_Lock]
     XREF_ENTRY(0x28, XREF_CDirectSoundBuffer_Lock),
@@ -3890,16 +4175,18 @@ OOVPA_XREF(IDirectSoundBuffer_Lock, 3911, 1 + 8,
     // IDirectSoundBuffer_Lock+0x2D : retn 0x20
     { 0x2D, 0xC2 },
     { 0x2E, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_SetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_SetCurrentPosition, 3911, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_SetCurrentPosition,
+                      3911,
 
-           XREF_CMcpxBuffer_SetCurrentPosition,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_SetCurrentPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_SetCurrentPosition+0x25 : mov eax, [esi+0x148]
     { 0x25, 0x8B },
@@ -3917,16 +4204,18 @@ OOVPA_XREF(CMcpxBuffer_SetCurrentPosition, 3911, 11,
     { 0x72, 0xB7 },
     { 0x73, 0x40 },
     { 0x74, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetCurrentPosition, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetCurrentPosition,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetCurrentPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetCurrentPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetCurrentPosition+0x15 : call [CMcpxBuffer_SetCurrentPosition]
     XREF_ENTRY(0x15, XREF_CMcpxBuffer_SetCurrentPosition),
@@ -3949,17 +4238,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetCurrentPosition, 3911, 1 + 11,
     // CDirectSoundBuffer_SetCurrentPosition+0x2E : retn 0x08
     { 0x2E, 0xC2 },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetCurrentPosition
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetCurrentPosition, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetCurrentPosition,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetCurrentPosition+0x15 : call [CDirectSoundBuffer_SetCurrentPosition]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetCurrentPosition),
@@ -3978,16 +4269,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetCurrentPosition, 3911, 1 + 9,
     // IDirectSoundBuffer_SetCurrentPosition+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DSound_CRefCount_AddRef
 // ******************************************************************
-OOVPA_XREF(DSound_CRefCount_AddRef, 3911, 11,
+OOVPA_SIG_HEADER_XREF(DSound_CRefCount_AddRef,
+                      3911,
 
-           XREF_DSound_CRefCount_AddRef,
-           XRefZero)
-{
+                      XREF_DSound_CRefCount_AddRef,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // DSound_CRefCount_AddRef+0x04 : add eax, 4
     { 0x00, 0x56 },
@@ -4008,16 +4301,18 @@ OOVPA_XREF(DSound_CRefCount_AddRef, 3911, 11,
     // DSound_CRefCount_AddRef+0x22 : retn 0x04
     { 0x22, 0xC2 },
     { 0x23, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_AddRef
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_AddRef, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_AddRef,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_AddRef+0x08 : call [CRefCount_AddRef]
     XREF_ENTRY(0x09, XREF_DSound_CRefCount_AddRef),
@@ -4036,16 +4331,18 @@ OOVPA_XREF(CDirectSoundStream_AddRef, 3911, 1 + 7,
     // CDirectSoundStream_AddRef+0x0D : retn 0x04
     { 0x0D, 0xC2 },
     { 0x0E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DSound_CRefCount_Release
 // ******************************************************************
-OOVPA_XREF(DSound_CRefCount_Release, 3911, 11,
+OOVPA_SIG_HEADER_XREF(DSound_CRefCount_Release,
+                      3911,
 
-           XREF_DSound_CRefCount_Release,
-           XRefZero)
-{
+                      XREF_DSound_CRefCount_Release,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // DSound_CRefCount_Release+0x04 : add eax, 4
     { 0x00, 0x56 },
@@ -4066,16 +4363,18 @@ OOVPA_XREF(DSound_CRefCount_Release, 3911, 11,
     // DSound_CRefCount_Release+0x30 : retn 0x04
     { 0x30, 0xC2 },
     { 0x31, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Release
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Release, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Release,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_Release+0x08 : call [CRefCount_Release]
     XREF_ENTRY(0x09, XREF_DSound_CRefCount_Release),
@@ -4094,16 +4393,18 @@ OOVPA_XREF(CDirectSoundStream_Release, 3911, 1 + 7,
     // CDirectSoundStream_Release+0x0D : retn 0x04
     { 0x0D, 0xC2 },
     { 0x0E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::GetCaps
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetCaps, 3911, 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetCaps,
+                      3911,
 
-           XREF_CDirectSound_GetCaps,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetCaps,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x8B },
     { 0x12, 0x8D },
@@ -4113,17 +4414,19 @@ OOVPA_XREF(CDirectSound_GetCaps, 3911, 8,
     { 0x3A, 0xDB },
     { 0x48, 0x8B },
     { 0x4E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_GetCaps
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_GetCaps, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound_GetCaps,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSound_GetCaps),
 
@@ -4134,16 +4437,18 @@ OOVPA_XREF(IDirectSound_GetCaps, 3911, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetSpeakerConfig
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetSpeakerConfig, 3911, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetSpeakerConfig,
+                      3911,
 
-           XREF_CDirectSound_GetSpeakerConfig,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetSpeakerConfig,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x03, 0x04 },
@@ -4167,17 +4472,19 @@ OOVPA_XREF(CDirectSound_GetSpeakerConfig, 3911, 15,
     // CDirectSound_GetSpeakerConfig+0x17 : ret 8
     { 0x17, 0xC2 },
     { 0x18, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_GetSpeakerConfig
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_GetSpeakerConfig, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound_GetSpeakerConfig,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSound_GetSpeakerConfig),
 
@@ -4188,16 +4495,18 @@ OOVPA_XREF(IDirectSound_GetSpeakerConfig, 3911, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_DownloadEffectsImage
 // ******************************************************************
-OOVPA_XREF(CDirectSound_DownloadEffectsImage, 3911, 18,
+OOVPA_SIG_HEADER_XREF(CDirectSound_DownloadEffectsImage,
+                      3911,
 
-           XREF_CDirectSound_DownloadEffectsImage,
-           XRefZero)
-{
+                      XREF_CDirectSound_DownloadEffectsImage,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_DownloadEffectsImage+0x00 : push ebp
     { 0x00, 0x55 },
@@ -4235,17 +4544,19 @@ OOVPA_XREF(CDirectSound_DownloadEffectsImage, 3911, 18,
     // CDirectSound_DownloadEffectsImage+0x41 : ret 14h
     { 0x41, 0xC2 },
     { 0x42, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_DownloadEffectsImage
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_DownloadEffectsImage, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSound_DownloadEffectsImage,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_CDirectSound_DownloadEffectsImage),
 
@@ -4267,16 +4578,18 @@ OOVPA_XREF(IDirectSound_DownloadEffectsImage, 3911, 1 + 11,
     // IDirectSound_DownloadEffectsImage+0x24 : retn 0x14
     { 0x24, 0xC2 },
     { 0x25, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetEffectData
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetEffectData, 3911, 18,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetEffectData,
+                      3911,
 
-           XREF_CDirectSound_GetEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_GetEffectData+0x00 : push ebp
     { 0x00, 0x55 },
@@ -4314,17 +4627,19 @@ OOVPA_XREF(CDirectSound_GetEffectData, 3911, 18,
     // CDirectSound_GetEffectData+0x3F : ret 14h
     { 0x3F, 0xC2 },
     { 0x40, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_GetEffectData
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_GetEffectData, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSound_GetEffectData,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_CDirectSound_GetEffectData),
 
@@ -4346,16 +4661,18 @@ OOVPA_XREF(IDirectSound_GetEffectData, 3911, 1 + 11,
     // IDirectSound_GetEffectData+0x24 : retn 0x14
     { 0x24, 0xC2 },
     { 0x25, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetEffectData
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetEffectData, 3911, 21,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetEffectData,
+                      3911,
 
-           XREF_CDirectSound_SetEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_GetEffectData+0x00 : push ebp
     { 0x00, 0x55 },
@@ -4398,17 +4715,19 @@ OOVPA_XREF(CDirectSound_SetEffectData, 3911, 21,
     // CDirectSound_GetEffectData+0x3F : ret 18h
     { 0x48, 0xC2 },
     { 0x49, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetEffectData
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetEffectData, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetEffectData,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x22, XREF_CDirectSound_SetEffectData),
 
@@ -4430,16 +4749,18 @@ OOVPA_XREF(IDirectSound_SetEffectData, 3911, 1 + 11,
     // IDirectSound_SetEffectData+0x27 : retn 0x18
     { 0x27, 0xC2 },
     { 0x28, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_CommitEffectData
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CommitEffectData, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitEffectData,
+                      3911,
 
-           XREF_CDirectSound_CommitEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_CommitEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CommitEffectData+0x00 : push esi
     { 0x00, 0x56 },
@@ -4464,17 +4785,19 @@ OOVPA_XREF(CDirectSound_CommitEffectData, 3911, 12,
     // CDirectSound_CommitEffectData+0x30 : retn 0x04
     { 0x30, 0xC2 },
     { 0x31, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_CommitEffectData
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_CommitEffectData, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound_CommitEffectData,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSound_CommitEffectData),
 
@@ -4490,16 +4813,18 @@ OOVPA_XREF(IDirectSound_CommitEffectData, 3911, 1 + 7,
     // IDirectSound_CommitEffectData+0x15 : retn 0x04
     { 0x15, 0xC2 },
     { 0x16, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::EnableHeadphones
 // ******************************************************************
-OOVPA_XREF(CDirectSound_EnableHeadphones, 3911, 18,
+OOVPA_SIG_HEADER_XREF(CDirectSound_EnableHeadphones,
+                      3911,
 
-           XREF_CDirectSound_EnableHeadphones,
-           XRefZero)
-{
+                      XREF_CDirectSound_EnableHeadphones,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -4523,17 +4848,19 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 3911, 18,
 
     { 0xCB, 0xC2 },
     { 0xCC, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_EnableHeadphones
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_EnableHeadphones, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSound_EnableHeadphones,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSound_EnableHeadphones),
 
@@ -4551,16 +4878,18 @@ OOVPA_XREF(IDirectSound_EnableHeadphones, 3911, 1 + 9,
     // IDirectSound_EnableHeadphones+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU_SetMixBinHeadroom
 // ******************************************************************
-OOVPA_XREF(CMcpxAPU_SetMixBinHeadroom, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_SetMixBinHeadroom,
+                      3911,
 
-           XREF_CMcpxAPU_SetMixBinHeadroom,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_SetMixBinHeadroom,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_SetMixBinHeadroom+0x04 : cmp dword ptr ds:[0xFE820010], 4
     { 0x12, 0x83 },
@@ -4579,16 +4908,18 @@ OOVPA_XREF(CMcpxAPU_SetMixBinHeadroom, 3911, 12,
     // CMcpxAPU_SetMixBinHeadroom+0x2D : jl +0xD8
     { 0x2D, 0x7C },
     { 0x2E, 0xD8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetMixBinHeadroom
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetMixBinHeadroom, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetMixBinHeadroom,
+                      3911,
 
-           XREF_CDirectSound_SetMixBinHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetMixBinHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetMixBinHeadroom+0x18 : call [CMcpxAPU_SetMixBinHeadroom]
     XREF_ENTRY(0x19, XREF_CMcpxAPU_SetMixBinHeadroom),
@@ -4606,17 +4937,19 @@ OOVPA_XREF(CDirectSound_SetMixBinHeadroom, 3911, 1 + 8,
     // CDirectSound_SetMixBinHeadroom+0x21 : jz +0x0B
     { 0x21, 0x74 },
     { 0x22, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetMixBinHeadroom
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetMixBinHeadroom, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetMixBinHeadroom,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_SetMixBinHeadroom+0x19 : call [CDirectSound_SetMixBinHeadroom]
     XREF_ENTRY(0x19, XREF_CDirectSound_SetMixBinHeadroom),
@@ -4639,18 +4972,20 @@ OOVPA_XREF(IDirectSound_SetMixBinHeadroom, 3911, 1 + 11,
     // IDirectSound_SetMixBinHeadroom+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::Set3dParameters
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
 // TODO:
-OOVPA_XREF(CMcpxAPU_Set3dParameters, 3911, 7,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Set3dParameters,
+                      3911,
 
-           XREF_CMcpxAPU_Set3dParameters,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Set3dParameters,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x57 },
     { 0x0C, 0xB8 },
@@ -4659,16 +4994,18 @@ OOVPA_XREF(CMcpxAPU_Set3dParameters, 3911, 7,
     { 0x21, 0x74 },
     { 0x2C, 0x33 },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetAllParameters, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetAllParameters,
+                      3911,
 
-           XREF_CDirectSound_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_CMcpxAPU_Set3dParameters),
 
@@ -4680,17 +5017,19 @@ OOVPA_XREF(CDirectSound_SetAllParameters, 3911, 1 + 8,
     { 0x26, 0xF8 },
     { 0x2E, 0xFF },
     { 0x36, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetAllParameters
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetAllParameters, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetAllParameters,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSound_SetAllParameters),
 
@@ -4712,17 +5051,19 @@ OOVPA_XREF(IDirectSound_SetAllParameters, 3911, 1 + 11,
     // IDirectSound_SetAllParameters+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::Set3dDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_Set3dDistanceFactor, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Set3dDistanceFactor,
+                      3911,
 
-           XREF_CMcpxAPU_Set3dDistanceFactor,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Set3dDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // Unique value difference against CMcpxAPU_Set3dDopperFactor's unique value.
     // CMcpxAPU_Set3dDistanceFactor+0x04 : or dword ptr [ecx+0x01B4], 0x60
@@ -4744,16 +5085,18 @@ OOVPA_XREF(CMcpxAPU_Set3dDistanceFactor, 3911, 13,
     // CMcpxAPU_Set3dDistanceFactor+0x12 : mov [ecx+0x0178], eax
     { 0x12, 0x78 },
     { 0x13, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDistanceFactor, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDistanceFactor,
+                      3911,
 
-           XREF_CDirectSound_SetDistanceFactor,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetDistanceFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDistanceFactor+0x23 : call [CMcpxAPU_Set3dDistanceFactor]
     XREF_ENTRY(0x23, XREF_CMcpxAPU_Set3dDistanceFactor),
@@ -4774,17 +5117,19 @@ OOVPA_XREF(CDirectSound_SetDistanceFactor, 3911, 1 + 11,
     { 0x13, 0x83 },
     { 0x14, 0xE0 },
     { 0x15, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetDistanceFactor, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetDistanceFactor,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_SetDistanceFactor+0x1D : call [CDirectSound_SetDistanceFactor]
     XREF_ENTRY(0x1D, XREF_CDirectSound_SetDistanceFactor),
@@ -4806,17 +5151,19 @@ OOVPA_XREF(IDirectSound_SetDistanceFactor, 3911, 1 + 10,
     // IDirectSound_SetDistanceFactor+0x21 : retn 0x0C
     { 0x21, 0xC2 },
     { 0x22, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::Set3dDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_Set3dDopplerFactor, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Set3dDopplerFactor,
+                      3911,
 
-           XREF_CMcpxAPU_Set3dDopplerFactor,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Set3dDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // Unique value difference against CMcpxAPU_Set3dDistanceFactor's unique value.
     // CMcpxAPU_Set3dDopplerFactor+0x04 : or dword ptr [ecx+0x01B4], 0x40
@@ -4838,16 +5185,18 @@ OOVPA_XREF(CMcpxAPU_Set3dDopplerFactor, 3911, 13,
     // CMcpxAPU_Set3dDopplerFactor+0x12 : mov [ecx+0x0180], eax
     { 0x12, 0x80 },
     { 0x13, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDopplerFactor, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDopplerFactor,
+                      3911,
 
-           XREF_CDirectSound_SetDopplerFactor,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetDopplerFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x23, XREF_CMcpxAPU_Set3dDopplerFactor),
 
@@ -4859,17 +5208,19 @@ OOVPA_XREF(CDirectSound_SetDopplerFactor, 3911, 1 + 8,
     { 0x32, 0xFF },
     { 0x38, 0x8B },
     { 0x3E, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetDopplerFactor, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetDopplerFactor,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSound_SetDopplerFactor),
 
@@ -4890,17 +5241,19 @@ OOVPA_XREF(IDirectSound_SetDopplerFactor, 3911, 1 + 10,
     // IDirectSound_SetDopplerFactor+0x21 : retn 0x0C
     { 0x21, 0xC2 },
     { 0x22, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::Set3dVelocity
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_Set3dVelocity, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Set3dVelocity,
+                      3911,
 
-           XREF_CMcpxAPU_Set3dVelocity,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Set3dVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_Set3dVelocity+0x0C : movsd; movsd; movsd
     { 0x0C, 0xA5 },
@@ -4919,16 +5272,18 @@ OOVPA_XREF(CMcpxAPU_Set3dVelocity, 3911, 12,
     // CMcpxAPU_Set3dVelocity+0x28 : retn 0x08
     { 0x28, 0xC2 },
     { 0x29, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetVelocity, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetVelocity,
+                      3911,
 
-           XREF_CDirectSound_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetVelocity+0x35 : call [CMcpxAPU_Set3dVelocity]
     XREF_ENTRY(0x35, XREF_CMcpxAPU_Set3dVelocity),
@@ -4947,17 +5302,19 @@ OOVPA_XREF(CDirectSound_SetVelocity, 3911, 1 + 9,
     // CDirectSound_SetVelocity+0x4F : retn 0x14
     { 0x4F, 0xC2 },
     { 0x50, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetVelocity, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetVelocity,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_SetVelocity+0x2D : call [CDirectSound_SetVelocity]
     XREF_ENTRY(0x2D, XREF_CDirectSound_SetVelocity),
@@ -4979,17 +5336,19 @@ OOVPA_XREF(IDirectSound_SetVelocity, 3911, 1 + 10,
     // IDirectSound_SetVelocity+0x32 : retn 0x14
     { 0x32, 0xC2 },
     { 0x33, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetTime
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(CDirectSound_GetTime, 3911, 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetTime,
+                      3911,
 
-           XREF_CDirectSound_GetTime,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetTime,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_GetTime+0x00 : push dword ptr [esp+8]
     { 0x00, 0xFF },
@@ -5006,17 +5365,19 @@ OOVPA_XREF(CDirectSound_GetTime, 3911, 8,
     // CDirectSound_GetTime+0x0C : retn 0x08
     { 0x0C, 0xC2 },
     { 0x0D, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_GetTime
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSound_GetTime, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound_GetTime,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_GetTime+0x10 : call [CDirectSound_GetTime]
     XREF_ENTRY(0x15, XREF_CDirectSound_GetTime),
@@ -5033,17 +5394,19 @@ OOVPA_XREF(IDirectSound_GetTime, 3911, 1 + 7,
     // IDirectSound_GetTime+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::Set3dRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_Set3dRolloffFactor, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_Set3dRolloffFactor,
+                      3911,
 
-           XREF_CMcpxAPU_Set3dRolloffFactor,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_Set3dRolloffFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_Set3dRolloffFactor+0x04 : or dword ptr [ecx+0x01B4], 0x04
     { 0x04, 0x83 },
@@ -5063,16 +5426,18 @@ OOVPA_XREF(CMcpxAPU_Set3dRolloffFactor, 3911, 13,
     // CMcpxAPU_Set3dRolloffFactor+0x12 : mov [ecx+0x017C], eax
     { 0x12, 0x7C },
     { 0x13, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetRolloffFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetRolloffFactor, 3911, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetRolloffFactor,
+                      3911,
 
-           XREF_CDirectSound_SetRolloffFactor,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetRolloffFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetRolloffFactor+0x23 : call [CMcpxAPU_Set3dRolloffFactor]
     XREF_ENTRY(0x23, XREF_CMcpxAPU_Set3dRolloffFactor),
@@ -5093,17 +5458,19 @@ OOVPA_XREF(CDirectSound_SetRolloffFactor, 3911, 1 + 11,
     { 0x13, 0x83 },
     { 0x14, 0xE0 },
     { 0x15, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSound_SetRolloffFactor, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetRolloffFactor,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_SetRolloffFactor+0x1D : call [CDirectSound_SetRolloffFactor]
     XREF_ENTRY(0x1D, XREF_CDirectSound_SetRolloffFactor),
@@ -5125,17 +5492,19 @@ OOVPA_XREF(IDirectSound_SetRolloffFactor, 3911, 1 + 10,
     // IDirectSound_SetRolloffFactor+0x21 : retn 0x0C
     { 0x21, 0xC2 },
     { 0x22, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::SetI3DL2Listener
 // ******************************************************************
 // Generic OOVPA as of 3911 to 4039; 4134 and newer no longer have it.
-OOVPA_XREF(CMcpxAPU_SetI3DL2Listener, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_SetI3DL2Listener,
+                      3911,
 
-           XREF_CMcpxAPU_SetI3DL2Listener,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_SetI3DL2Listener,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_SetI3DL2Listener+0x08 : push 0x0C; pop ecx
     { 0x08, 0x6A },
@@ -5155,16 +5524,18 @@ OOVPA_XREF(CMcpxAPU_SetI3DL2Listener, 3911, 13,
     // CMcpxAPU_SetI3DL2Listener+0x30 : retn 0x08
     { 0x30, 0xC2 },
     { 0x31, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetI3DL2Listener
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetI3DL2Listener, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetI3DL2Listener,
+                      3911,
 
-           XREF_CDirectSound_SetI3DL2Listener,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetI3DL2Listener,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2F, XREF_CMcpxAPU_SetI3DL2Listener),
 
@@ -5175,17 +5546,19 @@ OOVPA_XREF(CDirectSound_SetI3DL2Listener, 3911, 1 + 7,
     { 0x33, 0x8B },
     { 0x3E, 0xFF },
     { 0x44, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_SetI3DL2Listener
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IDirectSound_SetI3DL2Listener, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SetI3DL2Listener,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSound_SetI3DL2Listener),
 
@@ -5197,18 +5570,20 @@ OOVPA_XREF(IDirectSound_SetI3DL2Listener, 3911, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVolume
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetVolume has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetVolume, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetVolume,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetVolume+0x0C : call [CMcpxVoiceClient_SetVolume]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetVolume),
@@ -5227,18 +5602,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetVolume, 3911, 1 + 9,
     // CDirectSoundStream_SetVolume+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetVolume
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetVolume has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetVolume, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetVolume,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetVolume+0x0C : call [CMcpxVoiceClient_SetVolume]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetVolume),
@@ -5257,18 +5634,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetVolume, 3911, 1 + 9,
     // IDirectSoundStream_SetVolume+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetPitch
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetPitch has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetPitch, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetPitch,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetPitch+0x0C : call [CMcpxVoiceClient_SetPitch]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetPitch),
@@ -5287,18 +5666,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetPitch, 3911, 1 + 9,
     // CDirectSoundStream_SetPitch+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetPitch
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetPitch has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetPitch, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetPitch,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetPitch+0x0C : call [CMcpxVoiceClient_SetPitch]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetPitch),
@@ -5317,18 +5698,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetPitch, 3911, 1 + 9,
     // IDirectSoundStream_SetPitch+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetLFO
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetLFO has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetLFO, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetLFO,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetLFO+0x0C : call [CMcpxVoiceClient_SetLFO]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetLFO),
@@ -5347,18 +5730,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetLFO, 3911, 1 + 9,
     // CDirectSoundStream_SetLFO+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetLFO
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetLFO has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetLFO, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetLFO,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetLFO+0x0C : call [CMcpxVoiceClient_SetLFO]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetLFO),
@@ -5377,18 +5762,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetLFO, 3911, 1 + 9,
     // IDirectSoundStream_SetLFO+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetEG
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetEG has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetEG, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetEG,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetEG+0x0C : call [CMcpxVoiceClient_SetEG]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetEG),
@@ -5407,18 +5794,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetEG, 3911, 1 + 9,
     // CDirectSoundStream_SetEG+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetEG
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetEG has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetEG, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetEG,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetEG+0x0C : call [CMcpxVoiceClient_SetEG]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetEG),
@@ -5437,18 +5826,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetEG, 3911, 1 + 9,
     // IDirectSoundStream_SetEG+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetFilter
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetFilter has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetFilter, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetFilter,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetFilter+0x0C : call [CMcpxVoiceClient_SetFilter]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetFilter),
@@ -5467,17 +5858,19 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetFilter, 3911, 1 + 9,
     // CDirectSoundStream_SetFilter+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetFilter
 // ******************************************************************
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetFilter, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetFilter,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetFilter+0x0C : call [CMcpxVoiceClient_SetFilter]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetFilter),
@@ -5496,18 +5889,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetFilter, 3911, 1 + 9,
     // IDirectSoundStream_SetFilter+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetHeadroom
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetHeadroom has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetHeadroom, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetHeadroom,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetHeadroom+0x0C : call [CDirectSoundVoice_SetHeadroom]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetHeadroom),
@@ -5526,18 +5921,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetHeadroom, 3911, 1 + 9,
     // CDirectSoundStream_SetHeadroom+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetHeadroom
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetHeadroom has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetHeadroom, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetHeadroom,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetHeadroom+0x0C : call [CDirectSoundVoice_SetHeadroom]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetHeadroom),
@@ -5556,18 +5953,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetHeadroom, 3911, 1 + 9,
     // IDirectSoundStream_SetHeadroom+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetFrequency
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetFrequency has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetFrequency, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetFrequency,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetFrequency+0x0C : call [CDirectSoundVoice_SetFrequency]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetFrequency),
@@ -5586,18 +5985,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetFrequency, 3911, 1 + 9,
     // CDirectSoundStream_SetFrequency+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetFrequency
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetFrequency has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetFrequency, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetFrequency,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetFrequency+0x0C : call [CDirectSoundVoice_SetFrequency]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetFrequency),
@@ -5616,18 +6017,20 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetFrequency, 3911, 1 + 9,
     // IDirectSoundStream_SetFrequency+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMixBins
 // ******************************************************************
 // NOTE: IDirectSoundStream_SetMixBins has the same asm code as this function.
-OOVPA_XREF_EXTEND(CDirectSoundStream_SetMixBins, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(CDirectSoundStream_SetMixBins,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectFirst)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectFirst)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_SetMixBins+0x0C : call [CDirectSoundVoice_SetMixBins]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetMixBins),
@@ -5646,18 +6049,20 @@ OOVPA_XREF_EXTEND(CDirectSoundStream_SetMixBins, 3911, 1 + 9,
     // CDirectSoundStream_SetMixBins+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMixBins
 // ******************************************************************
 // NOTE: CDirectSoundStream_SetMixBins has the same asm code as this function.
-OOVPA_XREF_EXTEND(IDirectSoundStream_SetMixBins, 3911, 1 + 9,
+OOVPA_SIG_HEADER_XREF_EXTEND(IDirectSoundStream_SetMixBins,
+                             3911,
 
-                  XRefNoSaveIndex,
-                  XRefOne,
-                  DetectSecond)
-{
+                             XRefNoSaveIndex,
+                             XRefOne,
+                             DetectSecond)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetMixBins+0x0C : call [CDirectSoundVoice_SetMixBins]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoice_SetMixBins),
@@ -5676,146 +6081,164 @@ OOVPA_XREF_EXTEND(IDirectSoundStream_SetMixBins, 3911, 1 + 9,
     // IDirectSoundStream_SetMixBins+0x11 : retn 0x08
     { 0x11, 0xC2 },
     { 0x12, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetOutputBuffer
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetOutputBuffer, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetOutputBuffer,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetOutputBuffer+0x00 : jmp [CDirectSoundStream_SetOutputBuffer]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetOutputBuffer),
 
     // IDirectSoundStream_SetOutputBuffer+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMixBinVolumes
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetMixBinVolumes_12, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetMixBinVolumes_12,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetMixBinVolumes_12+0x00 : jmp [CDirectSoundStream_SetMixBinVolumes_12]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetMixBinVolumes_12),
 
     // IDirectSoundStream_SetMixBinVolumes_12+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetAllParameters
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetAllParameters, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetAllParameters,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetAllParameters+0x00 : jmp [CDirectSoundStream_SetAllParameters]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetAllParameters),
 
     // IDirectSoundStream_SetAllParameters+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetConeAngles
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetConeAngles, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetConeAngles,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetConeAngles+0x00 : jmp [CDirectSoundStream_SetConeAngles]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetConeAngles),
 
     // IDirectSoundStream_SetConeAngles+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetConeOutsideVolume, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetConeOutsideVolume,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetConeOutsideVolume+0x00 : jmp [CDirectSoundStream_SetConeOutsideVolume]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetConeOutsideVolume),
 
     // IDirectSoundStream_SetConeOutsideVolume+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMode
 // ******************************************************************
-OOVPA_XREF(IDirectSoundStream_SetMode, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetMode,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetMode+0x00 : jmp [CDirectSoundStream_SetMode]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetMode),
 
     // IDirectSoundStream_SetMode+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetI3DL2Source
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundStream_SetI3DL2Source, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetI3DL2Source,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetI3DL2Source+0x00 : jmp [CDirectSoundStream_SetI3DL2Source]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetI3DL2Source),
 
     // IDirectSoundStream_SetI3DL2Source+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_Pause
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(IDirectSoundStream_Pause, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_Pause,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_Pause+0x00 : jmp [CDirectSoundStream_Pause]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_Pause),
 
     // IDirectSoundStream_Pause+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Pause
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Pause, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Pause,
+                      3911,
 
-           XREF_CMcpxStream_Pause,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Pause,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxStream_Pause+0x00 : push ebp
     { 0x00, 0x55 },
@@ -5838,7 +6261,8 @@ OOVPA_XREF(CMcpxStream_Pause, 3911, 12,
     { 0x44, 0xC9 },
     { 0x45, 0xC2 },
     { 0x46, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioCreatePcmFormat
@@ -5846,8 +6270,9 @@ OOVPA_XREF(CMcpxStream_Pause, 3911, 12,
 // Generic OOVPA as of 3911 and newer
 // NOTE: 4134 and later versions changed to a jmp, then convert into
 // class function
-OOVPA_NO_XREF(XAudioCreatePcmFormat, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XAudioCreatePcmFormat,
+                         3911)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x00, 0x8B),
 
@@ -5859,13 +6284,15 @@ OOVPA_NO_XREF(XAudioCreatePcmFormat, 3911, 11)
     OV_MATCH(0x34, 0x66, 0xC7, 0x01, 0x01, 0x00),
 
     OV_MATCH(0x47, 0xC2, 0x10),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioCreateAdpcmFormat
 // ******************************************************************
-OOVPA_NO_XREF(XAudioCreateAdpcmFormat, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XAudioCreateAdpcmFormat,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x04, 0x8B },
@@ -5888,13 +6315,15 @@ OOVPA_NO_XREF(XAudioCreateAdpcmFormat, 3911, 14)
 
     { 0x41, 0xC2 },
     { 0x42, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IsValidFormat
 // ******************************************************************
-OOVPA_NO_XREF(IsValidFormat, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(IsValidFormat,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x04, 0x0F },
@@ -5911,16 +6340,18 @@ OOVPA_NO_XREF(IsValidFormat, 3911, 10)
 
     { 0x21, 0xC2 },
     { 0x22, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFileCreateMediaObject
 // ******************************************************************
-OOVPA_XREF(XFileCreateMediaObject, 3911, 14,
+OOVPA_SIG_HEADER_XREF(XFileCreateMediaObject,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x08, 0xE8 },
@@ -5941,13 +6372,15 @@ OOVPA_XREF(XFileCreateMediaObject, 3911, 14,
 
     { 0x78, 0xC2 },
     { 0x79, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XWaveFileCreateMediaObject
 // ******************************************************************
-OOVPA_NO_XREF(XWaveFileCreateMediaObject, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XWaveFileCreateMediaObject,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x07, 0x5C },
@@ -5965,16 +6398,18 @@ OOVPA_NO_XREF(XWaveFileCreateMediaObject, 3911, 14)
 
     { 0x65, 0xC2 },
     { 0x66, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBufferSettings::SetBufferData
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBufferSettings_SetBufferData, 3911, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBufferSettings_SetBufferData,
+                      3911,
 
-           XREF_CDirectSoundBufferSettings_SetBufferData,
-           XRefZero)
-{
+                      XREF_CDirectSoundBufferSettings_SetBufferData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBufferSettings::SetBufferData+0x00 : push ebp
     { 0x00, 0x55 },
@@ -6000,16 +6435,18 @@ OOVPA_XREF(CDirectSoundBufferSettings_SetBufferData, 3911, 12,
     // CDirectSoundBufferSettings::SetBufferData+0x6F : ret 8
     { 0x6F, 0xC2 },
     { 0x70, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::SetBufferData
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_SetBufferData, 3911, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_SetBufferData,
+                      3911,
 
-           XREF_CMcpxBuffer_SetBufferData,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_SetBufferData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer::SetBufferData+0x00 : mov edx,[ecx+0x000000XX]
     { 0x00, 0x8B },
@@ -6031,225 +6468,253 @@ OOVPA_XREF(CMcpxBuffer_SetBufferData, 3911, 9,
 
     // CMcpxBuffer::SetBufferData+0x13 : ret
     { 0x13, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetAllParameters, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetAllParameters,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetAllParameters+0x00 : jmp CDirectSoundVoice::SetAllParameters
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetAllParameters),
 
     // CDirectSoundBuffer::SetAllParameters+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeAngles
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetConeAngles, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeAngles,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetConeAngles,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeAngles,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetConeAngles+0x00 : jmp CDirectSoundVoice::SetConeAngles
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetConeAngles),
 
     // CDirectSoundBuffer::SetConeAngles+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetEG
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetEG, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetEG,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetEG+0x00 : jmp CDirectSoundVoice::SetEG
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetEG),
 
     // CDirectSoundBuffer::SetEG+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetFilter
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetFilter, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFilter,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetFilter+0x00 : jmp CDirectSoundVoice::SetFilter
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetFilter),
 
     // CDirectSoundBuffer::SetFilter+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetHeadroom
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetHeadroom, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetHeadroom,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetHeadroom+0x00 : jmp CDirectSoundVoice::SetHeadroom
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetHeadroom),
 
     // CDirectSoundBuffer::SetHeadroom+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetFrequency
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetFrequency, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFrequency,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetFrequency,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFrequency,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetFrequency+0x00 : jmp CDirectSoundVoice::SetFrequency
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetFrequency),
 
     // CDirectSoundBuffer::SetFrequency+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetI3DL2Source, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetI3DL2Source,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetI3DL2Source+0x00 : jmp CDirectSoundVoice::SetI3DL2Source
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetI3DL2Source),
 
     // CDirectSoundBuffer::SetI3DL2Source+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetLFO
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetLFO, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetLFO,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetLFO+0x00 : jmp CDirectSoundVoice::SetLFO
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetLFO),
 
     // CDirectSoundBuffer::SetLFO+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMixBins
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMixBins, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMixBins,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetMixBins,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMixBins,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetMixBins+0x00 : jmp CDirectSoundVoice::SetMixBins
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetMixBins),
 
     // CDirectSoundBuffer::SetMixBins+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMixBinVolumes
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMixBinVolumes, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMixBinVolumes,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetMixBinVolumes,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMixBinVolumes,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetMixBinVolumes+0x00 : jmp CDirectSoundVoice::SetMixBinVolumes
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetMixBinVolumes),
 
     // CDirectSoundBuffer::SetMixBinVolumes+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMode, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMode,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetMode+0x00 : jmp CDirectSoundVoice::SetMode
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetMode),
 
     // CDirectSoundBuffer::SetMode+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPitch
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetPitch, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPitch,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetPitch+0x00 : jmp CDirectSoundVoice::SetPitch
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetPitch),
 
     // CDirectSoundBuffer:SetPitch:+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetVolume, 3911, 1 + 1,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetVolume,
+                      3911,
 
-           XREF_CDirectSoundBuffer_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer::SetVolume+0x00 : jmp CDirectSoundVoice::SetVolume
     XREF_ENTRY(0x01, XREF_CDirectSoundVoice_SetVolume),
 
     // CDirectSoundBuffer::SetVolume+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::Constructor
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer
-OOVPA_XREF(CDirectSoundStream_Constructor, 3911, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Constructor,
+                      3911,
 
-           XREF_CDirectSoundStream_Constructor,
-           XRefZero)
-{
+                      XREF_CDirectSoundStream_Constructor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream::Constructor+0x00 : push esi; mov esi, ecx; push edi
     OV_MATCH(0x00, 0x56, 0x8B, 0xF1, 0x57),
@@ -6265,4 +6730,5 @@ OOVPA_XREF(CDirectSoundStream_Constructor, 3911, 13,
 
     // CDirectSoundStream::Constructor+0x22 : ret 0x0004
     OV_MATCH(0x22, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/3936.inl
+++ b/src/OOVPADatabase/DSound/3936.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CSensaura3d::GetFullHRTFFilterPair
 // ******************************************************************
-OOVPA_XREF(CSensaura3d_GetFullHRTFFilterPair, 3936, 9,
+OOVPA_SIG_HEADER_XREF(CSensaura3d_GetFullHRTFFilterPair,
+                      3936,
 
-           XREF_CSensaura3d_GetFullHRTFFilterPair,
-           XRefZero)
-{
+                      XREF_CSensaura3d_GetFullHRTFFilterPair,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x0C },
     { 0x0E, 0xD9 },
@@ -41,16 +42,18 @@ OOVPA_XREF(CSensaura3d_GetFullHRTFFilterPair, 3936, 9,
     { 0xAB, 0x17 },
     { 0xAC, 0xD8 },
     { 0xAD, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Flush, 3936, 15,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Flush,
+                      3936,
 
-           XREF_CMcpxStream_Flush,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Flush,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0xF6 },
     { 0x12, 0xF6 },
@@ -74,4 +77,5 @@ OOVPA_XREF(CMcpxStream_Flush, 3936, 15,
 
     { 0xA1, 0xC9 },
     { 0xA2, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4039.inl
+++ b/src/OOVPADatabase/DSound/4039.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * DirectSoundCreate
 // ******************************************************************
-OOVPA_NO_XREF(DirectSoundCreate, 4039, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(DirectSoundCreate,
+                         4039)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreate+0x0B : mov esi, eax
     { 0x0B, 0x8B },
@@ -47,16 +48,18 @@ OOVPA_NO_XREF(DirectSoundCreate, 4039, 9)
     // DirectSoundCreate+0x43 : retn 0x0C
     { 0x43, 0xC2 },
     { 0x44, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreateBuffer
 // ******************************************************************
-OOVPA_XREF(DirectSoundCreateBuffer, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(DirectSoundCreateBuffer,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreateBuffer+0x2B : call [CDirectSound::CreateSoundBuffer]
     XREF_ENTRY(0x2C, XREF_CDirectSound_CreateSoundBuffer),
@@ -78,16 +81,18 @@ OOVPA_XREF(DirectSoundCreateBuffer, 4039, 1 + 10,
     // DirectSoundCreateBuffer+0x4F : retn 0x08
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CreateSoundBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CreateSoundBuffer, 4039, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CreateSoundBuffer,
+                      4039,
 
-           XREF_CDirectSound_CreateSoundBuffer,
-           XRefZero)
-{
+                      XREF_CDirectSound_CreateSoundBuffer,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CreateSoundBuffer+0x00 : push ebp
     { 0x00, 0x55 },
@@ -113,7 +118,8 @@ OOVPA_XREF(CDirectSound_CreateSoundBuffer, 4039, 15,
     // CDirectSound_CreateSoundBuffer+0x9C : retn 0x10
     { 0x9C, 0xC2 },
     { 0x9D, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_DoWork
@@ -158,11 +164,12 @@ OOVPA_END;
 // ******************************************************************
 // * CDirectSoundBuffer::SetLoopRegion
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetLoopRegion, 4039, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetLoopRegion,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetLoopRegion,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetLoopRegion,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetLoopRegion+0x00 : push ebp
     { 0x00, 0x55 },
@@ -194,16 +201,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetLoopRegion, 4039, 17,
 
     // CDirectSoundBuffer_SetLoopRegion+0x66 : call CMcpxBuffer_SetLoopRegion
     { 0x66, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDistanceFactor, 4039, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDistanceFactor,
+                      4039,
 
-           XREF_CDirectSound_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDistanceFactor+0x20 : mov eax, 0x80004005
     { 0x20, 0xB8 },
@@ -231,16 +240,18 @@ OOVPA_XREF(CDirectSound_SetDistanceFactor, 4039, 17,
     // CDirectSound_SetDistanceFactor+0x4E : jz +0x0B
     { 0x4E, 0x74 },
     { 0x4F, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetRolloffFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetRolloffFactor, 4039, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetRolloffFactor,
+                      4039,
 
-           XREF_CDirectSound_SetRolloffFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetRolloffFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetRolloffFactor+0x20 : mov eax, 0x80004005
     { 0x20, 0xB8 },
@@ -268,16 +279,18 @@ OOVPA_XREF(CDirectSound_SetRolloffFactor, 4039, 17,
     // CDirectSound_SetRolloffFactor+0x4E : jz +0x0B
     { 0x4E, 0x74 },
     { 0x4F, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDopplerFactor, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDopplerFactor,
+                      4039,
 
-           XREF_CDirectSound_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDopplerFactor+0x20 : mov eax, 0x80004005
     { 0x20, 0xB8 },
@@ -300,17 +313,19 @@ OOVPA_XREF(CDirectSound_SetDopplerFactor, 4039, 14,
     // CDirectSound_SetDopplerFactor+0x4E : jz +0x0B
     { 0x4E, 0x74 },
     { 0x4F, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_SetVolume
 // ******************************************************************
 // Verified with Agent Under Fire title.
-OOVPA_XREF(CMcpxVoiceClient_SetVolume, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetVolume,
+                      4039,
 
-           XREF_CMcpxVoiceClient_SetVolume,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetVolume+0x15 : test byte ptr [esi+90h], 1
     { 0x15, 0xF6 },
@@ -330,17 +345,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetVolume, 4039, 13,
     { 0x74, 0x54 },
     { 0x75, 0x85 },
     { 0x76, 0xEC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetVolume
 // ******************************************************************
 // Verified with Agent Under Fire.
-OOVPA_XREF(CDirectSoundVoice_SetVolume, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVolume,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetVolume+0x15 : call [CMcpxVoiceClient::SetVolume]
     XREF_ENTRY(0x15, XREF_CMcpxVoiceClient_SetVolume),
@@ -364,17 +381,19 @@ OOVPA_XREF(CDirectSoundVoice_SetVolume, 4039, 1 + 12,
     // CDirectSoundVoice_SetVolume+0x19 : retn 8
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetVolume
 // ******************************************************************
 // Verified with Agent Under Fire.
-OOVPA_XREF(CDirectSoundBuffer_SetVolume, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetVolume,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetVolume+0x31 : call [CMcpxVoiceClient::SetVolume]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetVolume), // Was 4134 Offset -0x01h
@@ -395,7 +414,8 @@ OOVPA_XREF(CDirectSoundBuffer_SetVolume, 4039, 1 + 9,
     // CDirectSoundBuffer_SetVolume+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer::SetVolume
@@ -403,11 +423,12 @@ OOVPA_XREF(CDirectSoundBuffer_SetVolume, 4039, 1 + 9,
 // Generic OOVPA as of 4039 and newer
 // Verified with Agent Under Fire.
 // Side note: It is compatible down to XDK 3911. Except 3911 is calling to CDirectSoundVoice_SetVolume directly.
-OOVPA_XREF(IDirectSoundBuffer_SetVolume, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetVolume,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetVolume),
 
@@ -418,16 +439,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetVolume, 4039, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetVolume, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetVolume,
+                      4039,
 
-           XREF_CDirectSoundStream_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetVolume), // Was 4134 Offset -0x01h
 
@@ -439,17 +462,19 @@ OOVPA_XREF(CDirectSoundStream_SetVolume, 4039, 1 + 8,
     { 0x34, 0xE8 },
     { 0x3F, 0x68 },
     { 0x4A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetHeadroom
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CDirectSoundVoice_SetHeadroom, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetHeadroom,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetHeadroom+0x1A : call [CMcpxVoiceClient::SetVolume]
     XREF_ENTRY(0x1B, XREF_CMcpxVoiceClient_SetVolume),
@@ -477,16 +502,18 @@ OOVPA_XREF(CDirectSoundVoice_SetHeadroom, 4039, 1 + 12,
 
     { 0x20, 0xC2 },
     { 0x21, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetHeadroom
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetHeadroom, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetHeadroom,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetHeadroom), // Was 4134 Offset -0x01h
 
@@ -497,7 +524,8 @@ OOVPA_XREF(CDirectSoundBuffer_SetHeadroom, 4039, 1 + 7,
     { 0x2F, 0x10 },
     { 0x39, 0x74 },
     { 0x46, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetBufferData
@@ -552,11 +580,12 @@ OOVPA_END;
 // Generic OOVPA as of 4039 and newer
 // Verified with Agent Under Fire.
 // Same as 4134
-OOVPA_XREF(CDirectSoundVoice_SetPitch, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetPitch,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetPitch+0x11 : call [CMcpxVoiceClient::SetPitch]
     XREF_ENTRY(0x12, XREF_CMcpxVoiceClient_SetPitch),
@@ -578,16 +607,18 @@ OOVPA_XREF(CDirectSoundVoice_SetPitch, 4039, 1 + 11,
 
     { 0x16, 0xC2 },
     { 0x17, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPitch
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetPitch, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPitch,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetPitch+0x31 : call [CDirectSoundVoice::SetPitch]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetPitch), // Was 4134 Offset -0x01h
@@ -611,17 +642,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetPitch, 4039, 1 + 12,
     // CDirectSoundBuffer_SetPitch+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetPitch
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetPitch, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetPitch,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetPitch+0x15 : call [CDirectSoundBuffer_SetPitch]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetPitch),
@@ -640,17 +673,19 @@ OOVPA_XREF(IDirectSoundBuffer_SetPitch, 4039, 1 + 9,
     // IDirectSoundBuffer_SetPitch+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetFrequency
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CDirectSoundVoice_SetFrequency, 4039, 2 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetFrequency,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetFrequency,
-           XRefTwo)
-{
+                      XREF_CDirectSoundVoice_SetFrequency,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetFrequency+0x14 : call [XAudioCalcatePitch]
     XREF_ENTRY(0x15, XREF_XAudioCalculatePitch),
@@ -663,17 +698,19 @@ OOVPA_XREF(CDirectSoundVoice_SetFrequency, 4039, 2 + 6,
 
     // CDirectSoundVoice_SetFrequency+0x22 : retn 0x08
     OV_MATCH(0x21, 0xC2, 0x08),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetFrequency
 // ******************************************************************
 // Verified with Agent Under Fire.
-OOVPA_XREF(CDirectSoundBuffer_SetFrequency, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFrequency,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetFrequency,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFrequency,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetFrequency+0x31 : call [CDirectSoundVoice::SetFrequency]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetFrequency), // Was 4134 Offset -0x01
@@ -697,18 +734,20 @@ OOVPA_XREF(CDirectSoundBuffer_SetFrequency, 4039, 1 + 12,
     // CDirectSoundBuffer_SetFrequency+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetFrequency
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
 // Verified with Agent Under Fire.
-OOVPA_XREF(IDirectSoundBuffer_SetFrequency, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetFrequency,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetFrequency+0x15 : call [CDirectSound::SetFrequency]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetFrequency),
@@ -731,16 +770,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetFrequency, 4039, 1 + 11,
     // IDirectSoundBuffer_SetFrequency+0x11 : and ecx, eax
     { 0x11, 0x23 },
     { 0x12, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Stop
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Stop, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Stop,
+                      4039,
 
-           XREF_CDirectSoundBuffer_Stop,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_Stop,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_Stop+0x33 : call [CMcpxBuffer::Stop]
     //XREF_ENTRY( 0x30, XREF_CMcpxBuffer_Stop), //TODO: is this CMcpxBuffer::Stop or something else?
@@ -764,17 +805,19 @@ OOVPA_XREF(CDirectSoundBuffer_Stop, 4039, 12,
     // CDirectSoundBuffer_Stop+0x49 : retn 0x04
     { 0x49, 0xC2 },
     { 0x4A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CommitDeferredSettings
 // ******************************************************************
 // Verified with Agent Under Fire.
-OOVPA_XREF(CDirectSound_CommitDeferredSettings, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitDeferredSettings,
+                      4039,
 
-           XREF_CDirectSound_CommitDeferredSettings,
-           XRefOne)
-{
+                      XREF_CDirectSound_CommitDeferredSettings,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CommitDeferredSettings+0x44 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x45, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -800,16 +843,18 @@ OOVPA_XREF(CDirectSound_CommitDeferredSettings, 4039, 1 + 12,
 
     // CDirectSound_CommitDeferredSettings+0x78 : leave
     { 0x6F, 0xC9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Play(unsigned long)
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Play, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play,
+                      4039,
 
-           XREF_CMcpxBuffer_Play,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Play+0x00 : push ebp
     { 0x00, 0x55 },
@@ -833,17 +878,19 @@ OOVPA_XREF(CMcpxBuffer_Play, 4039, 13,
     { 0x40, 0x45 },
     { 0x41, 0x08 },
     { 0x42, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Play(__int64,unsigned long)
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CMcpxBuffer_Play_Ex, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play_Ex,
+                      4039,
 
-           XREF_CMcpxBuffer_Play_Ex,
-           XRefOne)
-{
+                      XREF_CMcpxBuffer_Play_Ex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Play_Ex+0x2B : call [CMcpxBuffer::Play]
     XREF_ENTRY(0x2B, XREF_CMcpxBuffer_Play),
@@ -863,16 +910,18 @@ OOVPA_XREF(CMcpxBuffer_Play_Ex, 4039, 1 + 8,
     // CMcpxBuffer_Play_Ex+0x36 : push esi
     { 0x36, 0xC2 },
     { 0x37, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::Play
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Play, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Play,
+                      4039,
 
-           XREF_CDirectSoundBuffer_Play,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundBuffer_Play+0x00 : push esi
     { 0x00, 0x56 },
@@ -894,16 +943,18 @@ OOVPA_XREF(CDirectSoundBuffer_Play, 4039, 13,
     { 0x4D, 0xC2 },
     { 0x4E, 0x10 },
     { 0x4F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::PlayEx
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_PlayEx, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_PlayEx,
+                      4039,
 
-           XREF_CDirectSoundBuffer_PlayEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_PlayEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3C, XREF_CMcpxBuffer_Play_Ex),
 
@@ -914,16 +965,18 @@ OOVPA_XREF(CDirectSoundBuffer_PlayEx, 4039, 1 + 7,
     { 0x39, 0x24 },
     { 0x45, 0x0B },
     { 0x51, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_GetCurrentPosition, 4039, 17,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_GetCurrentPosition,
+                      4039,
 
-           XREF_CMcpxBuffer_GetCurrentPosition,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_GetCurrentPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_GetCurrentPosition+0x16 : mov eax, [esi+0x00000090]
     { 0x16, 0x8B },
@@ -953,16 +1006,18 @@ OOVPA_XREF(CMcpxBuffer_GetCurrentPosition, 4039, 17,
     { 0xDB, 0xC2 },
     { 0xDC, 0x08 },
     { 0xDD, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_GetCurrentPosition, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetCurrentPosition,
+                      4039,
 
-           XREF_CDirectSoundBuffer_GetCurrentPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetCurrentPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_GetCurrentPosition+0x38 : call [CMcpxBuffer::GetCurrentPosition]
     XREF_ENTRY(0x38, XREF_CMcpxBuffer_GetCurrentPosition),
@@ -983,16 +1038,18 @@ OOVPA_XREF(CDirectSoundBuffer_GetCurrentPosition, 4039, 1 + 10,
     // CDirectSoundBuffer_GetCurrentPosition+0x51 : retn 0x08
     { 0x51, 0xC2 },
     { 0x52, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_GetStatus, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_GetStatus,
+                      4039,
 
-           XREF_CMcpxBuffer_GetStatus,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_GetStatus,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_GetStatus+0x14 : mov ecx, [ebp+0x08]
     { 0x14, 0x8B },
@@ -1018,16 +1075,18 @@ OOVPA_XREF(CMcpxBuffer_GetStatus, 4039, 13,
     // CMcpxBuffer_GetStatus+0x48 : retn 0x04
     { 0x48, 0xC2 },
     { 0x49, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetStatus
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_GetStatus, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetStatus,
+                      4039,
 
-           XREF_CDirectSoundBuffer_GetStatus,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetStatus,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_GetStatus+0x14 : call [CMcpxBuffer::GetStatus]
     XREF_ENTRY(0x34, XREF_CMcpxBuffer_GetStatus),
@@ -1049,16 +1108,18 @@ OOVPA_XREF(CDirectSoundBuffer_GetStatus, 4039, 1 + 10,
     // CDirectSoundBuffer_GetStatus+0x4D : retn 0x08
     { 0x4D, 0xC2 },
     { 0x4E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Lock
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_Lock, 4039, 1 + 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Lock,
+                      4039,
 
-           XREF_CDirectSoundBuffer_Lock,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Lock,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x45, XREF_CDirectSoundBuffer_GetCurrentPosition),
 
@@ -1080,16 +1141,18 @@ OOVPA_XREF(CDirectSoundBuffer_Lock, 4039, 1 + 13,
     { 0xA1, 0x8B },
     { 0xA2, 0x76 },
     { 0xA3, 0x1C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPlayRegion
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetPlayRegion, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPlayRegion,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetPlayRegion,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetPlayRegion,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x18, 0x68 },
@@ -1106,17 +1169,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetPlayRegion, 4039, 13,
 
     { 0x7C, 0xC2 },
     { 0x7D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetPlayRegion
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetPlayRegion, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetPlayRegion,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetPlayRegion+0x19 : call [CDirectSoundBuffer_SetPlayRegion]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetPlayRegion),
@@ -1135,16 +1200,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetPlayRegion, 4039, 1 + 9,
     // IDirectSoundBuffer_SetPlayRegion+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_SetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_SetCurrentPosition, 4039, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_SetCurrentPosition,
+                      4039,
 
-           XREF_CMcpxBuffer_SetCurrentPosition,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_SetCurrentPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_SetCurrentPosition+0x11 : lea eax, [esi+90h]
     { 0x11, 0x8D },
@@ -1160,16 +1227,18 @@ OOVPA_XREF(CMcpxBuffer_SetCurrentPosition, 4039, 9,
     { 0x6B, 0x86 },
     { 0x6C, 0xE4 },
     { 0x6D, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetCurrentPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetCurrentPosition, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetCurrentPosition,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetCurrentPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetCurrentPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetCurrentPosition+0x34 : call [CMcpxBuffer::SetCurrentPosition]
     XREF_ENTRY(0x34, XREF_CMcpxBuffer_SetCurrentPosition),
@@ -1191,16 +1260,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetCurrentPosition, 4039, 1 + 10,
     // CDirectSoundBuffer_SetCurrentPosition+0x4D : retn 0x08
     { 0x4D, 0xC2 },
     { 0x4E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CMcpxVoiceClient::SetFilter
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetFilter, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetFilter,
+                      4039,
 
-           XREF_CMcpxVoiceClient_SetFilter,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetFilter,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0xF8 },
     { 0x12, 0xE8 },
@@ -1216,16 +1287,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetFilter, 4039, 12,
 
     { 0x47, 0x83 },
     { 0x4D, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetFilter
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetFilter, 4039, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetFilter,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_CMcpxVoiceClient_SetFilter),
 
@@ -1235,16 +1308,18 @@ OOVPA_XREF(CDirectSoundVoice_SetFilter, 4039, 1 + 6,
     { 0x0A, 0x0C },
     { 0x10, 0xC2 },
     { 0x11, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetFilter
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetFilter, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFilter,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetFilter),
 
@@ -1255,17 +1330,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetFilter, 4039, 1 + 7,
     { 0x2F, 0x10 },
     { 0x39, 0x74 },
     { 0x46, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetFilter
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetFilter, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetFilter,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetFilter+0x15 : call [CDirectSoundBuffer_SetFilter]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetFilter),
@@ -1284,16 +1361,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetFilter, 4039, 1 + 9,
     // IDirectSoundBuffer_SetFilter+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetFilter
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetFilter, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetFilter,
+                      4039,
 
-           XREF_CDirectSoundStream_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetFilter),
 
@@ -1306,17 +1385,19 @@ OOVPA_XREF(CDirectSoundStream_SetFilter, 4039, 1 + 8,
     { 0x34, 0xE8 },
     { 0x3F, 0x68 },
     { 0x4A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetMixBins
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CMcpxVoiceClient_SetMixBins, 4039, 21,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetMixBins,
+                      4039,
 
-           XREF_CMcpxVoiceClient_SetMixBins,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetMixBins,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetMixBins+0x00 : push ebp
     { 0x00, 0x55 },
@@ -1348,18 +1429,20 @@ OOVPA_XREF(CMcpxVoiceClient_SetMixBins, 4039, 21,
     // CMcpxVoiceClient_SetMixBins+0xC8 : leave; retn
     { 0xC8, 0xC9 },
     { 0xC9, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMixBins
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
 // TODO: Maybe able to reduce pairs and include another XREF.
-OOVPA_XREF(CDirectSoundVoice_SetMixBins, 4039, 1 + 16,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMixBins,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetMixBins,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMixBins,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMixBins+0x0D : call [CDirectSoundVoiceSettings::SetMixBins]
     //XREF_ENTRY( 0x0D, XREF_CDirectSoundVoiceSettings_SetMixBins ),
@@ -1392,16 +1475,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMixBins, 4039, 1 + 16,
     // CDirectSoundVoice_SetMixBins+0x1A : retn 0x08
     { 0x1A, 0xC2 },
     { 0x1B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMixBins
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMixBins, 4039, 1 + 17,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMixBins,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetMixBins,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMixBins,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMixBins+0x31 : call [CDirectSoundVoice::SetMixBins]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetMixBins),
@@ -1432,17 +1517,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMixBins, 4039, 1 + 17,
     // CDirectSoundBuffer_SetMixBins+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMixBins
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetMixBins, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMixBins,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetMixBins+0x14 : call [CDirectSoundVoice::SetMixBins]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetMixBins),
@@ -1459,16 +1546,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMixBins, 4039, 1 + 7,
     // IDirectSoundBuffer_SetMixBins+0x11 : and ecx, eax
     { 0x11, 0x23 },
     { 0x12, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoiceSettings::SetMixBinVolumes
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoiceSettings_SetMixBinVolumes, 4039, 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoiceSettings_SetMixBinVolumes,
+                      4039,
 
-           XREF_CDirectSoundVoiceSettings_SetMixBinVolumes,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoiceSettings_SetMixBinVolumes,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoiceSettings_SetMixBinVolumes+0x09 : jbe +0x16
     { 0x09, 0x76 },
@@ -1487,18 +1576,20 @@ OOVPA_XREF(CDirectSoundVoiceSettings_SetMixBinVolumes, 4039, 10,
     // CDirectSoundVoiceSettings_SetMixBinVolumes+0x22 : retn 0x04
     { 0x22, 0xC2 },
     { 0x23, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMixBinVolumes
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer.
 // TODO: Should be able to reduce pairs since there are two XREFs.
-OOVPA_XREF(CDirectSoundVoice_SetMixBinVolumes, 4039, 2 + 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMixBinVolumes,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetMixBinVolumes,
-           XRefTwo)
-{
+                      XREF_CDirectSoundVoice_SetMixBinVolumes,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMixBinVolumes+0x0D : call [CDirectSoundVoiceSettings::SetMixBinVolumes]
     XREF_ENTRY(0x0D, XREF_CDirectSoundVoiceSettings_SetMixBinVolumes),
@@ -1528,17 +1619,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMixBinVolumes, 4039, 2 + 13,
     // CDirectSoundVoice_SetMixBinVolumes+0x1A : retn 0x08
     { 0x1A, 0xC2 },
     { 0x1B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMixBinVolumes
 // ******************************************************************
 //Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetMixBinVolumes, 4039, 1 + 17,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMixBinVolumes,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetMixBinVolumes,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMixBinVolumes,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMixBinVolumes+0x31 : call [CDirectSoundVoice::SetMixBinVolumes]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetMixBinVolumes),
@@ -1569,17 +1662,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMixBinVolumes, 4039, 1 + 17,
     // CDirectSoundBuffer_SetMixBinVolumes+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMixBinVolumes_8
 // ******************************************************************
 //Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetMixBinVolumes_8, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMixBinVolumes_8,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetMixBinVolumes_8+0x15 : call [CDirectSoundBuffer::SetMixBinVolumes]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetMixBinVolumes),
@@ -1602,16 +1697,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMixBinVolumes_8, 4039, 1 + 11,
     // IDirectSoundBuffer_SetMixBinVolumes_8+0x11 : and ecx, eax
     { 0x11, 0x23 },
     { 0x12, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMixBinVolumes_8
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMixBinVolumes_8, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMixBinVolumes_8,
+                      4039,
 
-           XREF_CDirectSoundStream_SetMixBinVolumes_8,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMixBinVolumes_8,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetMixBinVolumes),
 
@@ -1627,16 +1724,18 @@ OOVPA_XREF(CDirectSoundStream_SetMixBinVolumes_8, 4039, 1 + 11,
     { 0x24, 0x80 },
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CreateSoundStream
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CreateSoundStream, 4039, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CreateSoundStream,
+                      4039,
 
-           XREF_CDirectSound_CreateSoundStream,
-           XRefZero)
-{
+                      XREF_CDirectSound_CreateSoundStream,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CreateSoundStream+0x25 : mov eax, 0x80004005
     { 0x25, 0xB8 },
@@ -1664,17 +1763,19 @@ OOVPA_XREF(CDirectSound_CreateSoundStream, 4039, 15,
     // CDirectSound_CreateSoundStream+0x91 : retn 0x10
     { 0x91, 0xC2 },
     { 0x92, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_StopEx
 // ******************************************************************
 // Similar pattern of version 3911
-OOVPA_XREF(CDirectSoundBuffer_StopEx, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_StopEx,
+                      4039,
 
-           XREF_CDirectSoundBuffer_StopEx,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_StopEx,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x23, 0xB8 },
@@ -1690,17 +1791,19 @@ OOVPA_XREF(CDirectSoundBuffer_StopEx, 4039, 12,
 
     { 0x72, 0xC2 },
     { 0x73, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetLFO
 // ******************************************************************
 // Similar pattern of version 3911
-OOVPA_XREF(CMcpxVoiceClient_SetLFO, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetLFO,
+                      4039,
 
-           XREF_CMcpxVoiceClient_SetLFO,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetLFO,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x25, 0xEB },
@@ -1717,16 +1820,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetLFO, 4039, 13,
 
     { 0xCD, 0xC2 },
     { 0xCE, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetLFO
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetLFO, 4039, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetLFO,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_CMcpxVoiceClient_SetLFO),
 
@@ -1737,16 +1842,18 @@ OOVPA_XREF(CDirectSoundVoice_SetLFO, 4039, 1 + 6,
 
     { 0x10, 0xC2 },
     { 0x11, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetLFO
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetLFO, 4039, 1 + 17,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetLFO,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetLFO+0x31 : call [CDirectSoundVoice_SetLFO]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetLFO),
@@ -1777,17 +1884,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetLFO, 4039, 1 + 17,
     // CDirectSoundBuffer_SetLFO+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetLFO
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetLFO, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetLFO,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetLFO),
 
@@ -1798,16 +1907,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetLFO, 4039, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetLFO
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetLFO, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetLFO,
+                      4039,
 
-           XREF_CDirectSoundStream_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetLFO),
 
@@ -1822,17 +1933,19 @@ OOVPA_XREF(CDirectSoundStream_SetLFO, 4039, 1 + 10,
     { 0x3F, 0x68 },
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetEG
 // ******************************************************************
 // Similar pattern of version 3911
-OOVPA_XREF(CMcpxVoiceClient_SetEG, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetEG,
+                      4039,
 
-           XREF_CMcpxVoiceClient_SetEG,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetEG,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x25, 0xEB },
@@ -1848,16 +1961,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetEG, 4039, 12,
 
     { 0xD3, 0xC2 },
     { 0xD4, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetEG
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetEG, 4039, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetEG,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_CMcpxVoiceClient_SetEG),
 
@@ -1867,16 +1982,18 @@ OOVPA_XREF(CDirectSoundVoice_SetEG, 4039, 1 + 6,
     { 0x0A, 0x0C },
     { 0x10, 0xC2 },
     { 0x11, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetEG
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetEG, 4039, 1 + 17,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetEG,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetEG+0x31 : call [CDirectSoundVoice_SetEG]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetEG),
@@ -1907,16 +2024,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetEG, 4039, 1 + 17,
     // CDirectSoundBuffer_SetEG+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetEG
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetEG, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetEG,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetEG),
 
@@ -1927,16 +2046,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetEG, 4039, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetEG
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetEG, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetEG,
+                      4039,
 
-           XREF_CDirectSoundStream_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetEG),
 
@@ -1949,17 +2070,19 @@ OOVPA_XREF(CDirectSoundStream_SetEG, 4039, 1 + 8,
     { 0x34, 0xE8 },
     { 0x3F, 0x68 },
     { 0x4A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetOutputBuffer
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CDirectSoundVoice_SetOutputBuffer, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetOutputBuffer,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetOutputBuffer,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetOutputBuffer,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
 
@@ -1985,16 +2108,18 @@ OOVPA_XREF(CDirectSoundVoice_SetOutputBuffer, 4039, 13,
     // CDirectSoundVoice::SetOutputBuffer+0x51 : ret 0x0008
     { 0x51, 0xC2 },
     { 0x52, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetOutputBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetOutputBuffer, 4039, 1 + 17,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetOutputBuffer,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetOutputBuffer,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetOutputBuffer,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetOutputBuffer+0x30 : call [XREF_CDirectSoundVoice_SetOutputBuffer]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetOutputBuffer),
@@ -2025,16 +2150,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetOutputBuffer, 4039, 1 + 17,
     // CDirectSoundBuffer_SetOutputBuffer+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 4039, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOutsideVolume,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetConeOutsideVolume,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeOutsideVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOutsideVolume+0x07 : mov edx, [esp+arg_4]
     { 0x07, 0x8B },
@@ -2057,16 +2184,18 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 4039, 15,
     // CDirectSoundVoice_SetConeOutsideVolume+0x2A : retn 0Ch
     { 0x2A, 0xC2 },
     { 0x2B, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetConeOutsideVolume, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeOutsideVolume,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetConeOutsideVolume+0x35 : call [CDirectSoundVoice::SetConeOutsideVolume]
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetConeOutsideVolume),
@@ -2089,17 +2218,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeOutsideVolume, 4039, 1 + 11,
     // CDirectSoundBuffer_SetConeOutsideVolume+0x4E : retn 0Ch
     { 0x4E, 0xC2 },
     { 0x4F, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetConeOutsideVolume
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetConeOutsideVolume, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetConeOutsideVolume,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetConeOutsideVolume+0x18 : call [CDirectSoundBuffer_SetConeOutsideVolume]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetConeOutsideVolume),
@@ -2117,16 +2248,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetConeOutsideVolume, 4039, 1 + 8,
     // IDirectSoundBuffer_SetConeOutsideVolume+0x1D : retn 0Ch
     { 0x1E, 0x0C },
     { 0x1F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMaxDistance,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetMaxDistance,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetMaxDistance,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMaxDistance+0x07 : mov edx, [esp+arg_4]
     { 0x07, 0x8B },
@@ -2149,16 +2282,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 4039, 14,
     // CDirectSoundVoice_SetMaxDistance+0x2A : retn 0Ch
     { 0x2A, 0xC2 },
     { 0x2B, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMaxDistance, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMaxDistance,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMaxDistance+0x39 : call [CDirectSoundVoice_SetMaxDistance]
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetMaxDistance),
@@ -2180,16 +2315,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetMaxDistance, 4039, 1 + 10,
     // CDirectSoundBuffer_SetMaxDistance+0x52 : retn 0Ch
     { 0x53, 0x0C },
     { 0x54, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMinDistance,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetMinDistance,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetMinDistance,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetMinDistance+0x07 : mov edx, [esp+arg_4]
     { 0x07, 0x8B },
@@ -2212,16 +2349,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 4039, 14,
     // CDirectSoundVoice_SetMinDistance+0x2A : retn 0Ch
     { 0x2A, 0xC2 },
     { 0x2B, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMinDistance, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMinDistance,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMinDistance+0x39 : call [CDirectSoundVoice_SetMinDistance]
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetMinDistance),
@@ -2243,16 +2382,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetMinDistance, 4039, 1 + 10,
     // CDirectSoundBuffer_SetMinDistance+0x52 : retn 0Ch
     { 0x53, 0x0C },
     { 0x54, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMode, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMode,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMode+0x19 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x1A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -2278,16 +2419,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMode, 4039, 1 + 12,
     // CDirectSoundVoice::SetMode+0x20 : ret 0x000C
     { 0x20, 0xC2 },
     { 0x21, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetMode, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMode,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMode+0x35 : call [CDirectSoundVoice::SetMode]
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetMode),
@@ -2310,16 +2453,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetMode, 4039, 1 + 11,
     // CDirectSoundBuffer_SetMode+0x4E : retn 0Ch
     { 0x4E, 0xC2 },
     { 0x4F, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetPosition, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetPosition,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetPosition,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x08 },
     { 0x1C, 0xDC },
@@ -2335,16 +2480,18 @@ OOVPA_XREF(CDirectSoundVoice_SetPosition, 4039, 12,
 
     { 0x44, 0xC2 },
     { 0x45, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetPosition, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPosition,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetPosition+0x49 : call [CDirectSoundVoice::SetPosition]
     XREF_ENTRY(0x49, XREF_CDirectSoundVoice_SetPosition),
@@ -2365,17 +2512,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetPosition, 4039, 1 + 9,
     // CDirectSoundBuffer_SetPosition+0x63 : retn 14h
     { 0x63, 0xC2 },
     { 0x64, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetMode
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetMode, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetMode,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetMode+0x18 : call [CDirectSoundBuffer::SetMode]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetMode),
@@ -2394,16 +2543,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetMode, 4039, 1 + 9,
     // IDirectSoundBuffer_SetMode+0x1D : retn 0x0C
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetVelocity, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVelocity,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x08 },
     { 0x1C, 0xE8 },
@@ -2419,16 +2570,18 @@ OOVPA_XREF(CDirectSoundVoice_SetVelocity, 4039, 12,
 
     { 0x44, 0xC2 },
     { 0x45, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetVelocity, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetVelocity,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetVelocity+0x49 : call [CDirectSoundVoice::SetVelocity]
     XREF_ENTRY(0x49, XREF_CDirectSoundVoice_SetVelocity),
@@ -2449,16 +2602,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetVelocity, 4039, 1 + 9,
     // CDirectSoundBuffer_SetVelocity+0x63 : retn 14h
     { 0x63, 0xC2 },
     { 0x64, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOrientation,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetConeOrientation,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x08 },
     { 0x1C, 0xFC },
@@ -2474,16 +2629,18 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 4039, 12,
 
     { 0x44, 0xC2 },
     { 0x45, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetConeOrientation, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeOrientation,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetConeOrientation+0x49 : call [CDirectSoundVoice::SetConeOrientation]
     XREF_ENTRY(0x49, XREF_CDirectSoundVoice_SetConeOrientation),
@@ -2504,16 +2661,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeOrientation, 4039, 1 + 9,
     // CDirectSoundBuffer_SetConeOrientation+0x63 : retn 14h
     { 0x63, 0xC2 },
     { 0x64, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetOrientation, 4039, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetOrientation,
+                      4039,
 
-           XREF_CDirectSound_SetOrientation,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetOrientation+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2530,13 +2689,15 @@ OOVPA_XREF(CDirectSound_SetOrientation, 4039, 13,
     { 0x56, 0x1C },
     { 0x5D, 0x8B },
     { 0x5F, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetStatus
 // ******************************************************************
-OOVPA_NO_XREF(CDirectSoundStream_GetStatus, 4039, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_GetStatus,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -2559,16 +2720,18 @@ OOVPA_NO_XREF(CDirectSoundStream_GetStatus, 4039, 14)
 
     { 0x51, 0xC2 },
     { 0x52, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_DownloadEffectsImage
 // ******************************************************************
-OOVPA_XREF(CDirectSound_DownloadEffectsImage, 4039, 18,
+OOVPA_SIG_HEADER_XREF(CDirectSound_DownloadEffectsImage,
+                      4039,
 
-           XREF_CDirectSound_DownloadEffectsImage,
-           XRefZero)
-{
+                      XREF_CDirectSound_DownloadEffectsImage,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_DownloadEffectsImage+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2606,17 +2769,19 @@ OOVPA_XREF(CDirectSound_DownloadEffectsImage, 4039, 18,
     // CDirectSound_DownloadEffectsImage+0x60 : ret 14h
     { 0x60, 0xC2 },
     { 0x61, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetHeadroom
 // ******************************************************************
 //Generic OOVPA as of 4039 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetHeadroom, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetHeadroom,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetHeadroom+0x15 : call [CDirectSoundBuffer_SetHeadroom]
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetHeadroom),
@@ -2635,16 +2800,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetHeadroom, 4039, 1 + 9,
     // IDirectSoundBuffer_SetHeadroom+0x19 : retn 0x08
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetPosition, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetPosition,
+                      4039,
 
-           XREF_CDirectSound_SetPosition,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetPosition+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2669,16 +2836,18 @@ OOVPA_XREF(CDirectSound_SetPosition, 4039, 14,
     // CDirectSound_SetPosition+0x72 : retn 0x14
     { 0x72, 0xC2 },
     { 0x73, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetVelocity, 4039, 16,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetVelocity,
+                      4039,
 
-           XREF_CDirectSound_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetVelocity+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2705,16 +2874,18 @@ OOVPA_XREF(CDirectSound_SetVelocity, 4039, 16,
     // CDirectSound_SetVelocity+0x72 : retn 0x14
     { 0x72, 0xC2 },
     { 0x73, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetI3DL2Listener
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetI3DL2Listener, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetI3DL2Listener,
+                      4039,
 
-           XREF_CDirectSound_SetI3DL2Listener,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetI3DL2Listener,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetI3DL2Listener+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2740,16 +2911,18 @@ OOVPA_XREF(CDirectSound_SetI3DL2Listener, 4039, 12,
     { 0x3F, 0x00 },
     { 0x40, 0x78 },
     { 0x41, 0x88 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetAllParameters, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetAllParameters,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetAllParameters,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetAllParameters,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetAllParameters+0x00 : mov edx,[esp+04]
     { 0x00, 0x8B },
@@ -2773,16 +2946,18 @@ OOVPA_XREF(CDirectSoundVoice_SetAllParameters, 4039, 12,
     // CDirectSoundVoice_SetAllParameters+0x33 : retn 0x0C
     { 0x33, 0xC2 },
     { 0x34, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetAllParameters, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetAllParameters,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetAllParameters),
 
@@ -2797,17 +2972,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetAllParameters, 4039, 1 + 7,
     // CDirectSoundBuffer_SetAllParameters+0x4E : retn 0x0C
     { 0x4E, 0xC2 },
     { 0x4F, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetAllParameters
 // ******************************************************************
 //Generic OOVPA as of 4039 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetAllParameters, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetAllParameters,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetAllParameters),
 
@@ -2819,16 +2996,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetAllParameters, 4039, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeAngles
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeAngles,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetConeAngles,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeAngles,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x03, 0x04 },
@@ -2851,16 +3030,18 @@ OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 4039, 14,
     // CDirectSoundVoice_SetConeAngles+0x37 : retn 10h
     { 0x37, 0xC2 },
     { 0x38, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeAngles
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetConeAngles, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeAngles,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetConeAngles,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeAngles,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetConeAngles+0x39 : call [CDirectSoundVoice::SetConeAngles]
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetConeAngles),
@@ -2883,17 +3064,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeAngles, 4039, 1 + 11,
     // CDirectSoundBuffer_SetConeAngles+0x52 : retn 10h
     { 0x52, 0xC2 },
     { 0x53, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetConeAngles
 // ******************************************************************
 //Generic OOVPA as of 4039 and newer.
-OOVPA_XREF(IDirectSoundBuffer_SetConeAngles, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetConeAngles,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetConeAngles+0x1C : call [CDirectSoundBuffer::SetConeAngles]
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetConeAngles),
@@ -2912,16 +3095,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetConeAngles, 4039, 1 + 9,
     // IDirectSoundBuffer_SetConeAngles+0x21 : retn 10h
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetVelocity, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetVelocity,
+                      4039,
 
-           XREF_CDirectSoundStream_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4D, XREF_CDirectSoundVoice_SetVelocity),
 
@@ -2936,16 +3121,18 @@ OOVPA_XREF(CDirectSoundStream_SetVelocity, 4039, 1 + 10,
 
     { 0x67, 0xC2 },
     { 0x68, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetPosition, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetPosition,
+                      4039,
 
-           XREF_CDirectSoundStream_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4D, XREF_CDirectSoundVoice_SetPosition),
 
@@ -2960,16 +3147,18 @@ OOVPA_XREF(CDirectSoundStream_SetPosition, 4039, 1 + 10,
 
     { 0x67, 0xC2 },
     { 0x68, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMode, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMode,
+                      4039,
 
-           XREF_CDirectSoundStream_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetMode),
 
@@ -2984,16 +3173,18 @@ OOVPA_XREF(CDirectSoundStream_SetMode, 4039, 1 + 10,
 
     { 0x52, 0xC2 },
     { 0x53, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMaxDistance, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMaxDistance,
+                      4039,
 
-           XREF_CDirectSoundStream_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CDirectSoundVoice_SetMaxDistance),
 
@@ -3008,16 +3199,18 @@ OOVPA_XREF(CDirectSoundStream_SetMaxDistance, 4039, 1 + 10,
 
     { 0x56, 0xC2 },
     { 0x57, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMinDistance, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMinDistance,
+                      4039,
 
-           XREF_CDirectSoundStream_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CDirectSoundVoice_SetMinDistance),
 
@@ -3032,16 +3225,18 @@ OOVPA_XREF(CDirectSoundStream_SetMinDistance, 4039, 1 + 10,
 
     { 0x56, 0xC2 },
     { 0x57, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetConeOutsideVolume, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeOutsideVolume,
+                      4039,
 
-           XREF_CDirectSoundStream_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetConeOutsideVolume),
 
@@ -3053,16 +3248,18 @@ OOVPA_XREF(CDirectSoundStream_SetConeOutsideVolume, 4039, 1 + 8,
     { 0x3D, 0x85 },
     { 0x4E, 0x8B },
     { 0x52, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeOrientation
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetConeOrientation, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeOrientation,
+                      4039,
 
-           XREF_CDirectSoundStream_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4D, XREF_CDirectSoundVoice_SetConeOrientation),
 
@@ -3074,16 +3271,18 @@ OOVPA_XREF(CDirectSoundStream_SetConeOrientation, 4039, 1 + 8,
     { 0x38, 0xEC },
     { 0x43, 0x24 },
     { 0x4C, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeAngles
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetConeAngles, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeAngles,
+                      4039,
 
-           XREF_CDirectSoundStream_SetConeAngles,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeAngles,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CDirectSoundVoice_SetConeAngles),
 
@@ -3097,16 +3296,18 @@ OOVPA_XREF(CDirectSoundStream_SetConeAngles, 4039, 1 + 8,
     { 0x36, 0x18 },
 
     { 0x3C, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetAllParameters, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetAllParameters,
+                      4039,
 
-           XREF_CDirectSoundStream_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetAllParameters),
 
@@ -3118,16 +3319,18 @@ OOVPA_XREF(CDirectSoundStream_SetAllParameters, 4039, 1 + 8,
     { 0x38, 0xE8 },
     { 0x43, 0x68 },
     { 0x4E, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetOutputBuffer
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetOutputBuffer, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetOutputBuffer,
+                      4039,
 
-           XREF_CDirectSoundStream_SetOutputBuffer,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetOutputBuffer,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetOutputBuffer),
 
@@ -3140,16 +3343,18 @@ OOVPA_XREF(CDirectSoundStream_SetOutputBuffer, 4039, 1 + 8,
     { 0x34, 0xE8 },
     { 0x3F, 0x68 },
     { 0x4A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetFrequency
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetFrequency, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetFrequency,
+                      4039,
 
-           XREF_CDirectSoundStream_SetFrequency,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetFrequency,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetFrequency),
 
@@ -3174,50 +3379,56 @@ OOVPA_XREF(CDirectSoundStream_SetFrequency, 4039, 1 + 11,
     // ret 8
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetFrequency
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetFrequency, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetFrequency,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetFrequency+0x00 : jmp [CDirectSoundStream_SetFrequency]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetFrequency),
 
     // IDirectSoundStream_SetFrequency+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetVolume
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetVolume, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetVolume,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetVolume+0x00 : jmp [CDirectSoundStream_SetVolume]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetVolume),
 
     // IDirectSoundStream_SetVolume+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetPitch
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetPitch, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetPitch,
+                      4039,
 
-           XREF_CDirectSoundStream_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetPitch),
 
@@ -3232,101 +3443,113 @@ OOVPA_XREF(CDirectSoundStream_SetPitch, 4039, 1 + 11,
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
     { 0x50, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetPitch
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetPitch, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetPitch,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetPitch+0x00 : jmp [CDirectSoundStream_SetPitch]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetPitch),
 
     // IDirectSoundStream_SetPitch+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetLFO
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetLFO, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetLFO,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetLFO+0x00 : jmp [CDirectSoundStream_SetLFO]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetLFO),
 
     // IDirectSoundStream_SetLFO+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetEG
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetEG, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetEG,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetEG+0x00 : jmp [CDirectSoundStream_SetEG]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetEG),
 
     // IDirectSoundStream_SetEG+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetFilter
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetFilter, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetFilter,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetFilter+0x00 : jmp [CDirectSoundStream_SetFilter]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetFilter),
 
     // IDirectSoundStream_SetFilter+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMixBinVolumes
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetMixBinVolumes_8, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetMixBinVolumes_8,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetMixBinVolumes+0x00 : jmp [CDirectSoundStream_SetMixBinVolumes]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetMixBinVolumes_8),
 
     // IDirectSoundStream_SetMixBinVolumes+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Pause
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Pause, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Pause,
+                      4039,
 
-           XREF_CMcpxStream_Pause,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Pause,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxStream_Pause+0x00 : push ebp
     { 0x00, 0x55 },
@@ -3349,16 +3572,18 @@ OOVPA_XREF(CMcpxStream_Pause, 4039, 12,
     // CMcpxStream_Pause+0x48 : retn 0x04
     { 0x48, 0xC2 },
     { 0x49, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Pause
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Pause, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Pause,
+                      4039,
 
-           XREF_CDirectSoundStream_Pause,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_Pause,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_Pause+0x33 : call [CMcpxStream::Pause]
     XREF_ENTRY(0x34, XREF_CMcpxStream_Pause),
@@ -3381,17 +3606,19 @@ OOVPA_XREF(CDirectSoundStream_Pause, 4039, 1 + 11,
     // CDirectSoundStream_Pause+0x4D : retn 0x08
     { 0x4D, 0xC2 },
     { 0x4E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DSound_CRefCount_AddRef
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(DSound_CRefCount_AddRef, 4039, 12,
+OOVPA_SIG_HEADER_XREF(DSound_CRefCount_AddRef,
+                      4039,
 
-           XREF_DSound_CRefCount_AddRef,
-           XRefZero)
-{
+                      XREF_DSound_CRefCount_AddRef,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // DSound_CRefCount_AddRef+0x00 : mov eax,dword ptr [esp+4]
     { 0x00, 0x8B },
@@ -3412,16 +3639,18 @@ OOVPA_XREF(DSound_CRefCount_AddRef, 4039, 12,
     // DSound_CRefCount_AddRef+0x0A : retn 0x04
     { 0x0A, 0xC2 },
     { 0x0B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DSound_CRefCount_Release
 // ******************************************************************
-OOVPA_XREF(DSound_CRefCount_Release, 4039, 10,
+OOVPA_SIG_HEADER_XREF(DSound_CRefCount_Release,
+                      4039,
 
-           XREF_DSound_CRefCount_Release,
-           XRefZero)
-{
+                      XREF_DSound_CRefCount_Release,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -3441,17 +3670,19 @@ OOVPA_XREF(DSound_CRefCount_Release, 4039, 10,
     // DSound_CRefCount_Release+0x20 : retn 0x04
     { 0x20, 0xC2 },
     { 0x21, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::Release
 // ******************************************************************
 // NOTE: Has identical function to CAc97MediaObject::Release
-OOVPA_XREF(CDirectSoundStream_Release, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Release,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x31, XREF_DSound_CRefCount_Release),
 
@@ -3469,16 +3700,18 @@ OOVPA_XREF(CDirectSoundStream_Release, 4039, 1 + 11,
     { 0x4A, 0xC2 },
     { 0x4B, 0x04 },
     { 0x4C, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CFullHRTFSource::GetCenterVolume
 // ******************************************************************
-OOVPA_XREF(CFullHRTFSource_GetCenterVolume, 4039, 11,
+OOVPA_SIG_HEADER_XREF(CFullHRTFSource_GetCenterVolume,
+                      4039,
 
-           XREF_CFullHRTFSource_GetCenterVolume,
-           XRefZero)
-{
+                      XREF_CFullHRTFSource_GetCenterVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CFullHRTFSource::GetCenterVolume+0x00 : push ebp; mov ebp,esp
     OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
@@ -3491,16 +3724,18 @@ OOVPA_XREF(CFullHRTFSource_GetCenterVolume, 4039, 11,
 
     // CFullHRTFSource::GetCenterVolume+0xD1 : ret 0x0004
     OV_MATCH(0xD1, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHRTFSource::SetFullHRTF5Channel
 // ******************************************************************
-OOVPA_XREF(CHRTFSource_SetFullHRTF5Channel, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CHRTFSource_SetFullHRTF5Channel,
+                      4039,
 
-           XREF_CHRTFSource_SetFullHRTF5Channel,
-           XRefOne)
-{
+                      XREF_CHRTFSource_SetFullHRTF5Channel,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CHRTFSource::SetFullHRTF5Channel+0x36 : mov [var],CFullHRTFSource::GetCenterVolume
     XREF_ENTRY(0x38, XREF_CFullHRTFSource_GetCenterVolume),
@@ -3515,16 +3750,18 @@ OOVPA_XREF(CHRTFSource_SetFullHRTF5Channel, 4039, 1 + 8,
     OV_MATCH(0x46, 0xC7),
 
     OV_MATCH(0x50, 0xC3),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseFullHRTF
 // ******************************************************************
-OOVPA_XREF(DirectSoundUseFullHRTF, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseFullHRTF,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundUseFullHRTF+0x08 : call [CHRTFSource::SetFullHRTF5Channel]
     XREF_ENTRY(0x09, XREF_CHRTFSource_SetFullHRTF5Channel),
@@ -3540,16 +3777,18 @@ OOVPA_XREF(DirectSoundUseFullHRTF, 4039, 1 + 7,
 
     // DirectSoundUseFullHRTF+0x1D : ret
     OV_MATCH(0x1D, 0xC3),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioCalculatePitch
 // ******************************************************************
-OOVPA_XREF(XAudioCalculatePitch, 4039, 12,
+OOVPA_SIG_HEADER_XREF(XAudioCalculatePitch,
+                      4039,
 
-           XREF_XAudioCalculatePitch,
-           XRefZero)
-{
+                      XREF_XAudioCalculatePitch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -3571,16 +3810,18 @@ OOVPA_XREF(XAudioCalculatePitch, 4039, 12,
     // XAudioCalculatePitch+0x48 : retn 0x04
     { 0x48, 0xC2 },
     { 0x49, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::EnableHeadphones
 // ******************************************************************
-OOVPA_XREF(CDirectSound_EnableHeadphones, 4039, 16,
+OOVPA_SIG_HEADER_XREF(CDirectSound_EnableHeadphones,
+                      4039,
 
-           XREF_CDirectSound_EnableHeadphones,
-           XRefZero)
-{
+                      XREF_CDirectSound_EnableHeadphones,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -3602,13 +3843,15 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 4039, 16,
 
     { 0x7F, 0xC2 },
     { 0x80, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Process
 // ******************************************************************
-OOVPA_NO_XREF(CDirectSoundStream_Process, 4039, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_Process,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x57 },
 
@@ -3635,16 +3878,18 @@ OOVPA_NO_XREF(CDirectSoundStream_Process, 4039, 17)
 
     { 0x60, 0xC2 },
     { 0x61, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Flush, 4039, 10,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Flush,
+                      4039,
 
-           XREF_CMcpxStream_Flush,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Flush,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -3661,16 +3906,18 @@ OOVPA_XREF(CMcpxStream_Flush, 4039, 10,
 
     { 0x98, 0xC9 },
     { 0x99, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Flush
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Flush, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Flush,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream::Flush+0x2F : call [CMcpxStream::Flush]
     XREF_ENTRY(0x30, XREF_CMcpxStream_Flush),
@@ -3689,17 +3936,19 @@ OOVPA_XREF(CDirectSoundStream_Flush, 4039, 1 + 8,
     //CDirectSoundStream_Flush+0x49 : ret 4
     { 0x49, 0xC2 },
     { 0x4A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_AddRef
 // ******************************************************************
 // NOTE: Has identical function to DirectSound::CAc97MediaObject::AddRef
-OOVPA_XREF(CDirectSoundStream_AddRef, 4039, 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_AddRef,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream::AddRef+0x00 : call DirectSoundEnterCriticalSection
     { 0x00, 0xE8 },
@@ -3721,13 +3970,15 @@ OOVPA_XREF(CDirectSoundStream_AddRef, 4039, 11,
     // CDirectSoundStream::AddRef+0x41 : ret 4
     { 0x41, 0xC2 },
     { 0x42, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetInfo
 // ******************************************************************
-OOVPA_NO_XREF(CDirectSoundStream_GetInfo, 4039, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_GetInfo,
+                         4039)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream_GetInfo+0x00 : push ebx
     { 0x00, 0x53 },
@@ -3757,16 +4008,18 @@ OOVPA_NO_XREF(CDirectSoundStream_GetInfo, 4039, 17)
     //CDirectSoundStream_GetInfo+0x63 : ret 8
     { 0x63, 0xC2 },
     { 0x64, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Discontinuity, 4039, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Discontinuity,
+                      4039,
 
-           XREF_CMcpxStream_Discontinuity,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Discontinuity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CMcpxStream_Discontinuity+0x17 : call [CMcpxStream_Flush]
     XREF_ENTRY(0x18, XREF_CMcpxStream_Flush),
@@ -3782,16 +4035,18 @@ OOVPA_XREF(CMcpxStream_Discontinuity, 4039, 1 + 6,
     { 0x1E, 0x5E },
 
     { 0x1F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Discontinuity, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Discontinuity,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream_Discontinuity+0x2F : call [CMcpxStream_Discontinuity]
     XREF_ENTRY(0x30, XREF_CMcpxStream_Discontinuity),
@@ -3810,16 +4065,18 @@ OOVPA_XREF(CDirectSoundStream_Discontinuity, 4039, 1 + 8,
     //CDirectSoundStream_Discontinuity+0x49 : ret 4
     { 0x49, 0xC2 },
     { 0x4A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetMixBins
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMixBins, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMixBins,
+                      4039,
 
-           XREF_CDirectSoundStream_SetMixBins,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMixBins,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetMixBins),
 
@@ -3835,34 +4092,38 @@ OOVPA_XREF(CDirectSoundStream_SetMixBins, 4039, 1 + 9,
 
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetMixBins
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetMixBins, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetMixBins,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetMixBins+0x00 : jmp [CDirectSoundStream_SetMixBins]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetMixBins),
 
     // IDirectSoundStream_SetMixBins+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetI3DL2Source
 // ******************************************************************
 // TODO: Is possible to reduce pairs with an XREF included?
-OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 4039, 18,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetI3DL2Source,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetI3DL2Source,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetI3DL2Source,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetI3DL2Source+0x00 : mov edx, [esp+arg_0]
     { 0x00, 0x8B },
@@ -3889,16 +4150,18 @@ OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 4039, 18,
     // CDirectSoundVoice_SetI3DL2Source+0x57 : retn 08h
     { 0x57, 0xC2 },
     { 0x58, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetI3DL2Source, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetI3DL2Source,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetI3DL2Source+0x35 : call [CDirectSoundVoice::SetI3DL2Source]
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetI3DL2Source),
@@ -3921,17 +4184,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetI3DL2Source, 4039, 1 + 11,
     // CDirectSoundBuffer_SetI3DL2Source+0x4E : retn 0Ch
     { 0x4E, 0xC2 },
     { 0x4F, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetI3DL2Source
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetI3DL2Source, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetI3DL2Source,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetI3DL2Source+0x18 : call [CDirectSoundBuffer::SetI3DL2Source]
     XREF_ENTRY(0x19, XREF_CDirectSoundBuffer_SetI3DL2Source),
@@ -3950,16 +4215,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetI3DL2Source, 4039, 1 + 9,
     // IDirectSoundBuffer_SetI3DL2Source+0x1D : retn 0Ch
     { 0x1E, 0x0C },
     { 0x1F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::GetCaps
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetCaps, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetCaps,
+                      4039,
 
-           XREF_CDirectSound_GetCaps,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetCaps,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x15, 0x68 },
@@ -3975,16 +4242,18 @@ OOVPA_XREF(CDirectSound_GetCaps, 4039, 12,
 
     { 0x6C, 0xC2 },
     { 0x6D, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreateStream
 // ******************************************************************
-OOVPA_XREF(DirectSoundCreateStream, 4039, 1 + 10,
+OOVPA_SIG_HEADER_XREF(DirectSoundCreateStream,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreateStream+0x2B : call [CDirectSound::CreateSoundStream]
     XREF_ENTRY(0x2C, XREF_CDirectSound_CreateSoundStream),
@@ -4006,16 +4275,18 @@ OOVPA_XREF(DirectSoundCreateStream, 4039, 1 + 10,
     // DirectSoundCreateStream+0x4F : retn 0x08
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetHeadroom
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetHeadroom, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetHeadroom,
+                      4039,
 
-           XREF_CDirectSoundStream_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetHeadroom),
 
@@ -4028,31 +4299,35 @@ OOVPA_XREF(CDirectSoundStream_SetHeadroom, 4039, 1 + 8,
     { 0x34, 0xE8 },
     { 0x3F, 0x68 },
     { 0x4A, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetHeadroom
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetHeadroom, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetHeadroom,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetHeadroom+0x00 : jmp [CDirectSoundStream_SetHeadroom]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetHeadroom),
 
     // IDirectSoundStream_SetHeadroom+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IsValidFormat
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_NO_XREF(IsValidFormat, 4039, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(IsValidFormat,
+                         4039)
+OOVPA_SIG_MATCH(
 
     // IsValidFormat+0x00 : mov ecx, [esp+4]
     { 0x00, 0x8B },
@@ -4078,16 +4353,18 @@ OOVPA_NO_XREF(IsValidFormat, 4039, 11)
     // IsValidFormat+0x30 : retn 4
     { 0x30, 0xC2 },
     { 0x31, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetNotificationPositions
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetNotificationPositions,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetNotificationPositions,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetNotificationPositions,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetNotificationPositions+0x00 : push esi
     { 0x00, 0x56 },
@@ -4112,16 +4389,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 4039, 12,
     // CDirectSoundBuffer_SetNotificationPositions+0x22 : retn 0Ch
     { 0x22, 0xC2 },
     { 0x23, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetFormat
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetFormat, 4039, 2 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetFormat,
+                      4039,
 
-           XREF_CDirectSoundVoice_SetFormat,
-           XRefTwo)
-{
+                      XREF_CDirectSoundVoice_SetFormat,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetFormat+0x2C : call [CMcpxVoiceClient::SetMixBins]
     XREF_ENTRY(0x2D, XREF_CMcpxVoiceClient_SetMixBins),
@@ -4140,16 +4419,18 @@ OOVPA_XREF(CDirectSoundVoice_SetFormat, 4039, 2 + 6,
     // CDirectSoundVoice::SetFormat+0x44 : ret 0x08
     { 0x44, 0xC2 },
     { 0x45, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetFormat
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetFormat, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFormat,
+                      4039,
 
-           XREF_CDirectSoundBuffer_SetFormat,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFormat,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetFormat+0x30 : call [CDirectSoundVoice::SetFormat]
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_SetFormat), // Was 4134 Offset -0x01h
@@ -4173,17 +4454,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetFormat, 4039, 1 + 12,
     // CDirectSoundBuffer_SetFormat+0x4A : retn 0x08
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetFormat
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetFormat, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetFormat,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_SetFormat),
 
@@ -4194,16 +4477,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetFormat, 4039, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetFormat
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetFormat, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetFormat,
+                      4039,
 
-           XREF_CDirectSoundStream_SetFormat,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetFormat,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_SetFormat),
 
@@ -4228,33 +4513,37 @@ OOVPA_XREF(CDirectSoundStream_SetFormat, 4039, 1 + 11,
     // ret 8
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetFormat
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(IDirectSoundStream_SetFormat, 4039, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetFormat,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetFormat+0x00 : jmp [CDirectSoundStream_SetFormat]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetFormat),
 
     // IDirectSoundStream_SetFormat+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_CommitEffectData
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CommitEffectData, 4039, 16,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitEffectData,
+                      4039,
 
-           XREF_CDirectSound_CommitEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_CommitEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0C, 0x00 },
@@ -4278,16 +4567,18 @@ OOVPA_XREF(CDirectSound_CommitEffectData, 4039, 16,
 
     { 0x4C, 0xC2 },
     { 0x4D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetEffectData
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetEffectData, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetEffectData,
+                      4039,
 
-           XREF_CDirectSound_GetEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0x00 },
@@ -4308,16 +4599,18 @@ OOVPA_XREF(CDirectSound_GetEffectData, 4039, 14,
 
     { 0x5B, 0xC2 },
     { 0x5C, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetEffectData
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetEffectData, 4039, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetEffectData,
+                      4039,
 
-           XREF_CDirectSound_SetEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0x00 },
@@ -4338,16 +4631,18 @@ OOVPA_XREF(CDirectSound_SetEffectData, 4039, 14,
 
     { 0x5E, 0xC2 },
     { 0x5F, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetI3DL2Source, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetI3DL2Source,
+                      4039,
 
-           XREF_CDirectSoundStream_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x39, XREF_CDirectSoundVoice_SetI3DL2Source),
 
@@ -4359,16 +4654,18 @@ OOVPA_XREF(CDirectSoundStream_SetI3DL2Source, 4039, 1 + 8,
     { 0x38, 0xE8 },
     { 0x43, 0x68 },
     { 0x4E, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetAllParameters
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetAllParameters, 4039, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetAllParameters,
+                      4039,
 
-           XREF_CDirectSound_SetAllParameters,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetAllParameters,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetAllParameters+0x00 : push ebx
     { 0x00, 0x53 },
@@ -4392,18 +4689,20 @@ OOVPA_XREF(CDirectSound_SetAllParameters, 4039, 15,
     // CDirectSound_SetAllParameters+0x67 : retn 0Ch
     { 0x67, 0xC2 },
     { 0x68, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioCreateAdpcmFormat
 // ******************************************************************
 // NOTE: 4134 later versions changed to a jmp, then convert into
 // class function.
-OOVPA_XREF(XAudioCreateAdpcmFormat, 4039, 12,
+OOVPA_SIG_HEADER_XREF(XAudioCreateAdpcmFormat,
+                      4039,
 
-           XREF_WaveFormat_CreateXboxAdpcmFormat,
-           XRefZero)
-{
+                      XREF_WaveFormat_CreateXboxAdpcmFormat,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x07, 0x08),
     OV_MATCH(0x10, 0xE9),
@@ -4413,16 +4712,18 @@ OOVPA_XREF(XAudioCreateAdpcmFormat, 4039, 12,
 
     OV_MATCH(0x34, 0x66),
     OV_MATCH(0x3D, 0x12),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      4039,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -4447,16 +4748,18 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4039, 12,
     //{ 0x77, 0x00 },
     { 0x78, 0x00 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::CommitDeferredSettings
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 4039, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_CommitDeferredSettings,
+                      4039,
 
-           XREF_CDirectSoundVoice_CommitDeferredSettings,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_CommitDeferredSettings,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::CommitDeferredSettings+0x1D : call [CMcpxVoiceClient::Commit3dSettings]
     XREF_ENTRY(0x1E, XREF_CMcpxVoiceClient_Commit3dSettings),
@@ -4482,16 +4785,18 @@ OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 4039, 1 + 11,
     { 0x2F, 0xC2 },
     { 0x30, 0x04 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_SetPitch
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetPitch, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetPitch,
+                      4039,
 
-           XREF_CMcpxVoiceClient_SetPitch,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetPitch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -4511,16 +4816,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetPitch, 4039, 12,
     { 0x73, 0x86 },
     { 0x74, 0x84 },
     { 0x75, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBufferSettings::SetBufferData
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBufferSettings_SetBufferData, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBufferSettings_SetBufferData,
+                      4039,
 
-           XREF_CDirectSoundBufferSettings_SetBufferData,
-           XRefZero)
-{
+                      XREF_CDirectSoundBufferSettings_SetBufferData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBufferSettings::SetBufferData+0x00 : push ebp
     { 0x00, 0x55 },
@@ -4546,16 +4853,18 @@ OOVPA_XREF(CDirectSoundBufferSettings_SetBufferData, 4039, 12,
     // CDirectSoundBufferSettings::SetBufferData+0x78 : ret 8
     { 0x78, 0xC2 },
     { 0x79, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CLightHRTFSource::GetCenterVolume
 // ******************************************************************
-OOVPA_XREF(CLightHRTFSource_GetCenterVolume, 4039, 11,
+OOVPA_SIG_HEADER_XREF(CLightHRTFSource_GetCenterVolume,
+                      4039,
 
-           XREF_CLightHRTFSource_GetCenterVolume,
-           XRefZero)
-{
+                      XREF_CLightHRTFSource_GetCenterVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CLightHRTFSource::GetCenterVolume+0x00 : push ebp; mov ebp,esp
     OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
@@ -4568,16 +4877,18 @@ OOVPA_XREF(CLightHRTFSource_GetCenterVolume, 4039, 11,
 
     // CLightHRTFSource::GetCenterVolume+0xB9 : ret 0x0004
     OV_MATCH(0xB9, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHRTFSource::SetLightHRTF5Channel
 // ******************************************************************
-OOVPA_XREF(CHRTFSource_SetLightHRTF5Channel, 4039, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CHRTFSource_SetLightHRTF5Channel,
+                      4039,
 
-           XREF_CHRTFSource_SetLightHRTF5Channel,
-           XRefOne)
-{
+                      XREF_CHRTFSource_SetLightHRTF5Channel,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CHRTFSource::SetLightHRTF5Channel+0x36 : mov [var],CLightHRTFSource::GetCenterVolume
     XREF_ENTRY(0x38, XREF_CLightHRTFSource_GetCenterVolume),
@@ -4592,16 +4903,18 @@ OOVPA_XREF(CHRTFSource_SetLightHRTF5Channel, 4039, 1 + 8,
     OV_MATCH(0x46, 0xC7),
 
     OV_MATCH(0x50, 0xC3),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseLightHRTF
 // ******************************************************************
-OOVPA_XREF(DirectSoundUseLightHRTF, 4039, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseLightHRTF,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundUseLightHRTF+0x08 : call [CHRTFSource::SetLightHRTF5Channel]
     XREF_ENTRY(0x09, XREF_CHRTFSource_SetLightHRTF5Channel),
@@ -4617,17 +4930,19 @@ OOVPA_XREF(DirectSoundUseLightHRTF, 4039, 1 + 7,
 
     // DirectSoundUseLightHRTF+0x1D : ret
     OV_MATCH(0x1D, 0xC3),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxAPU::SetMixBinHeadroom
 // ******************************************************************
 // Generic OOVPA as of 4039 and newer
-OOVPA_XREF(CMcpxAPU_SetMixBinHeadroom, 4039, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_SetMixBinHeadroom,
+                      4039,
 
-           XREF_CMcpxAPU_SetMixBinHeadroom,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_SetMixBinHeadroom,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_SetMixBinHeadroom+0x00: push ebp;
     OV_MATCH(0x00, 0x55),
@@ -4642,16 +4957,18 @@ OOVPA_XREF(CMcpxAPU_SetMixBinHeadroom, 4039, 12,
     OV_MATCH(0x1C, 0x83, 0xF8, 0x04),
 
     // Generic support over multiple revisions end at offset 0x27
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetMixBinHeadroom
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetMixBinHeadroom, 4039, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetMixBinHeadroom,
+                      4039,
 
-           XREF_CDirectSound_SetMixBinHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetMixBinHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound::SetMixBinHeadroom+0x42 : call [CMcpxAPU::SetMixBinHeadroom]
     XREF_ENTRY(0x43, XREF_CMcpxAPU_SetMixBinHeadroom),
@@ -4667,16 +4984,18 @@ OOVPA_XREF(CDirectSound_SetMixBinHeadroom, 4039, 1 + 12,
 
     // CDirectSound::SetMixBinHeadroom+0x5C : retn 0x0C
     OV_MATCH(0x5C, 0xC2, 0x0C),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundOverrideSpeakerConfig
 // ******************************************************************
-OOVPA_XREF(DirectSoundOverrideSpeakerConfig, 4039, 1 + 9,
+OOVPA_SIG_HEADER_XREF(DirectSoundOverrideSpeakerConfig,
+                      4039,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundOverrideSpeakerConfig+0x00 : call [DirectSoundEnterCriticalSection]
     XREF_ENTRY(0x01, XREF_DirectSoundEnterCriticalSection),
@@ -4689,13 +5008,15 @@ OOVPA_XREF(DirectSoundOverrideSpeakerConfig, 4039, 1 + 9,
 
     // DirectSoundOverrideSpeakerConfig+0x24 : retn 0x0004
     OV_MATCH(0x24, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioDownloadEffectsImage
 // ******************************************************************
-OOVPA_NO_XREF(XAudioDownloadEffectsImage, 4039, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(XAudioDownloadEffectsImage,
+                         4039)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x00, 0x55),
 
@@ -4704,4 +5025,5 @@ OOVPA_NO_XREF(XAudioDownloadEffectsImage, 4039, 10)
     OV_MATCH(0x3C, 0x83),
     OV_MATCH(0x4E, 0xE8),
     OV_MATCH(0x65, 0x8B),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4134.inl
+++ b/src/OOVPADatabase/DSound/4134.inl
@@ -28,8 +28,9 @@
 // * DirectSoundCreate
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_NO_XREF(DirectSoundCreate, 4134, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(DirectSoundCreate,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreate+0x0B : movzx esi, al
     { 0x0B, 0x0F },
@@ -49,17 +50,19 @@ OOVPA_NO_XREF(DirectSoundCreate, 4134, 9)
 
     // DirectSoundCreate+0x43 : leave
     { 0x43, 0xC9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundDoWork
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(DirectSoundDoWork, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(DirectSoundDoWork,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundDoWork+0x13 : call [CDirectSound::DoWork]
     XREF_ENTRY(0x14, XREF_CDirectSound_DoWork),
@@ -77,17 +80,19 @@ OOVPA_XREF(DirectSoundDoWork, 4134, 1 + 11,
     { 0x1C, 0x0B },
     { 0x22, 0xFF },
     { 0x28, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CreateSoundBuffer
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_CreateSoundBuffer, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CreateSoundBuffer,
+                      4134,
 
-           XREF_CDirectSound_CreateSoundBuffer,
-           XRefZero)
-{
+                      XREF_CDirectSound_CreateSoundBuffer,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CreateSoundBuffer+0x23 : mov eax, 0x80004005
     { 0x23, 0xB8 },
@@ -110,16 +115,18 @@ OOVPA_XREF(CDirectSound_CreateSoundBuffer, 4134, 14,
     // CDirectSound_CreateSoundBuffer+0x99 : retn 0x10
     { 0x99, 0xC2 },
     { 0x9A, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetLoopRegion
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetLoopRegion, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetLoopRegion,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetLoopRegion,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetLoopRegion,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetLoopRegion+0x00 : push ebp
     { 0x00, 0x55 },
@@ -142,17 +149,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetLoopRegion, 4134, 12,
     // CDirectSoundBuffer_SetLoopRegion+0x82 : retn 0x0C
     { 0x82, 0xC2 },
     { 0x83, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetI3DL2Listener
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_SetI3DL2Listener, 4134, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetI3DL2Listener,
+                      4134,
 
-           XREF_CDirectSound_SetI3DL2Listener,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetI3DL2Listener,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetI3DL2Listener+0x00 : push esi; push edi
     { 0x00, 0x56 },
@@ -183,17 +192,19 @@ OOVPA_XREF(CDirectSound_SetI3DL2Listener, 4134, 13,
 
     // After offset 0x44, asm code does shift around in 5344 and 5455.
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetHeadroom
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetHeadroom, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetHeadroom,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetHeadroom),
 
@@ -206,7 +217,8 @@ OOVPA_XREF(CDirectSoundBuffer_SetHeadroom, 4134, 1 + 8,
     { 0x30, 0x10 },
     { 0x3A, 0x74 },
     { 0x47, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMixBins
@@ -255,11 +267,12 @@ OOVPA_END;
 // ******************************************************************
 // * CDirectSound_SetPosition
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetPosition, 4134, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetPosition,
+                      4134,
 
-           XREF_CDirectSound_SetPosition,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetPosition+0x00 : push ebp; mov ebp, esp
     { 0x00, 0x55 },
@@ -288,7 +301,8 @@ OOVPA_XREF(CDirectSound_SetPosition, 4134, 15,
 
     // After offset 0x4A, asm code does change in 4627 and later.
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetFrequency
@@ -338,11 +352,12 @@ OOVPA_END;
 // * CMcpxVoiceClient_SetVolume
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CMcpxVoiceClient_SetVolume, 4134, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetVolume,
+                      4134,
 
-           XREF_CMcpxVoiceClient_SetVolume,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetVolume+0x2A : lea eax, [ecx+ecx*2]
     { 0x2A, 0x8D },
@@ -364,17 +379,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetVolume, 4134, 13,
     { 0x84, 0x40 },
     { 0x85, 0x41 },
     { 0x86, 0x41 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetVolume
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundVoice_SetVolume, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVolume,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetVolume+0x15 : call [CMcpxVoiceClient::SetVolume]
     XREF_ENTRY(0x15, XREF_CMcpxVoiceClient_SetVolume),
@@ -394,17 +411,19 @@ OOVPA_XREF(CDirectSoundVoice_SetVolume, 4134, 1 + 10,
     { 0x11, 0x8B },
     { 0x12, 0x49 },
     { 0x13, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVolume
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundStream_SetVolume, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetVolume,
+                      4134,
 
-           XREF_CDirectSoundStream_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetVolume),
 
@@ -416,17 +435,19 @@ OOVPA_XREF(CDirectSoundStream_SetVolume, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Lock
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_Lock, 4134, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Lock,
+                      4134,
 
-           XREF_CDirectSoundBuffer_Lock,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Lock,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x48, XREF_CDirectSoundBuffer_GetCurrentPosition),
 
@@ -450,7 +471,8 @@ OOVPA_XREF(CDirectSoundBuffer_Lock, 4134, 1 + 12,
     { 0x83, 0x0C },
 
     // Major changes occur at 0x84 and later
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBufferSettings::SetBufferData
@@ -552,11 +574,12 @@ OOVPA_END;
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_GetStatus, 4134, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_GetStatus,
+                      4134,
 
-           XREF_CMcpxBuffer_GetStatus,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_GetStatus,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_GetStatus+0x0A : mov esi, ecx
     { 0x0A, 0x8B },
@@ -576,17 +599,19 @@ OOVPA_XREF(CMcpxBuffer_GetStatus, 4134, 11,
     { 0x2C, 0x66 },
     { 0x2D, 0xF7 },
     { 0x2E, 0x46 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetStatus
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_GetStatus, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetStatus,
+                      4134,
 
-           XREF_CDirectSoundBuffer_GetStatus,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetStatus,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_GetStatus+0x35 : call [CMcpxBuffer::GetStatus]
     XREF_ENTRY(0x35, XREF_CMcpxBuffer_GetStatus),
@@ -608,17 +633,19 @@ OOVPA_XREF(CDirectSoundBuffer_GetStatus, 4134, 1 + 10,
     // CDirectSoundBuffer_GetStatus+0x4E : retn 0x08
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_SetCurrentPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CMcpxBuffer_SetCurrentPosition, 4134, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_SetCurrentPosition,
+                      4134,
 
-           XREF_CMcpxBuffer_SetCurrentPosition,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_SetCurrentPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_SetCurrentPosition+0x11 : mov al, [esi+12]
     { 0x11, 0x8A },
@@ -634,17 +661,19 @@ OOVPA_XREF(CMcpxBuffer_SetCurrentPosition, 4134, 9,
     { 0x87, 0xB6 },
     { 0x88, 0x46 },
     { 0x89, 0x64 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetCurrentPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetCurrentPosition, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetCurrentPosition,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetCurrentPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetCurrentPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetCurrentPosition+0x35 : call [CMcpxBuffer::SetCurrentPosition]
     XREF_ENTRY(0x35, XREF_CMcpxBuffer_SetCurrentPosition),
@@ -666,17 +695,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetCurrentPosition, 4134, 1 + 10,
     // CDirectSoundBuffer_SetCurrentPosition+0x3D : retn 0x08
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetCurrentPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CMcpxBuffer_GetCurrentPosition, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_GetCurrentPosition,
+                      4134,
 
-           XREF_CMcpxBuffer_GetCurrentPosition,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_GetCurrentPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_GetCurrentPosition+0x00 : push ebp
     { 0x00, 0x55 },
@@ -713,17 +744,19 @@ OOVPA_XREF(CMcpxBuffer_GetCurrentPosition, 4134, 14,
     //{ 0xD6, 0xC2 },
     //{ 0xD7, 0x08 },
     //{ 0xD8, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetCurrentPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_GetCurrentPosition, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetCurrentPosition,
+                      4134,
 
-           XREF_CDirectSoundBuffer_GetCurrentPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetCurrentPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_GetCurrentPosition+0x39 : call [CMcpxBuffer::GetCurrentPosition]
     XREF_ENTRY(0x39, XREF_CMcpxBuffer_GetCurrentPosition),
@@ -745,16 +778,18 @@ OOVPA_XREF(CDirectSoundBuffer_GetCurrentPosition, 4134, 1 + 10,
     // CDirectSoundBuffer_GetCurrentPosition+0x52 : retn 0x08
     { 0x52, 0xC2 },
     { 0x53, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDistanceFactor, 4134, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDistanceFactor,
+                      4134,
 
-           XREF_CDirectSound_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDistanceFactor+0x21 : mov eax, 0x80004005
     { 0x21, 0xB8 },
@@ -782,16 +817,18 @@ OOVPA_XREF(CDirectSound_SetDistanceFactor, 4134, 17,
     // CDirectSound_SetDistanceFactor+0x4F : jz +0x0B
     { 0x4F, 0x74 },
     { 0x50, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetRolloffFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetRolloffFactor, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetRolloffFactor,
+                      4134,
 
-           XREF_CDirectSound_SetRolloffFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetRolloffFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetRolloffFactor+0x00 : push esi
     { 0x00, 0x56 },
@@ -822,16 +859,18 @@ OOVPA_XREF(CDirectSound_SetRolloffFactor, 4134, 14,
     { 0x3A, 0x88 },
     //{ 0x3B, 0xA4 },
     { 0x3F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDopplerFactor, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDopplerFactor,
+                      4134,
 
-           XREF_CDirectSound_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDopplerFactor+0x21 : mov eax, 0x80004005
     { 0x21, 0xB8 },
@@ -854,7 +893,8 @@ OOVPA_XREF(CDirectSound_SetDopplerFactor, 4134, 14,
     // CDirectSound_SetDopplerFactor+0x4F : jz +0x0B
     { 0x4F, 0x74 },
     { 0x50, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CommitDeferredSettings
@@ -891,17 +931,19 @@ OOVPA_XREF(CDirectSound_CommitDeferredSettings, 4134, 1 + 9,
 
             // CDirectSound_CommitDeferredSettings+0x78 : leave
             { 0x78, 0xC9 },
+        //
     }
 OOVPA_END;
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 4134, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMaxDistance,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMaxDistance+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -924,17 +966,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 4134, 1 + 12,
     // CDirectSoundVoice_SetMaxDistance+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMaxDistance
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetMaxDistance, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMaxDistance,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMaxDistance+0x39 : call [CDirectSoundVoice::SetMaxDistance]
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetMaxDistance),
@@ -955,17 +999,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMaxDistance, 4134, 1 + 10,
     // CDirectSoundBuffer_SetMaxDistance+0x53 : retn 0Ch
     { 0x54, 0x0C },
     { 0x55, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMaxDistance
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetMaxDistance, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMaxDistance,
+                      4134,
 
-           XREF_CDirectSoundStream_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetMaxDistance),
 
@@ -980,16 +1026,18 @@ OOVPA_XREF(CDirectSoundStream_SetMaxDistance, 4134, 1 + 10,
 
     { 0x57, 0xC2 },
     { 0x58, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 4134, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMinDistance,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMinDistance+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -1012,17 +1060,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 4134, 1 + 12,
     // CDirectSoundVoice_SetMinDistance+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMinDistance
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetMinDistance, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMinDistance,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetMinDistance+0x39 : call [CDirectSoundVoice::SetMinDistance]
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetMinDistance),
@@ -1043,17 +1093,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMinDistance, 4134, 1 + 10,
     // CDirectSoundBuffer_SetMinDistance+0x53 : retn 0Ch
     { 0x54, 0x0C },
     { 0x55, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetMinDistance
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetMinDistance, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMinDistance,
+                      4134,
 
-           XREF_CDirectSoundStream_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetMinDistance),
 
@@ -1073,16 +1125,18 @@ OOVPA_XREF(CDirectSoundStream_SetMinDistance, 4134, 1 + 11,
 
     { 0x57, 0xC2 },
     { 0x58, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetRolloffFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetRolloffFactor, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetRolloffFactor,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetRolloffFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetRolloffFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetRolloffFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -1102,17 +1156,19 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffFactor, 4134, 12,
     // CDirectSoundVoice_SetRolloffFactor+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetRolloffFactor, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetRolloffFactor,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetRolloffFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetRolloffFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetRolloffFactor+0x39 : call [CDirectSoundVoice::SetRolloffFactor]
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetRolloffFactor),
@@ -1133,17 +1189,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetRolloffFactor, 4134, 1 + 10,
     // CDirectSoundBuffer_SetRolloffFactor+0x53 : retn 0Ch
     { 0x54, 0x0C },
     { 0x55, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetRolloffFactor, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetRolloffFactor,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetRolloffFactor+0x1C : call [CDirectSoundBuffer::SetRolloffFactor]
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetRolloffFactor),
@@ -1165,17 +1223,19 @@ OOVPA_XREF(IDirectSoundBuffer_SetRolloffFactor, 4134, 1 + 10,
     // IDirectSoundBuffer_SetRolloffFactor+0x21 : retn 0Ch
     { 0x22, 0x0C },
     { 0x23, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetRolloffFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetRolloffFactor,
+                      4134,
 
-           XREF_CDirectSoundStream_SetRolloffFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetRolloffFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetRolloffFactor),
 
@@ -1187,16 +1247,18 @@ OOVPA_XREF(CDirectSoundStream_SetRolloffFactor, 4134, 1 + 8,
     { 0x3D, 0xE8 },
     { 0x48, 0x68 },
     { 0x53, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDistanceFactor,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetDistanceFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -1216,17 +1278,19 @@ OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4134, 12,
     // CDirectSoundVoice_SetDistanceFactor+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetDistanceFactor, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetDistanceFactor,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetDistanceFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetDistanceFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetDistanceFactor+0x39 : call [CDirectSoundVoice::SetDistanceFactor]
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetDistanceFactor),
@@ -1247,17 +1311,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetDistanceFactor, 4134, 1 + 10,
     // CDirectSoundBuffer_SetDistanceFactor+0x53 : retn 0Ch
     { 0x54, 0x0C },
     { 0x55, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetDistanceFactor, 4134, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetDistanceFactor,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetDistanceFactor+0x1C : call [CDirectSoundBuffer::SetDistanceFactor]
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetDistanceFactor),
@@ -1276,17 +1342,19 @@ OOVPA_XREF(IDirectSoundBuffer_SetDistanceFactor, 4134, 1 + 9,
     // IDirectSoundBuffer_SetSetDistanceFactor+0x21 : retn 0Ch
     { 0x22, 0x0C },
     { 0x23, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetConeAngles
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeAngles,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetConeAngles,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeAngles,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -1302,17 +1370,19 @@ OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 4134, 12,
 
     { 0x23, 0x20 }, // SetConeAngles 0x20 vs SetRolloffCurve 0x74
     { 0x30, 0x10 }, // SetConeAngles 0x10 vs SetRolloffCurve 0x04
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeAngles
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetConeAngles, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeAngles,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetConeAngles,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeAngles,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetConeAngles+0x39 : call [CDirectSoundVoice::SetConeAngles]
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetConeAngles),
@@ -1335,17 +1405,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeAngles, 4134, 1 + 11,
     // CDirectSoundBuffer_SetConeAngles+0x53 : retn 10h
     { 0x54, 0x10 },
     { 0x55, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetConeOrientation
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOrientation,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetConeOrientation,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOrientation+0x0F : mov edx, [ebp+arg_4]
     { 0x0F, 0x8B },
@@ -1366,17 +1438,19 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 4134, 12,
     { 0x30, 0x89 },
     { 0x31, 0x51 },
     { 0x32, 0x2C }, // SetConeOrientation vs SetPosition vs SetVelocity
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeOrientation
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetConeOrientation, 4134, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeOrientation,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetConeOrientation+0x49 : call [CDirectSoundVoice::SetConeOrientation]
     XREF_ENTRY(0x4A, XREF_CDirectSoundVoice_SetConeOrientation),
@@ -1397,17 +1471,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeOrientation, 4134, 1 + 9,
     // CDirectSoundBuffer_SetConeOrientation+0x64 : retn 14h
     { 0x65, 0x14 },
     { 0x66, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeOrientation
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetConeOrientation, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeOrientation,
+                      4134,
 
-           XREF_CDirectSoundStream_SetConeOrientation,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeOrientation,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4E, XREF_CDirectSoundVoice_SetConeOrientation),
 
@@ -1419,16 +1495,18 @@ OOVPA_XREF(CDirectSoundStream_SetConeOrientation, 4134, 1 + 8,
     { 0x39, 0xEC },
     { 0x44, 0x24 },
     { 0x4D, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOutsideVolume,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetConeOutsideVolume,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeOutsideVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOutsideVolume+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -1448,17 +1526,19 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 4134, 12,
     // CDirectSoundVoice_SetConeOutsideVolume+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetConeOutsideVolume
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetConeOutsideVolume, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetConeOutsideVolume,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetConeOutsideVolume+0x35 : call [CDirectSoundVoice::SetConeOutsideVolume]
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetConeOutsideVolume),
@@ -1481,17 +1561,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetConeOutsideVolume, 4134, 1 + 11,
     // CDirectSoundBuffer_SetConeOutsideVolume+0x4F : retn 0Ch
     { 0x50, 0x0C },
     { 0x51, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeOutsideVolume
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetConeOutsideVolume, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeOutsideVolume,
+                      4134,
 
-           XREF_CDirectSoundStream_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetConeOutsideVolume),
 
@@ -1503,17 +1585,19 @@ OOVPA_XREF(CDirectSoundStream_SetConeOutsideVolume, 4134, 1 + 8,
     { 0x3E, 0x85 },
     { 0x4F, 0x8B },
     { 0x53, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundVoice_SetPosition, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetPosition,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetPosition,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetPosition+0x0F : mov edx, [ebp+arg_4]
     { 0x0F, 0x8B },
@@ -1534,17 +1618,19 @@ OOVPA_XREF(CDirectSoundVoice_SetPosition, 4134, 12,
     { 0x30, 0x89 },
     { 0x31, 0x51 },
     { 0x32, 0x0C }, // SetConeOrientation vs SetPosition vs SetVelocity
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetPosition, 4134, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPosition,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetPosition+0x49 : call [CDirectSoundVoice::SetPosition]
     XREF_ENTRY(0x4A, XREF_CDirectSoundVoice_SetPosition),
@@ -1564,17 +1650,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetPosition, 4134, 1 + 9,
     // CDirectSoundBuffer_SetPosition+0x64 : retn 14h
     { 0x65, 0x14 },
     { 0x66, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetPosition
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetPosition, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetPosition,
+                      4134,
 
-           XREF_CDirectSoundStream_SetPosition,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetPosition,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4E, XREF_CDirectSoundVoice_SetPosition),
 
@@ -1589,17 +1677,19 @@ OOVPA_XREF(CDirectSoundStream_SetPosition, 4134, 1 + 10,
 
     { 0x68, 0xC2 },
     { 0x69, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundVoice_SetVelocity, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVelocity,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetVelocity+0x0F : mov edx, [ebp+arg_4]
     { 0x0F, 0x8B },
@@ -1620,17 +1710,19 @@ OOVPA_XREF(CDirectSoundVoice_SetVelocity, 4134, 12,
     { 0x30, 0x89 },
     { 0x31, 0x51 },
     { 0x32, 0x18 }, // SetConeOrientation vs SetPosition vs SetVelocity
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetVelocity, 4134, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetVelocity,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetVelocity+0x49 : call [CDirectSoundVoice::SetVelocity]
     XREF_ENTRY(0x4A, XREF_CDirectSoundVoice_SetVelocity),
@@ -1650,17 +1742,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetVelocity, 4134, 1 + 9,
     // CDirectSoundBuffer_SetVelocity+0x64 : retn 14h
     { 0x65, 0x14 },
     { 0x66, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetVelocity, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetVelocity,
+                      4134,
 
-           XREF_CDirectSoundStream_SetVelocity,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetVelocity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4E, XREF_CDirectSoundVoice_SetVelocity),
 
@@ -1675,16 +1769,18 @@ OOVPA_XREF(CDirectSoundStream_SetVelocity, 4134, 1 + 10,
 
     { 0x68, 0xC2 },
     { 0x69, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDopplerFactor,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetDopplerFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -1704,17 +1800,19 @@ OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4134, 12,
     // CDirectSoundVoice_SetDopplerFactor+0x31 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetDopplerFactor, 4134, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetDopplerFactor,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetDopplerFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetDopplerFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetDopplerFactor+0x39 : call [CDirectSoundVoice::SetDopplerFactor]
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetDopplerFactor),
@@ -1733,17 +1831,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetDopplerFactor, 4134, 1 + 9,
     // CDirectSoundBuffer_SetDopplerFactor+0x53 : retn 0Ch
     { 0x54, 0x0C },
     { 0x55, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(IDirectSoundBuffer_SetDopplerFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetDopplerFactor,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundBuffer_SetDopplerFactor+0x1C : call [CDirectSoundBuffer::SetDopplerFactor]
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetDopplerFactor),
@@ -1761,16 +1861,18 @@ OOVPA_XREF(IDirectSoundBuffer_SetDopplerFactor, 4134, 1 + 8,
     // IDirectSoundBuffer_SetDopplerFactor+0x21 : retn 0Ch
     { 0x22, 0x0C },
     { 0x23, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetI3DL2Source
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetI3DL2Source,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetI3DL2Source+0xA5 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0xA6, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -1794,17 +1896,19 @@ OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 4134, 1 + 11,
     // CDirectSoundVoice_SetI3DL2Source+0xAC : retn 0Ch
     { 0xAD, 0x0C },
     { 0xAE, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetI3DL2Source
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetI3DL2Source, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetI3DL2Source,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetI3DL2Source+0x35 : call [CDirectSoundVoice::SetI3DL2Source]
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetI3DL2Source),
@@ -1827,17 +1931,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetI3DL2Source, 4134, 1 + 11,
     // CDirectSoundBuffer_SetI3DL2Source+0x4F : retn 0Ch
     { 0x50, 0x0C },
     { 0x51, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetI3DL2Source
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetI3DL2Source, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetI3DL2Source,
+                      4134,
 
-           XREF_CDirectSoundStream_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetI3DL2Source),
 
@@ -1849,17 +1955,19 @@ OOVPA_XREF(CDirectSoundStream_SetI3DL2Source, 4134, 1 + 8,
     { 0x39, 0xE8 },
     { 0x44, 0x68 },
     { 0x4F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetAllParameters
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundVoice_SetAllParameters, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetAllParameters,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetAllParameters,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetAllParameters,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x04, 0x8B },
@@ -1881,17 +1989,19 @@ OOVPA_XREF(CDirectSoundVoice_SetAllParameters, 4134, 14,
     { 0x8A, 0x00 },
     { 0x8B, 0x00 },
     { 0x8C, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetAllParameters
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetAllParameters, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetAllParameters,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetAllParameters),
 
@@ -1903,17 +2013,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetAllParameters, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetAllParameters
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetAllParameters, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetAllParameters,
+                      4134,
 
-           XREF_CDirectSoundStream_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetAllParameters),
 
@@ -1925,16 +2037,18 @@ OOVPA_XREF(CDirectSoundStream_SetAllParameters, 4134, 1 + 8,
     { 0x39, 0xE8 },
     { 0x44, 0x68 },
     { 0x4F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetMode
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMode, 4134, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMode,
+                      4134,
 
-           XREF_CDirectSoundVoice_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMode+0x1C : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x1D, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -1959,17 +2073,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMode, 4134, 1 + 12,
 
     { 0x23, 0xC2 },
     { 0x24, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMode
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetMode, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetMode,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetMode),
 
@@ -1982,17 +2098,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetMode, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMode
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetMode, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMode,
+                      4134,
 
-           XREF_CDirectSoundStream_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetMode),
 
@@ -2007,17 +2125,19 @@ OOVPA_XREF(CDirectSoundStream_SetMode, 4134, 1 + 10,
 
     { 0x53, 0xC2 },
     { 0x54, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CMcpxVoiceClient::SetFilter
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CMcpxVoiceClient_SetFilter, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetFilter,
+                      4134,
 
-           XREF_CMcpxVoiceClient_SetFilter,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetFilter,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -2037,17 +2157,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetFilter, 4134, 12,
     { 0x55, 0x07 },
 
     //NOTE: Before offset 0x65, there has been no changes throughout all revisions.
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetFilter
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetFilter, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFilter,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetFilter),
 
@@ -2059,16 +2181,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetFilter, 4134, 1 + 8,
     { 0x30, 0x10 },
     { 0x3A, 0x74 },
     { 0x47, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetVelocity, 4134, 16,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetVelocity,
+                      4134,
 
-           XREF_CDirectSound_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetVelocity+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2095,17 +2219,19 @@ OOVPA_XREF(CDirectSound_SetVelocity, 4134, 16,
     // CDirectSound_SetVelocity+0x73 : retn 0x14
     { 0x73, 0xC2 },
     { 0x74, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPitch
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetPitch, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPitch,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetPitch),
 
@@ -2117,17 +2243,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetPitch, 4134, 1 + 8,
     { 0x30, 0x10 },
     { 0x3A, 0x74 },
     { 0x47, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetPitch
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetPitch, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetPitch,
+                      4134,
 
-           XREF_CDirectSoundStream_SetPitch,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetPitch,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetPitch),
 
@@ -2142,16 +2270,18 @@ OOVPA_XREF(CDirectSoundStream_SetPitch, 4134, 1 + 11,
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
     { 0x51, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetVolume, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetVolume,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetVolume+0x32 : call [CDirectSoundVoice::SetVolume]
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetVolume),
@@ -2174,17 +2304,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetVolume, 4134, 1 + 11,
     // CDirectSoundBuffer_SetVolume+0x4B : retn 0x08
     { 0x4B, 0xC2 },
     { 0x4C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CreateSoundStream
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_CreateSoundStream, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CreateSoundStream,
+                      4134,
 
-           XREF_CDirectSound_CreateSoundStream,
-           XRefZero)
-{
+                      XREF_CDirectSound_CreateSoundStream,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CreateSoundStream+0x23 : mov eax, 0x80004005
     { 0x23, 0xB8 },
@@ -2207,17 +2339,19 @@ OOVPA_XREF(CDirectSound_CreateSoundStream, 4134, 14,
     // CDirectSound_CreateSoundStream+0x8E : retn 0x10
     { 0x8E, 0xC2 },
     { 0x8F, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreateStream
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(DirectSoundCreateStream, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(DirectSoundCreateStream,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreateStream+0x2F : call [CDirectSound::CreateSoundStream]
     XREF_ENTRY(0x2F, XREF_CDirectSound_CreateSoundStream),
@@ -2240,17 +2374,19 @@ OOVPA_XREF(DirectSoundCreateStream, 4134, 1 + 11,
     // DirectSoundCreateStream+0x54 : retn 0x08
     { 0x54, 0xC2 },
     { 0x55, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoiceSettings::SetMixBinVolumes
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundVoiceSettings_SetMixBinVolumes, 4134, 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoiceSettings_SetMixBinVolumes,
+                      4134,
 
-           XREF_CDirectSoundVoiceSettings_SetMixBinVolumes,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoiceSettings_SetMixBinVolumes,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoiceSettings_SetMixBinVolumes+0x09 : jbe +0x16
     { 0x09, 0x76 },
@@ -2269,7 +2405,8 @@ OOVPA_XREF(CDirectSoundVoiceSettings_SetMixBinVolumes, 4134, 10,
     // CDirectSoundVoiceSettings_SetMixBinVolumes+0x22 : retn 0x04
     { 0x22, 0xC2 },
     { 0x23, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetMixBinVolumes
@@ -2312,6 +2449,7 @@ OOVPA_XREF(CDirectSoundBuffer_SetMixBinVolumes, 4134, 1 + 12,
             // CDirectSoundBuffer_SetMixBinVolumes+0x4B : retn 0x08
             { 0x4B, 0xC2 },
             { 0x4C, 0x08 },
+        //
     }
 OOVPA_END;
 
@@ -2319,11 +2457,12 @@ OOVPA_END;
 // * CDirectSound_SetEffectData
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_SetEffectData, 4134, 14, // Also for 5849
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetEffectData,
+                      4134, // Also for 5849
 
-           XREF_CDirectSound_SetEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0x00 },
@@ -2344,16 +2483,18 @@ OOVPA_XREF(CDirectSound_SetEffectData, 4134, 14, // Also for 5849
 
     { 0x5F, 0xC2 },
     { 0x60, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_Stop
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Stop, 4134, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Stop,
+                      4134,
 
-           XREF_CMcpxBuffer_Stop,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Stop,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Stop+0x0B : cmp al, 3
     { 0x0B, 0x3C },
@@ -2369,16 +2510,18 @@ OOVPA_XREF(CMcpxBuffer_Stop, 4134, 9,
     { 0x1E, 0x24 },
     { 0x1F, 0x0C },
     { 0x20, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Stop(__int64, unsigned long)
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Stop_Ex, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Stop_Ex,
+                      4134,
 
-           XREF_CMcpxBuffer_Stop_Ex,
-           XRefOne)
-{
+                      XREF_CMcpxBuffer_Stop_Ex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Stop_Ex+0x2B : call [CMcpxBuffer::Stop]
     XREF_ENTRY(0x2B, XREF_CMcpxBuffer_Stop),
@@ -2398,17 +2541,19 @@ OOVPA_XREF(CMcpxBuffer_Stop_Ex, 4134, 1 + 8,
     // CMcpxBuffer_Stop_Ex+0x36 : push esi
     { 0x36, 0xC2 },
     { 0x37, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Stop
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundBuffer_Stop, 4134, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Stop,
+                      4134,
 
-           XREF_CDirectSoundBuffer_Stop,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Stop,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_Stop+0x33 : call [CMcpxBuffer::Stop]
     XREF_ENTRY(0x33, XREF_CMcpxBuffer_Stop),
@@ -2432,17 +2577,19 @@ OOVPA_XREF(CDirectSoundBuffer_Stop, 4134, 1 + 12,
     // CDirectSoundBuffer_Stop+0x4C : retn 0x04
     { 0x4C, 0xC2 },
     { 0x4D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetEG
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundStream_SetEG, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetEG,
+                      4134,
 
-           XREF_CDirectSoundStream_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetEG),
 
@@ -2455,17 +2602,19 @@ OOVPA_XREF(CDirectSoundStream_SetEG, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetFilter
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundStream_SetFilter, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetFilter,
+                      4134,
 
-           XREF_CDirectSoundStream_SetFilter,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetFilter,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetFilter),
 
@@ -2478,17 +2627,19 @@ OOVPA_XREF(CDirectSoundStream_SetFilter, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetLFO
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundStream_SetLFO, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetLFO,
+                      4134,
 
-           XREF_CDirectSoundStream_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetLFO),
 
@@ -2503,17 +2654,19 @@ OOVPA_XREF(CDirectSoundStream_SetLFO, 4134, 1 + 10,
     { 0x40, 0x68 },
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetOrientation
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSound_SetOrientation, 4134, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetOrientation,
+                      4134,
 
-           XREF_CDirectSound_SetOrientation,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetOrientation+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2530,17 +2683,19 @@ OOVPA_XREF(CDirectSound_SetOrientation, 4134, 13,
     { 0x57, 0x1C },
     { 0x5E, 0x8B },
     { 0x60, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_DownloadEffectsImage
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSound_DownloadEffectsImage, 4134, 18,
+OOVPA_SIG_HEADER_XREF(CDirectSound_DownloadEffectsImage,
+                      4134,
 
-           XREF_CDirectSound_DownloadEffectsImage,
-           XRefZero)
-{
+                      XREF_CDirectSound_DownloadEffectsImage,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_DownloadEffectsImage+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2578,18 +2733,20 @@ OOVPA_XREF(CDirectSound_DownloadEffectsImage, 4134, 18,
     // CDirectSound_DownloadEffectsImage+0x61 : ret 14h
     { 0x61, 0xC2 },
     { 0x62, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::Release
 // ******************************************************************
 // Generic OOVPA as of 4134 plus 5344 and newer.
 // NOTE: Has identical function to CAc97MediaObject::Release
-OOVPA_XREF(CDirectSoundStream_Release, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Release,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_DSound_CRefCount_Release),
 
@@ -2607,16 +2764,18 @@ OOVPA_XREF(CDirectSoundStream_Release, 4134, 1 + 11,
     { 0x4B, 0xC2 },
     { 0x4C, 0x04 },
     { 0x4D, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CFullHRTFSource::GetCenterVolume
 // ******************************************************************
-OOVPA_XREF(CFullHRTFSource_GetCenterVolume, 4134, 9,
+OOVPA_SIG_HEADER_XREF(CFullHRTFSource_GetCenterVolume,
+                      4134,
 
-           XREF_CFullHRTFSource_GetCenterVolume,
-           XRefZero)
-{
+                      XREF_CFullHRTFSource_GetCenterVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -2630,17 +2789,19 @@ OOVPA_XREF(CFullHRTFSource_GetCenterVolume, 4134, 9,
 
     { 0xBC, 0xC2 },
     { 0xBD, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseFullHRTF
 // ******************************************************************
 // Generic OOVPA as of 4134 plus 5344 and newer.
-OOVPA_XREF(DirectSoundUseFullHRTF, 4134, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseFullHRTF,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0A, XREF_CHRTFSource_SetFullHRTF5Channel),
 
@@ -2651,17 +2812,19 @@ OOVPA_XREF(DirectSoundUseFullHRTF, 4134, 1 + 7,
     { 0x12, 0x0B },
     { 0x18, 0xFF },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetMixBins
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer.
-OOVPA_XREF(CDirectSoundStream_SetMixBins, 4134, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMixBins,
+                      4134,
 
-           XREF_CDirectSoundStream_SetMixBins,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMixBins,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetMixBins),
 
@@ -2677,16 +2840,18 @@ OOVPA_XREF(CDirectSoundStream_SetMixBins, 4134, 1 + 9,
 
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Pause
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Pause, 4134, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Pause,
+                      4134,
 
-           XREF_CMcpxStream_Pause,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Pause,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxStream_Pause+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2708,17 +2873,19 @@ OOVPA_XREF(CMcpxStream_Pause, 4134, 11,
     // CMcpxStream_Pause+0x44 : retn 0x04
     { 0x44, 0xC2 },
     { 0x45, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Pause
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_Pause, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Pause,
+                      4134,
 
-           XREF_CDirectSoundStream_Pause,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_Pause,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_Pause+0x34 : call [CMcpxStream::Pause]
     XREF_ENTRY(0x35, XREF_CMcpxStream_Pause),
@@ -2741,16 +2908,18 @@ OOVPA_XREF(CDirectSoundStream_Pause, 4134, 1 + 11,
     // CDirectSoundStream_Pause+0x4E : retn 0x08
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetLFO
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetLFO, 4134, 10,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetLFO,
+                      4134,
 
-           XREF_CMcpxVoiceClient_SetLFO,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetLFO,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetLFO+0x00 : push ebp
     { 0x00, 0x55 },
@@ -2769,16 +2938,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetLFO, 4134, 10,
     { 0x59, 0x0F },
     { 0x5A, 0xB7 },
     { 0x5B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetEG
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetEG, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetEG,
+                      4134,
 
-           XREF_CMcpxVoiceClient_SetEG,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetEG,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x25, 0xEB },
@@ -2796,17 +2967,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetEG, 4134, 12,
 
     { 0xC1, 0xC2 },
     { 0xC2, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetEG
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetEG, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetEG,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetEG,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetEG,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetEG),
 
@@ -2818,17 +2991,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetEG, 4134, 1 + 8,
     { 0x30, 0x10 },
     { 0x3A, 0x74 },
     { 0x47, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetLFO
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetLFO, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetLFO,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetLFO,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetLFO,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetLFO),
 
@@ -2840,17 +3015,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetLFO, 4134, 1 + 8,
     { 0x30, 0x10 },
     { 0x3A, 0x74 },
     { 0x47, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetAllParameters
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_SetAllParameters, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetAllParameters,
+                      4134,
 
-           XREF_CDirectSound_SetAllParameters,
-           XRefOne)
-{
+                      XREF_CDirectSound_SetAllParameters,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetAllParameters+0x01 : call [DirectSoundEnterCriticalSection]
     XREF_ENTRY(0x02, XREF_DirectSoundEnterCriticalSection),
@@ -2873,14 +3050,16 @@ OOVPA_XREF(CDirectSound_SetAllParameters, 4134, 1 + 8,
     { 0x32, 0x8B },
     //{ 0x33, 0x44 }, // 4134 0x44 vs 5558 0x4C
     { 0x34, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetInfo
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_NO_XREF(CDirectSoundStream_GetInfo, 4134, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(CDirectSoundStream_GetInfo,
+                         4134)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream::GetInfo+0x00 : push ebx
     { 0x00, 0x53 },
@@ -2903,7 +3082,8 @@ OOVPA_NO_XREF(CDirectSoundStream_GetInfo, 4134, 13)
     //CDirectSoundStream::GetInfo+0x64 : ret 8
     { 0x64, 0xC2 },
     { 0x65, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
@@ -2947,11 +3127,12 @@ OOVPA_END;
 // ******************************************************************
 // * CDirectSoundStream_Flush
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_Flush, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Flush,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream::Flush+0x30 : call [CMcpxStream::Flush]
     XREF_ENTRY(0x31, XREF_CMcpxStream_Flush),
@@ -2970,16 +3151,18 @@ OOVPA_XREF(CDirectSoundStream_Flush, 4134, 1 + 8,
     // CDirectSoundStream::Flush+0x4A : ret 4
     { 0x4A, 0xC2 },
     { 0x4B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_GetStatus, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_GetStatus,
+                      4134,
 
-           XREF_CMcpxStream_GetStatus,
-           XRefZero)
-{
+                      XREF_CMcpxStream_GetStatus,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -3004,17 +3187,19 @@ OOVPA_XREF(CMcpxStream_GetStatus, 4134, 14,
     // Removed due to 4242 has a return asm code at offset 0x75.
     //{ 0x65, 0xC2 },
     //{ 0x66, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetStatus
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_GetStatus, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_GetStatus,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream_GetStatus+0x34 : call [CMcpxStream::GetStatus]
     XREF_ENTRY(0x35, XREF_CMcpxStream_GetStatus),
@@ -3037,7 +3222,8 @@ OOVPA_XREF(CDirectSoundStream_GetStatus, 4134, 1 + 11,
     // CDirectSoundStream_GetStatus+0x4E : retn 0x08
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Process
@@ -3084,11 +3270,12 @@ OOVPA_END;
 // ******************************************************************
 // * CMcpxStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Discontinuity, 4134, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Discontinuity,
+                      4134,
 
-           XREF_CMcpxStream_Discontinuity,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Discontinuity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CMcpxStream_Discontinuity+0x1C : call [CMcpxStream_Flush]
     XREF_ENTRY(0x1D, XREF_CMcpxStream_Flush),
@@ -3104,17 +3291,19 @@ OOVPA_XREF(CMcpxStream_Discontinuity, 4134, 1 + 6,
     { 0x23, 0x5E },
 
     { 0x24, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_Discontinuity
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_Discontinuity, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Discontinuity,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream_Discontinuity+0x30 : call [CMcpxStream_Discontinuity]
     XREF_ENTRY(0x31, XREF_CMcpxStream_Discontinuity),
@@ -3133,13 +3322,15 @@ OOVPA_XREF(CDirectSoundStream_Discontinuity, 4134, 1 + 8,
     //CDirectSoundStream_Discontinuity+0x4A : ret 4
     { 0x4A, 0xC2 },
     { 0x4B, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CMemoryManager::PoolAlloc
 // ******************************************************************
-OOVPA_NO_XREF(DSound_CMemoryManager_PoolAlloc, 4134, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(DSound_CMemoryManager_PoolAlloc,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
 
@@ -3155,18 +3346,20 @@ OOVPA_NO_XREF(DSound_CMemoryManager_PoolAlloc, 4134, 11)
     { 0x42, 0xC2 },
     { 0x43, 0x0C },
     { 0x44, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_AddRef
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
 // NOTE: Has identical function to DirectSound::CAc97MediaObject::AddRef
-OOVPA_XREF(CDirectSoundStream_AddRef, 4134, 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_AddRef,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundStream::AddRef+0x00 : call DirectSoundEnterCriticalSection
     { 0x00, 0xE8 },
@@ -3188,16 +3381,18 @@ OOVPA_XREF(CDirectSoundStream_AddRef, 4134, 11,
     // CDirectSoundStream::AddRef+0x44 : ret 4
     { 0x44, 0xC2 },
     { 0x45, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::GetCaps
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetCaps, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetCaps,
+                      4134,
 
-           XREF_CDirectSound_GetCaps,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetCaps,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x57 },
     { 0x16, 0x68 },
@@ -3213,7 +3408,8 @@ OOVPA_XREF(CDirectSound_GetCaps, 4134, 12,
 
     { 0x6D, 0xC2 },
     { 0x6E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_SetOutputBuffer
@@ -3310,11 +3506,12 @@ OOVPA_END;
 // * CDirectSoundStream::SetFrequency
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetFrequency, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetFrequency,
+                      4134,
 
-           XREF_CDirectSoundStream_SetFrequency,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetFrequency,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetFrequency),
 
@@ -3339,17 +3536,19 @@ OOVPA_XREF(CDirectSoundStream_SetFrequency, 4134, 1 + 11,
     // ret 8
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetOutputBuffer
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetOutputBuffer, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetOutputBuffer,
+                      4134,
 
-           XREF_CDirectSoundStream_SetOutputBuffer,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetOutputBuffer,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetOutputBuffer),
 
@@ -3362,17 +3561,19 @@ OOVPA_XREF(CDirectSoundStream_SetOutputBuffer, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetConeAngles
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetConeAngles, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetConeAngles,
+                      4134,
 
-           XREF_CDirectSoundStream_SetConeAngles,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetConeAngles,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetConeAngles),
 
@@ -3386,17 +3587,19 @@ OOVPA_XREF(CDirectSoundStream_SetConeAngles, 4134, 1 + 8,
     { 0x37, 0x18 },
 
     { 0x3D, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream::SetHeadroom
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetHeadroom, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetHeadroom,
+                      4134,
 
-           XREF_CDirectSoundStream_SetHeadroom,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetHeadroom,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetHeadroom),
 
@@ -3409,16 +3612,18 @@ OOVPA_XREF(CDirectSoundStream_SetHeadroom, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Play(unsigned long)
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Play, 4134, 13,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play,
+                      4134,
 
-           XREF_CMcpxBuffer_Play,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Play+0x00 : push ebx
     { 0x00, 0x53 },
@@ -3442,17 +3647,19 @@ OOVPA_XREF(CMcpxBuffer_Play, 4134, 13,
     { 0x31, 0x46 },
     { 0x32, 0x12 },
     { 0x33, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_Play
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_Play, 4134, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Play,
+                      4134,
 
-           XREF_CDirectSoundBuffer_Play,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Play,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_Play+0x35 : call [CMcpxBuffer::Play]
     XREF_ENTRY(0x35, XREF_CMcpxBuffer_Play),
@@ -3474,17 +3681,19 @@ OOVPA_XREF(CDirectSoundBuffer_Play, 4134, 1 + 10,
     // CDirectSoundBuffer_Play+0x4E : retn 0x10
     { 0x4E, 0xC2 },
     { 0x4F, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetEffectData
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_GetEffectData, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetEffectData,
+                      4134,
 
-           XREF_CDirectSound_GetEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0x00 },
@@ -3505,17 +3714,19 @@ OOVPA_XREF(CDirectSound_GetEffectData, 4134, 14,
 
     { 0x5C, 0xC2 },
     { 0x5D, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_CommitEffectData
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSound_CommitEffectData, 4134, 16,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitEffectData,
+                      4134,
 
-           XREF_CDirectSound_CommitEffectData,
-           XRefZero)
-{
+                      XREF_CDirectSound_CommitEffectData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0C, 0x00 },
@@ -3539,17 +3750,19 @@ OOVPA_XREF(CDirectSound_CommitEffectData, 4134, 16,
 
     { 0x4D, 0xC2 },
     { 0x4E, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetDistanceFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetDistanceFactor,
+                      4134,
 
-           XREF_CDirectSoundStream_SetDistanceFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetDistanceFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetDistanceFactor),
 
@@ -3561,17 +3774,19 @@ OOVPA_XREF(CDirectSoundStream_SetDistanceFactor, 4134, 1 + 8,
     { 0x3D, 0xE8 },
     { 0x48, 0x68 },
     { 0x53, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(IDirectSoundStream_SetDistanceFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetDistanceFactor,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_SetDistanceFactor),
 
@@ -3583,17 +3798,19 @@ OOVPA_XREF(IDirectSoundStream_SetDistanceFactor, 4134, 1 + 8,
     { 0x0E, 0x24 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(IDirectSoundStream_SetRolloffFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetRolloffFactor,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_SetRolloffFactor),
 
@@ -3605,17 +3822,19 @@ OOVPA_XREF(IDirectSoundStream_SetRolloffFactor, 4134, 1 + 8,
     { 0x0E, 0x24 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetDopplerFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetDopplerFactor,
+                      4134,
 
-           XREF_CDirectSoundStream_SetDopplerFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetDopplerFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetDopplerFactor),
 
@@ -3627,17 +3846,19 @@ OOVPA_XREF(CDirectSoundStream_SetDopplerFactor, 4134, 1 + 8,
     { 0x3D, 0xE8 },
     { 0x48, 0x68 },
     { 0x53, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(IDirectSoundStream_SetDopplerFactor, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetDopplerFactor,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_SetDopplerFactor),
 
@@ -3649,16 +3870,18 @@ OOVPA_XREF(IDirectSoundStream_SetDopplerFactor, 4134, 1 + 8,
     { 0x0E, 0x24 },
     { 0x15, 0xC2 },
     { 0x16, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_SetMixBinVolumes_8
 // ******************************************************************
-OOVPA_XREF(CDirectSoundStream_SetMixBinVolumes_8, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetMixBinVolumes_8,
+                      4134,
 
-           XREF_CDirectSoundStream_SetMixBinVolumes_8,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetMixBinVolumes_8,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetMixBinVolumes),
 
@@ -3674,17 +3897,19 @@ OOVPA_XREF(CDirectSoundStream_SetMixBinVolumes_8, 4134, 1 + 11,
     { 0x25, 0x80 },
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetPlayRegion
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetPlayRegion, 4134, 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetPlayRegion,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetPlayRegion,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetPlayRegion,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetPlayRegion+0x10 : movzx edi, al
     { 0x10, 0x0F },
@@ -3701,16 +3926,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetPlayRegion, 4134, 10,
     { 0x48, 0x00 },
     { 0x49, 0x78 },
     { 0x4A, 0x88 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::EnableHeadphones
 // ******************************************************************
-OOVPA_XREF(CDirectSound_EnableHeadphones, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_EnableHeadphones,
+                      4134,
 
-           XREF_CDirectSound_EnableHeadphones,
-           XRefZero)
-{
+                      XREF_CDirectSound_EnableHeadphones,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x29, 0xB8 },
@@ -3728,17 +3955,19 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 4134, 12,
     { 0x64, 0xE8 },
     //{ 0x82, 0xC2 }, 4242 Different length
     //{ 0x83, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundBuffer::SetFormat
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetFormat, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetFormat,
+                      4134,
 
-           XREF_CDirectSoundBuffer_SetFormat,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetFormat,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_SetFormat),
 
@@ -3750,17 +3979,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetFormat, 4134, 1 + 8,
     { 0x30, 0x10 },
     { 0x3A, 0x74 },
     { 0x47, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetFormat
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundStream_SetFormat, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetFormat,
+                      4134,
 
-           XREF_CDirectSoundStream_SetFormat,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetFormat,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_SetFormat),
 
@@ -3772,17 +4003,19 @@ OOVPA_XREF(CDirectSoundStream_SetFormat, 4134, 1 + 8,
     { 0x35, 0xE8 },
     { 0x40, 0x68 },
     { 0x4B, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::PlayEx
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CDirectSoundBuffer_PlayEx, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_PlayEx,
+                      4134,
 
-           XREF_CDirectSoundBuffer_PlayEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_PlayEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CMcpxBuffer_Play_Ex),
 
@@ -3794,16 +4027,18 @@ OOVPA_XREF(CDirectSoundBuffer_PlayEx, 4134, 1 + 8,
     { 0x3A, 0x24 },
     { 0x46, 0x0B },
     { 0x52, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundBuffer::StopEx
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_StopEx, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_StopEx,
+                      4134,
 
-           XREF_CDirectSoundBuffer_StopEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_StopEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CMcpxBuffer_Stop_Ex),
 
@@ -3815,17 +4050,19 @@ OOVPA_XREF(CDirectSoundBuffer_StopEx, 4134, 1 + 8,
     { 0x3A, 0x24 },
     { 0x46, 0x0B },
     { 0x52, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundCreateBuffer
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(DirectSoundCreateBuffer, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(DirectSoundCreateBuffer,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundCreateBuffer+0x2E : call [CDirectSound::CreateSoundBuffer]
     XREF_ENTRY(0x2F, XREF_CDirectSound_CreateSoundBuffer),
@@ -3848,17 +4085,19 @@ OOVPA_XREF(DirectSoundCreateBuffer, 4134, 1 + 11,
     // DirectSoundCreateBuffer+0x54 : retn 0x08
     { 0x54, 0xC2 },
     { 0x55, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::FlushEx
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer (introduction)
-OOVPA_XREF(CDirectSoundStream_FlushEx, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_FlushEx,
+                      4134,
 
-           XREF_CDirectSoundStream_FlushEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_FlushEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x42, XREF_CMcpxStream_Stop_Ex),
 
@@ -3880,17 +4119,19 @@ OOVPA_XREF(CDirectSoundStream_FlushEx, 4134, 1 + 8,
     // CDirectSoundStream_FlushEx+0x54 : call CMcpxStream::Stop_Ex
     { 0x41, 0xE8 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream::FlushEx
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer (introduction)
-OOVPA_XREF(IDirectSoundStream_FlushEx, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_FlushEx,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_FlushEx),
 
@@ -3902,14 +4143,16 @@ OOVPA_XREF(IDirectSoundStream_FlushEx, 4134, 1 + 8,
     { 0x10, 0xE8 },
     { 0x15, 0xC2 },
     { 0x16, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioDownloadEffectsImage
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_NO_XREF(XAudioDownloadEffectsImage, 4134, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XAudioDownloadEffectsImage,
+                         4134)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x00, 0x55),
 
@@ -3918,17 +4161,19 @@ OOVPA_NO_XREF(XAudioDownloadEffectsImage, 4134, 12)
     OV_MATCH(0x41, 0x83),
     OV_MATCH(0x53, 0xE8),
     OV_MATCH(0x6A, 0x8B),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetMixBins
 // ******************************************************************
 // Generic OOVPA as of 4134? and newer
-OOVPA_XREF(CMcpxVoiceClient_SetMixBins, 4134, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetMixBins,
+                      4134,
 
-           XREF_CMcpxVoiceClient_SetMixBins,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetMixBins,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient_SetMixBins+0x00 : push ebp
     { 0x00, 0x55 },
@@ -3953,16 +4198,18 @@ OOVPA_XREF(CMcpxVoiceClient_SetMixBins, 4134, 14,
     // CMcpxVoiceClient_SetMixBins+0xBF : leave; retn
     { 0xBF, 0xC9 },
     { 0xC0, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream::Stop
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Stop, 4134, 7,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Stop,
+                      4134,
 
-           XREF_CMcpxStream_Stop,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Stop,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // calls to CIrql_Raise, CIrql_Lower, CMcpxVoiceClient_ReleaseVoice, CMcpxVoiceClient_DeactivateVoice
 
@@ -3977,16 +4224,18 @@ OOVPA_XREF(CMcpxStream_Stop, 4134, 7,
     { 0x31, 0x45 },
     { 0x32, 0x08 },
     { 0x33, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream::Stop_Ex
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Stop_Ex, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Stop_Ex,
+                      4134,
 
-           XREF_CMcpxStream_Stop_Ex,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Stop_Ex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CMcpxStream_Stop_Ex+0x2A : call [CMcpxBuffer::Play]
     XREF_ENTRY(0x2B, XREF_CMcpxStream_Stop),
@@ -4006,7 +4255,8 @@ OOVPA_XREF(CMcpxStream_Stop_Ex, 4134, 1 + 8,
     // CMcpxStream_Stop_Ex+0x36 : push esi
     { 0x36, 0xC2 },
     { 0x37, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::DoWork
@@ -4054,11 +4304,12 @@ OOVPA_END;
 // ******************************************************************
 // * DirectSound::CMcpxAPU::ServiceDeferredCommandsLow
 // ******************************************************************
-OOVPA_XREF(CMcpxAPU_ServiceDeferredCommandsLow, 4134, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_ServiceDeferredCommandsLow,
+                      4134,
 
-           XREF_CMcpxAPU_ServiceDeferredCommandsLow,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_ServiceDeferredCommandsLow,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_ServiceDeferredCommandsLow+0x00: push ebp; mov ebp,esp
     { 0x00, 0x55 },
@@ -4076,16 +4327,18 @@ OOVPA_XREF(CMcpxAPU_ServiceDeferredCommandsLow, 4134, 9,
     { 0x1C, 0xF8 },
 
     // Generic support over multiple revisions end at offset 0x3A
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4134, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      4134,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -4110,16 +4363,18 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4134, 12,
     //{ 0x6A, 0x00 },
     { 0x6B, 0x00 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 4134, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_CommitDeferredSettings,
+                      4134,
 
-           XREF_CDirectSoundVoice_CommitDeferredSettings,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_CommitDeferredSettings,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::CommitDeferredSettings+0x20 : call [CMcpxVoiceClient::Commit3dSettings]
     XREF_ENTRY(0x21, XREF_CMcpxVoiceClient_Commit3dSettings),
@@ -4145,16 +4400,18 @@ OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 4134, 1 + 11,
     { 0x36, 0xC2 },
     { 0x37, 0x04 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_SetPitch
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_SetPitch, 4134, 10,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetPitch,
+                      4134,
 
-           XREF_CMcpxVoiceClient_SetPitch,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetPitch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -4172,17 +4429,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetPitch, 4134, 10,
     { 0x64, 0x8D },
     { 0x65, 0x46 },
     { 0x66, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::SetBufferData
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(CMcpxBuffer_SetBufferData, 4134, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_SetBufferData,
+                      4134,
 
-           XREF_CMcpxBuffer_SetBufferData,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_SetBufferData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer::SetBufferData+0x00 : mov edx,[ecx+0x000000XX]
     { 0x00, 0x8B },
@@ -4204,17 +4463,19 @@ OOVPA_XREF(CMcpxBuffer_SetBufferData, 4134, 9,
 
     // CMcpxBuffer::SetBufferData+0x19 : ret
     { 0x19, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundOverrideSpeakerConfig
 // ******************************************************************
 // Generic OOVPA as of 4134 and newer
-OOVPA_XREF(DirectSoundOverrideSpeakerConfig, 4134, 1 + 8,
+OOVPA_SIG_HEADER_XREF(DirectSoundOverrideSpeakerConfig,
+                      4134,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // DirectSoundOverrideSpeakerConfig+0x00 : call [DirectSoundEnterCriticalSection]
     XREF_ENTRY(0x01, XREF_DirectSoundEnterCriticalSection),
@@ -4227,4 +4488,5 @@ OOVPA_XREF(DirectSoundOverrideSpeakerConfig, 4134, 1 + 8,
 
     // DirectSoundOverrideSpeakerConfig+0x32 : retn 0x0004
     OV_MATCH(0x32, 0xC2, 0x04),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4242.inl
+++ b/src/OOVPADatabase/DSound/4242.inl
@@ -27,11 +27,12 @@
 // * CMcpxVoiceClient::SetLFO
 // ******************************************************************
 // Generic OOVPA as of 4242 and newer
-OOVPA_XREF(CMcpxVoiceClient_SetLFO, 4242, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetLFO,
+                      4242,
 
-           XREF_CMcpxVoiceClient_SetLFO,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetLFO,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x14, 0x8B },
@@ -47,17 +48,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetLFO, 4242, 12,
 
     { 0x50, 0x31 },
     { 0x51, 0x4E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::SetEG
 // ******************************************************************
 // Generic OOVPA as of 4242 and newer
-OOVPA_XREF(CMcpxVoiceClient_SetEG, 4242, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_SetEG,
+                      4242,
 
-           XREF_CMcpxVoiceClient_SetEG,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_SetEG,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -75,17 +78,19 @@ OOVPA_XREF(CMcpxVoiceClient_SetEG, 4242, 14,
 
     { 0x50, 0x56 },
     { 0x51, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_Stop
 // ******************************************************************
 //Generic OOVPA as of 4242 and newer.
-OOVPA_XREF(CMcpxBuffer_Stop, 4242, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Stop,
+                      4242,
 
-           XREF_CMcpxBuffer_Stop,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Stop,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Stop+0x0E : cmp al, 3
     { 0x0E, 0x3C },
@@ -101,16 +106,18 @@ OOVPA_XREF(CMcpxBuffer_Stop, 4242, 9,
     { 0x1B, 0x24 },
     { 0x1C, 0x10 },
     { 0x1D, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundBuffer::SetNotificationPositions
 // ******************************************************************
-OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 4242, 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetNotificationPositions,
+                      4242,
 
-           XREF_CDirectSoundBuffer_SetNotificationPositions,
-           XRefZero)
-{
+                      XREF_CDirectSoundBuffer_SetNotificationPositions,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetNotificationPositions+0x00 : push ebx
     { 0x00, 0x53 },
@@ -128,16 +135,18 @@ OOVPA_XREF(CDirectSoundBuffer_SetNotificationPositions, 4242, 11,
 
     { 0x47, 0xE8 },
     { 0x5D, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetSpeakerConfig
 // ******************************************************************
-OOVPA_XREF(CDirectSound_GetSpeakerConfig, 4242, 1 + 19,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetSpeakerConfig,
+                      4242,
 
-           XREF_CDirectSound_GetSpeakerConfig,
-           XRefOne)
-{
+                      XREF_CDirectSound_GetSpeakerConfig,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // call DirectSoundEnterCriticalSection
     XREF_ENTRY(0x01, XREF_DirectSoundEnterCriticalSection),
@@ -160,16 +169,18 @@ OOVPA_XREF(CDirectSound_GetSpeakerConfig, 4242, 1 + 19,
 
     // ret 0x0008
     OV_MATCH(0x4E, 0xC2, 0x08, 0x00),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CFullHrtfSource_GetHrtfFilterPair
 // ******************************************************************
-OOVPA_XREF(CFullHrtfSource_GetHrtfFilterPair, 4242, 15,
+OOVPA_SIG_HEADER_XREF(CFullHrtfSource_GetHrtfFilterPair,
+                      4242,
 
-           XREF_CFullHrtfSource_GetHrtfFilterPair,
-           XRefZero)
-{
+                      XREF_CFullHrtfSource_GetHrtfFilterPair,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -188,16 +199,18 @@ OOVPA_XREF(CFullHrtfSource_GetHrtfFilterPair, 4242, 15,
 
     { 0x58, 0xD8 },
     { 0x59, 0x05 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHrtfSource_SetAlgorithm_FullHrtf
 // ******************************************************************
-OOVPA_XREF(CHrtfSource_SetAlgorithm_FullHrtf, 4242, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CHrtfSource_SetAlgorithm_FullHrtf,
+                      4242,
 
-           XREF_CHrtfSource_SetAlgorithm_FullHrtf,
-           XRefOne)
-{
+                      XREF_CHrtfSource_SetAlgorithm_FullHrtf,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x17, XREF_CFullHrtfSource_GetHrtfFilterPair),
 
@@ -209,16 +222,18 @@ OOVPA_XREF(CHrtfSource_SetAlgorithm_FullHrtf, 4242, 1 + 8,
     { 0x11, 0xC7 },
     { 0x12, 0x05 },
     { 0x1B, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseFullHRTF
 // ******************************************************************
-OOVPA_XREF(DirectSoundUseFullHRTF, 4242, 1 + 8,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseFullHRTF,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_CHrtfSource_SetAlgorithm_FullHrtf),
 
@@ -230,16 +245,18 @@ OOVPA_XREF(DirectSoundUseFullHRTF, 4242, 1 + 8,
     { 0x1A, 0x74 },
     { 0x1B, 0x0B },
     { 0x1C, 0x68 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CLightHrtfSource_GetHrtfFilterPair
 // ******************************************************************
-OOVPA_XREF(CLightHrtfSource_GetHrtfFilterPair, 4242, 16,
+OOVPA_SIG_HEADER_XREF(CLightHrtfSource_GetHrtfFilterPair,
+                      4242,
 
-           XREF_CLightHrtfSource_GetHrtfFilterPair,
-           XRefZero)
-{
+                      XREF_CLightHrtfSource_GetHrtfFilterPair,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x8B },
@@ -259,16 +276,18 @@ OOVPA_XREF(CLightHrtfSource_GetHrtfFilterPair, 4242, 16,
     { 0x1A, 0x6A },
 
     { 0x8B, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHrtfSource_SetAlgorithm_LightHrtf
 // ******************************************************************
-OOVPA_XREF(CHrtfSource_SetAlgorithm_LightHrtf, 4242, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CHrtfSource_SetAlgorithm_LightHrtf,
+                      4242,
 
-           XREF_CHrtfSource_SetAlgorithm_LightHrtf,
-           XRefOne)
-{
+                      XREF_CHrtfSource_SetAlgorithm_LightHrtf,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1A, XREF_CLightHrtfSource_GetHrtfFilterPair),
 
@@ -283,16 +302,18 @@ OOVPA_XREF(CHrtfSource_SetAlgorithm_LightHrtf, 4242, 1 + 11,
     { 0x14, 0xC7 },
     { 0x15, 0x05 },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseLightHRTF
 // ******************************************************************
-OOVPA_XREF(DirectSoundUseLightHRTF, 4242, 1 + 8,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseLightHRTF,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x13, XREF_CHrtfSource_SetAlgorithm_LightHrtf),
 
@@ -304,16 +325,18 @@ OOVPA_XREF(DirectSoundUseLightHRTF, 4242, 1 + 8,
     { 0x1A, 0x74 },
     { 0x1B, 0x0B },
     { 0x1C, 0x68 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4242, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      4242,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -338,16 +361,18 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4242, 12,
     //{ 0x7A, 0x00 },
     { 0x7B, 0x00 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFileCreateMediaObject
 // ******************************************************************
-OOVPA_XREF(XFileCreateMediaObject, 4242, 10,
+OOVPA_SIG_HEADER_XREF(XFileCreateMediaObject,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
 
@@ -358,13 +383,15 @@ OOVPA_XREF(XFileCreateMediaObject, 4242, 10,
     OV_MATCH(0x49, 0x08),
 
     OV_MATCH(0x80, 0xC2, 0x18),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFileCreateMediaObjectEx
 // ******************************************************************
-OOVPA_NO_XREF(XFileCreateMediaObjectEx, 4242, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XFileCreateMediaObjectEx,
+                         4242)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x00, 0x53),
     OV_MATCH(0x28, 0x1B),
@@ -372,13 +399,15 @@ OOVPA_NO_XREF(XFileCreateMediaObjectEx, 4242, 12)
     OV_MATCH(0x36, 0x78, 0x1C, 0xFF, 0x74, 0x24, 0x10, 0x57, 0xE8),
 
     OV_MATCH(0x72, 0xC2, 0x08),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XWaveFileCreateMediaObject
 // ******************************************************************
-OOVPA_NO_XREF(XWaveFileCreateMediaObject, 4242, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XWaveFileCreateMediaObject,
+                         4242)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x00, 0x53),
     OV_MATCH(0x25, 0xF7),
@@ -386,16 +415,18 @@ OOVPA_NO_XREF(XWaveFileCreateMediaObject, 4242, 12)
     OV_MATCH(0x45, 0xF6, 0x7C, 0x23, 0x83, 0x7C, 0x24, 0x14, 0x00),
 
     OV_MATCH(0x89, 0xC2, 0x0C),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XWaveFileCreateMediaObjectEx
 // ******************************************************************
-OOVPA_XREF(XWaveFileCreateMediaObjectEx, 4242, 12,
+OOVPA_SIG_HEADER_XREF(XWaveFileCreateMediaObjectEx,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     OV_MATCH(0x16, 0x0B),
     OV_MATCH(0x25, 0xF7),
@@ -403,4 +434,5 @@ OOVPA_XREF(XWaveFileCreateMediaObjectEx, 4242, 12,
     OV_MATCH(0x49, 0xEB, 0x0A, 0xFF, 0x74, 0x24, 0x14, 0x57, 0xE8),
 
     OV_MATCH(0x85, 0xC2, 0x0C),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4361.inl
+++ b/src/OOVPADatabase/DSound/4361.inl
@@ -27,8 +27,9 @@
 // * DirectSoundGetSampleTime
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_NO_XREF(DirectSoundGetSampleTime, 4361, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(DirectSoundGetSampleTime,
+                         4361)
+OOVPA_SIG_MATCH(
 
     // DirectSoundGetSampleTime+0x00 : xor eax, eax
     { 0x00, 0x33 },
@@ -43,17 +44,19 @@ OOVPA_NO_XREF(DirectSoundGetSampleTime, 4361, 8)
 
     // DirectSoundGetSampleTime+0x0F : retn
     { 0x0F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream::Pause(__int64, unsigned long)
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CMcpxStream_Pause_Ex, 4361, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Pause_Ex,
+                      4361,
 
-           XREF_CMcpxStream_Pause_Ex,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Pause_Ex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2B, XREF_CMcpxStream_Pause),
 
@@ -75,17 +78,19 @@ OOVPA_XREF(CMcpxStream_Pause_Ex, 4361, 1 + 8,
     // CMcpxStream::Pause+0x0F : ret 0xC
     { 0x36, 0xC2 },
     { 0x37, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::PauseEx
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CDirectSoundStream_PauseEx, 4361, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_PauseEx,
+                      4361,
 
-           XREF_CDirectSoundStream_PauseEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_PauseEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CMcpxStream_Pause_Ex),
 
@@ -101,17 +106,19 @@ OOVPA_XREF(CDirectSoundStream_PauseEx, 4361, 1 + 10,
 
     { 0x56, 0xC2 },
     { 0x57, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_PauseEx
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(IDirectSoundStream_PauseEx, 4361, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_PauseEx,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSoundStream_PauseEx),
 
@@ -122,16 +129,18 @@ OOVPA_XREF(IDirectSoundStream_PauseEx, 4361, 1 + 7,
     { 0x10, 0xE8 },
     { 0x15, 0xC2 },
     { 0x16, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * public: long __thiscall DirectSound::CMcpxBuffer::Play(unsigned long)
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Play, 4361, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play,
+                      4361,
 
-           XREF_CMcpxBuffer_Play,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Play+0x0E : cmp ebx, edi
     { 0x0E, 0x3B },
@@ -151,16 +160,18 @@ OOVPA_XREF(CMcpxBuffer_Play, 4361, 11,
     { 0x71, 0xFF },
     { 0x72, 0x50 },
     { 0x73, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMaxDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 4361, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMaxDistance,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMaxDistance+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -183,16 +194,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 4361, 1 + 12,
     // CDirectSoundVoice_SetMaxDistance+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 4361, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMinDistance,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMinDistance+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -215,16 +228,18 @@ OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 4361, 1 + 12,
     // CDirectSoundVoice_SetMinDistance+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetRolloffFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetRolloffFactor, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetRolloffFactor,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetRolloffFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetRolloffFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetRolloffFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -244,16 +259,18 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffFactor, 4361, 12,
     // CDirectSoundVoice_SetRolloffFactor+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeOutsideVolume
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOutsideVolume,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetConeOutsideVolume,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeOutsideVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOutsideVolume+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -273,16 +290,18 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 4361, 12,
     // CDirectSoundVoice_SetConeOutsideVolume+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Flush, 4361, 10,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Flush,
+                      4361,
 
-           XREF_CMcpxStream_Flush,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Flush,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -300,16 +319,18 @@ OOVPA_XREF(CMcpxStream_Flush, 4361, 10,
     // Might not be a requirement? Aka comment this out might will enable support detection later XDK revisions.
     { 0xD1, 0xC9 },
     { 0xD2, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDistanceFactor,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetDistanceFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -329,16 +350,18 @@ OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4361, 12,
     // CDirectSoundVoice_SetDistanceFactor+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDopplerFactor,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetDopplerFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -358,7 +381,8 @@ OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4361, 12,
     // CDirectSoundVoice_SetDopplerFactor+0x31 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 //TODO: Need further verification for 4361 titles, 4432 is last known lowest build match.
 //Test case for 4361: Burnout (found a match yet is called twice for every time joystick is moved. Is this normal?)
@@ -366,11 +390,12 @@ OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4361, 12,
 // * DirectSound::GetCaps
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CDirectSound_GetCaps, 4361, 13,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetCaps,
+                      4361,
 
-           XREF_CDirectSound_GetCaps,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetCaps,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xE8 },
     { 0x0D, 0xB6 },
@@ -387,17 +412,19 @@ OOVPA_XREF(CDirectSound_GetCaps, 4361, 13,
     { 0x52, 0x03 },
     { 0x69, 0xC2 },
     { 0x6A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetRolloffCurve
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CDirectSoundVoice_SetRolloffCurve, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetRolloffCurve,
+                      4361,
 
-           XREF_CDirectSoundVoice_SetRolloffCurve,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetRolloffCurve,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -413,17 +440,19 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffCurve, 4361, 12,
 
     { 0x23, 0x74 }, // SetConeAngles 0x20 vs SetRolloffCurve 0x74
     { 0x30, 0x04 }, // SetConeAngles 0x10 vs SetRolloffCurve 0x04
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::SetRolloffCurve
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CDirectSoundBuffer_SetRolloffCurve, 4361, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_SetRolloffCurve,
+                      4361,
 
-           XREF_CDirectSoundBuffer_SetRolloffCurve,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_SetRolloffCurve,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_CDirectSoundVoice_SetRolloffCurve),
 
@@ -434,17 +463,19 @@ OOVPA_XREF(CDirectSoundBuffer_SetRolloffCurve, 4361, 1 + 7,
     { 0x35, 0xFF },
     { 0x40, 0x8B },
     { 0x4F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::SetRolloffCurve
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CDirectSoundStream_SetRolloffCurve, 4361, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_SetRolloffCurve,
+                      4361,
 
-           XREF_CDirectSoundStream_SetRolloffCurve,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_SetRolloffCurve,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3E, XREF_CDirectSoundVoice_SetRolloffCurve),
 
@@ -455,16 +486,18 @@ OOVPA_XREF(CDirectSoundStream_SetRolloffCurve, 4361, 1 + 7,
     { 0x3A, 0x24 },
     { 0x46, 0x74 },
     { 0x53, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_SetRolloffCurve
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_SetRolloffCurve, 4361, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_SetRolloffCurve,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_SetRolloffCurve),
 
@@ -475,34 +508,38 @@ OOVPA_XREF(IDirectSoundBuffer_SetRolloffCurve, 4361, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_SetRolloffCurve
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(IDirectSoundStream_SetRolloffCurve, 4361, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_SetRolloffCurve,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_SetRolloffCurve+0x00 : jmp [CDirectSoundStream_SetRolloffCurve]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_SetRolloffCurve),
 
     // IDirectSoundStream_SetRolloffCurve+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSound::GetOutputLevels
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(CDirectSound_GetOutputLevels, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetOutputLevels,
+                      4361,
 
-           XREF_CDirectSound_GetOutputLevels,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetOutputLevels,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x07, 0x10 },
@@ -524,17 +561,19 @@ OOVPA_XREF(CDirectSound_GetOutputLevels, 4361, 12,
     // CDirectSound::GetOutputLevels+0x00 : ret 0xC
     { 0x43, 0xC2 },
     { 0x44, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_GetOutputLevels
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(IDirectSound_GetOutputLevels, 4361, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSound_GetOutputLevels,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_CDirectSound_GetOutputLevels),
 
@@ -546,17 +585,19 @@ OOVPA_XREF(IDirectSound_GetOutputLevels, 4361, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFileCreateMediaObject
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(XFileCreateMediaObject, 4361, 10,
+OOVPA_SIG_HEADER_XREF(XFileCreateMediaObject,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -570,14 +611,16 @@ OOVPA_XREF(XFileCreateMediaObject, 4361, 10,
 
     { 0x67, 0xC2 },
     { 0x68, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFileCreateMediaObjectEx
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_NO_XREF(XFileCreateMediaObjectEx, 4361, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XFileCreateMediaObjectEx,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x1F, 0x1B },
@@ -593,14 +636,16 @@ OOVPA_NO_XREF(XFileCreateMediaObjectEx, 4361, 12)
 
     { 0x59, 0xC2 },
     { 0x5A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XWaveFileCreateMediaObject
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_NO_XREF(XWaveFileCreateMediaObject, 4361, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XWaveFileCreateMediaObject,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x1C, 0xF7 },
@@ -616,17 +661,19 @@ OOVPA_NO_XREF(XWaveFileCreateMediaObject, 4361, 12)
 
     { 0x70, 0xC2 },
     { 0x71, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XWaveFileCreateMediaObjectEx
 // ******************************************************************
 // Generic OOVPA as of 4361 and newer
-OOVPA_XREF(XWaveFileCreateMediaObjectEx, 4361, 12,
+OOVPA_SIG_HEADER_XREF(XWaveFileCreateMediaObjectEx,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefZero)
-{
+                      XRefNoSaveIndex,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0D, 0x0B },
     { 0x1C, 0xF7 },
@@ -642,13 +689,15 @@ OOVPA_XREF(XWaveFileCreateMediaObjectEx, 4361, 12,
 
     { 0x6C, 0xC2 },
     { 0x6D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CMemoryManager::PoolAlloc
 // ******************************************************************
-OOVPA_NO_XREF(DSound_CMemoryManager_PoolAlloc, 4361, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(DSound_CMemoryManager_PoolAlloc,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x24, 0x83 },
@@ -661,4 +710,5 @@ OOVPA_NO_XREF(DSound_CMemoryManager_PoolAlloc, 4361, 11)
     { 0x44, 0xC2 },
     { 0x45, 0x0C },
     { 0x46, 0x00 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4432.inl
+++ b/src/OOVPADatabase/DSound/4432.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XFileCreateMediaObjectAsync
 // ******************************************************************
-OOVPA_NO_XREF(XFileCreateMediaObjectAsync, 4432, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XFileCreateMediaObjectAsync,
+                         4432)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x1F, 0x1B },
@@ -43,4 +44,5 @@ OOVPA_NO_XREF(XFileCreateMediaObjectAsync, 4432, 12)
 
     { 0x5D, 0xC2 },
     { 0x5E, 0x0C },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4531.inl
+++ b/src/OOVPADatabase/DSound/4531.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CMcpxStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Discontinuity, 4531, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Discontinuity,
+                      4531,
 
-           XREF_CMcpxStream_Discontinuity,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Discontinuity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x24, XREF_CMcpxStream_Stop_Ex),
 
@@ -50,4 +51,5 @@ OOVPA_XREF(CMcpxStream_Discontinuity, 4531, 1 + 9,
     // CMcpxStream_Discontinuity+0x2D : pop esi; ret
     { 0x2D, 0x5E },
     { 0x2E, 0xC3 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4627.inl
+++ b/src/OOVPADatabase/DSound/4627.inl
@@ -27,11 +27,12 @@
 // ******************************************************************
 // * CDirectSound::SetVelocity
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetVelocity, 4627, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetVelocity,
+                      4627,
 
-           XREF_CDirectSound_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetVelocity+0x24 : mov eax, 0x80004005
     { 0x24, 0xB8 },
@@ -55,7 +56,8 @@ OOVPA_XREF(CDirectSound_SetVelocity, 4627, 15,
     // CDirectSound_SetVelocity+0x73 : retn 0x14
     { 0x73, 0xC2 },
     { 0x74, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_Play_Ex
@@ -65,11 +67,12 @@ OOVPA_XREF(CDirectSound_SetVelocity, 4627, 15,
 // ******************************************************************
 // * CDirectSound::SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDistanceFactor, 4627, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDistanceFactor,
+                      4627,
 
-           XREF_CDirectSound_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDistanceFactor+0x21 : mov eax, 0x80004005
     { 0x21, 0xB8 },
@@ -97,16 +100,18 @@ OOVPA_XREF(CDirectSound_SetDistanceFactor, 4627, 17,
     // CDirectSound_SetDistanceFactor+0x4F : jz +0x0B
     { 0x4F, 0x74 },
     { 0x50, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SetDopplerFactor, 4627, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDopplerFactor,
+                      4627,
 
-           XREF_CDirectSound_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDopplerFactor+0x21 : mov eax, 0x80004005
     { 0x21, 0xB8 },
@@ -129,15 +134,17 @@ OOVPA_XREF(CDirectSound_SetDopplerFactor, 4627, 14,
     // CDirectSound_SetDopplerFactor+0x4F : jz +0x0B
     { 0x4F, 0x74 },
     { 0x50, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CMemoryManager::MemAlloc
 // ******************************************************************
 // * FOR DEBUGGING USE ONLY!
 // ******************************************************************
-OOVPA_NO_XREF(CMemoryManager_MemAlloc, 4627, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(CMemoryManager_MemAlloc,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // DirectSound::CMemoryManager::PoolAlloc + 0x1B: cmp [esp+4+0xC], 0
     { 0x1B, 0x83 },
@@ -152,16 +159,18 @@ OOVPA_NO_XREF(CMemoryManager_MemAlloc, 4627, 10)
     // DirectSound::CMemoryManager::PoolAlloc + 0x65: retn 0xC
     { 0x65, 0xC2 },
     { 0x66, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDistanceFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4627, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDistanceFactor,
+                      4627,
 
-           XREF_CDirectSoundVoice_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetDistanceFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -181,16 +190,18 @@ OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 4627, 12,
     // CDirectSoundVoice_SetDistanceFactor+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDopplerFactor
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4627, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDopplerFactor,
+                      4627,
 
-           XREF_CDirectSoundVoice_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetDopplerFactor+0x0D : mov edx, [esp+arg_4]
     { 0x0D, 0x8B },
@@ -210,16 +221,18 @@ OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 4627, 12,
     // CDirectSoundVoice_SetDopplerFactor+0x31 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4627, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      4627,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -244,4 +257,5 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 4627, 12,
     //{ 0x7B, 0x00 },
     { 0x7C, 0x00 },
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4721.inl
+++ b/src/OOVPADatabase/DSound/4721.inl
@@ -28,11 +28,12 @@
 // * CMcpxStream_GetStatus
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer;
-OOVPA_XREF(CMcpxStream_GetStatus, 4721, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_GetStatus,
+                      4721,
 
-           XREF_CMcpxStream_GetStatus,
-           XRefZero)
-{
+                      XREF_CMcpxStream_GetStatus,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x0F },
 
@@ -50,7 +51,8 @@ OOVPA_XREF(CMcpxStream_GetStatus, 4721, 14,
 
     { 0x1C, 0x80 },
     { 0x41, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
@@ -94,11 +96,12 @@ OOVPA_END;
 // ******************************************************************
 // * CMcpxBuffer::Pause(unsigned long)
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Pause, 4721, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Pause,
+                      4721,
 
-           XREF_CMcpxBuffer_Pause,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Pause,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer::Pause+0x00 : push ebp
     { 0x00, 0x55 },
@@ -123,17 +126,19 @@ OOVPA_XREF(CMcpxBuffer_Pause, 4721, 12,
     // CMcpxBuffer::Pause+0x42 : ret 4
     { 0x42, 0xC2 },
     { 0x43, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::PauseEx
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer
-OOVPA_XREF(CDirectSoundBuffer_PauseEx, 4721, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_PauseEx,
+                      4721,
 
-           XREF_CDirectSoundBuffer_PauseEx,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_PauseEx,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3D, XREF_CMcpxBuffer_Pause_Ex),
 
@@ -149,17 +154,19 @@ OOVPA_XREF(CDirectSoundBuffer_PauseEx, 4721, 1 + 10,
 
     { 0x56, 0xC2 },
     { 0x57, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_PauseEx
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer
-OOVPA_XREF(IDirectSoundBuffer_PauseEx, 4721, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_PauseEx,
+                      4721,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_CDirectSoundBuffer_PauseEx),
 
@@ -170,17 +177,19 @@ OOVPA_XREF(IDirectSoundBuffer_PauseEx, 4721, 1 + 7,
     { 0x1A, 0xC8 },
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Pause(__int64, unsigned long)
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer
-OOVPA_XREF(CMcpxBuffer_Pause_Ex, 4721, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Pause_Ex,
+                      4721,
 
-           XREF_CMcpxBuffer_Pause_Ex,
-           XRefOne)
-{
+                      XREF_CMcpxBuffer_Pause_Ex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2B, XREF_CMcpxBuffer_Pause),
 
@@ -197,17 +206,19 @@ OOVPA_XREF(CMcpxBuffer_Pause_Ex, 4721, 1 + 8,
 
     { 0x36, 0xC2 },
     { 0x37, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer::Pause
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer
-OOVPA_XREF(CDirectSoundBuffer_Pause, 4721, 1 + 10,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Pause,
+                      4721,
 
-           XREF_CDirectSoundBuffer_Pause,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Pause,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CMcpxBuffer_Pause),
 
@@ -222,17 +233,19 @@ OOVPA_XREF(CDirectSoundBuffer_Pause, 4721, 1 + 10,
     { 0x4B, 0xC7 },
     { 0x4E, 0xC2 },
     { 0x4F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_Pause
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer
-OOVPA_XREF(IDirectSoundBuffer_Pause, 4721, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_Pause,
+                      4721,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_Pause),
 
@@ -243,16 +256,18 @@ OOVPA_XREF(IDirectSoundBuffer_Pause, 4721, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Play(unsigned long)
 // ******************************************************************
-OOVPA_XREF(CMcpxBuffer_Play, 4721, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play,
+                      4721,
 
-           XREF_CMcpxBuffer_Play,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Play+0x00 : push ebx
     { 0x00, 0x53 },
@@ -272,17 +287,19 @@ OOVPA_XREF(CMcpxBuffer_Play, 4721, 11,
     // CMcpxBuffer_Play+0x52 : xor eax, eax
     { 0x52, 0x33 },
     { 0x53, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetFormat
 // ******************************************************************
 // Generic OOVPA as of 4721 and newer
-OOVPA_XREF(CDirectSoundVoice_SetFormat, 4721, 2 + 5,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetFormat,
+                      4721,
 
-           XREF_CDirectSoundVoice_SetFormat,
-           XRefTwo)
-{
+                      XREF_CDirectSoundVoice_SetFormat,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetFormat+0x2F : call [CMcpxVoiceClient::SetMixBins]
     XREF_ENTRY(0x30, XREF_CMcpxVoiceClient_SetMixBins),
@@ -300,4 +317,5 @@ OOVPA_XREF(CDirectSoundVoice_SetFormat, 4721, 2 + 5,
     // CDirectSoundVoice::SetFormat+0x41 : ret 0x08
     { 0x41, 0xC2 },
     { 0x42, 0x08 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/4831.inl
+++ b/src/OOVPADatabase/DSound/4831.inl
@@ -28,11 +28,12 @@
 // CMcpxAPU::SynchPlayback
 // ******************************************************************
 // Generic OOVPA as of 4831 and newer
-OOVPA_XREF(CMcpxAPU_SynchPlayback, 4831, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_SynchPlayback,
+                      4831,
 
-           XREF_CMcpxAPU_SynchPlayback,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_SynchPlayback,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     { 0x00, 0x55 },
 
     //{ 0x0C, 0x74 }, // vs 5344 0x3C
@@ -48,16 +49,18 @@ OOVPA_XREF(CMcpxAPU_SynchPlayback, 4831, 9,
 
     { 0x9E, 0x64 },
     { 0xFF, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SynchPlayback
 // ******************************************************************
-OOVPA_XREF(CDirectSound_SynchPlayback, 4831, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SynchPlayback,
+                      4831,
 
-           XREF_CDirectSound_SynchPlayback,
-           XRefOne)
-{
+                      XREF_CDirectSound_SynchPlayback,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x08, XREF_CMcpxAPU_SynchPlayback),
 
@@ -75,17 +78,19 @@ OOVPA_XREF(CDirectSound_SynchPlayback, 4831, 1 + 9,
     // CDirectSound_SynchPlayback+0x0C : retn 0x04
     { 0x0C, 0xC2 },
     { 0x0D, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound::SynchPlayback
 // ******************************************************************
 // Generic OOVPA as of 4831 and newer
-OOVPA_XREF(IDirectSound_SynchPlayback, 4831, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound_SynchPlayback,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x11, XREF_CDirectSound_SynchPlayback),
 
@@ -101,7 +106,8 @@ OOVPA_XREF(IDirectSound_SynchPlayback, 4831, 1 + 7,
     // IDirectSound_SynchPlayback+0x15 : retn 0x04
     { 0x15, 0xC2 },
     { 0x16, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer_GetStatus
@@ -149,11 +155,12 @@ OOVPA_END;
 // * CMcpxBuffer::Play(unsigned long)
 // ******************************************************************
 // Generic OOVPA as of 4831 and newer
-OOVPA_XREF(CMcpxBuffer_Play, 4831, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Play,
+                      4831,
 
-           XREF_CMcpxBuffer_Play,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer_Play+0x00 : push ebx
     { 0x00, 0x53 },
@@ -173,17 +180,19 @@ OOVPA_XREF(CMcpxBuffer_Play, 4831, 11,
     // CMcpxBuffer_Play+0x71 : xor eax, eax
     { 0x71, 0x33 },
     { 0x72, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Pause
 // ******************************************************************
 // Generic OOVPA as of ____? and newer
-OOVPA_XREF(CMcpxStream_Pause, 4831, 11,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Pause,
+                      4831,
 
-           XREF_CMcpxStream_Pause,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Pause,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxStream_Pause+0x17 : and ax, 0xFFDF
     { 0x17, 0x66 },
@@ -203,17 +212,19 @@ OOVPA_XREF(CMcpxStream_Pause, 4831, 11,
     // CMcpxStream_Pause+0x8B : retn 0x04
     { 0x8B, 0xC2 },
     { 0x8C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxBuffer::Pause(unsigned long)
 // ******************************************************************
 // Generic OOVPA as of 4831 and newer
-OOVPA_XREF(CMcpxBuffer_Pause, 4831, 10,
+OOVPA_SIG_HEADER_XREF(CMcpxBuffer_Pause,
+                      4831,
 
-           XREF_CMcpxBuffer_Pause,
-           XRefZero)
-{
+                      XREF_CMcpxBuffer_Pause,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxBuffer::Pause+0x00 : push ebp
     { 0x00, 0x55 },
@@ -237,4 +248,5 @@ OOVPA_XREF(CMcpxBuffer_Pause, 4831, 10,
     { 0x70, 0xC2 },
     { 0x71, 0x04 },
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/5028.inl
+++ b/src/OOVPADatabase/DSound/5028.inl
@@ -28,11 +28,12 @@
 // * CDirectSoundStream_Flush
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(CDirectSoundStream_Flush, 5028, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Flush,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     //CDirectSoundStream_Flush+0x31 : call [CMcpxStream_Flush]
     XREF_ENTRY(0x32, XREF_CMcpxStream_Flush),
@@ -50,17 +51,19 @@ OOVPA_XREF(CDirectSoundStream_Flush, 5028, 1 + 8,
     //CDirectSoundStream_Flush+0x48 : ret 4
     { 0x48, 0xC2 },
     { 0x49, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient_GetVoiceProperties
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(CMcpxVoiceClient_GetVoiceProperties, 5028, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_GetVoiceProperties,
+                      5028,
 
-           XREF_CMcpxVoiceClient_GetVoiceProperties,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_GetVoiceProperties,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -82,17 +85,19 @@ OOVPA_XREF(CMcpxVoiceClient_GetVoiceProperties, 5028, 14,
     { 0x107, 0xFF },
 
     // After offset 0x11C, lots of changes has occurred.
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_GetVoiceProperties
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(CDirectSoundVoice_GetVoiceProperties, 5028, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_GetVoiceProperties,
+                      5028,
 
-           XREF_CDirectSoundVoice_GetVoiceProperties,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_GetVoiceProperties,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0C, XREF_CMcpxVoiceClient_GetVoiceProperties),
 
@@ -103,17 +108,19 @@ OOVPA_XREF(CDirectSoundVoice_GetVoiceProperties, 5028, 1 + 7,
     { 0x0B, 0xE8 },
     { 0x10, 0xC2 },
     { 0x11, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundBuffer_GetVoiceProperties
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(CDirectSoundBuffer_GetVoiceProperties, 5028, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_GetVoiceProperties,
+                      5028,
 
-           XREF_CDirectSoundBuffer_GetVoiceProperties,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_GetVoiceProperties,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_GetVoiceProperties),
 
@@ -124,17 +131,19 @@ OOVPA_XREF(CDirectSoundBuffer_GetVoiceProperties, 5028, 1 + 7,
     { 0x31, 0xE8 },
     { 0x4B, 0xC2 },
     { 0x4C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer_GetVoiceProperties
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(IDirectSoundBuffer_GetVoiceProperties, 5028, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_GetVoiceProperties,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_GetVoiceProperties),
 
@@ -145,17 +154,19 @@ OOVPA_XREF(IDirectSoundBuffer_GetVoiceProperties, 5028, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundStream_GetVoiceProperties
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(CDirectSoundStream_GetVoiceProperties, 5028, 1 + 7,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_GetVoiceProperties,
+                      5028,
 
-           XREF_CDirectSoundStream_GetVoiceProperties,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_GetVoiceProperties,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_GetVoiceProperties),
 
@@ -166,33 +177,37 @@ OOVPA_XREF(CDirectSoundStream_GetVoiceProperties, 5028, 1 + 7,
     { 0x35, 0xE8 },
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_GetVoiceProperties
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer
-OOVPA_XREF(IDirectSoundStream_GetVoiceProperties, 5028, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_GetVoiceProperties,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_GetVoiceProperties+0x00 : jmp [CDirectSoundStream_GetVoiceProperties]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_GetVoiceProperties),
 
     // IDirectSoundStream_GetVoiceProperties+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 5028, 12,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      5028,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefZero)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -213,17 +228,19 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 5028, 12,
     //OV_MATCH(0x74, 0x00),
     OV_MATCH(0x75, 0x00),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream::Stop
 // ******************************************************************
 // Generic OOVPA as of 5028 and newer;
-OOVPA_XREF(CMcpxStream_Stop, 5028, 7,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Stop,
+                      5028,
 
-           XREF_CMcpxStream_Stop,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Stop,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // calls to CIrql_Raise, CIrql_Lower, CMcpxVoiceClient_ReleaseVoice, CMcpxVoiceClient_DeactivateVoice
 
@@ -233,16 +250,18 @@ OOVPA_XREF(CMcpxStream_Stop, 5028, 7,
     // Offset is unique for this asm code.
     // CMcpxStream_Stop+0x1F : test [ebp+8],6
     OV_MATCH(0x1F, 0xF6, 0x45, 0x08, 0x06),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioSetEffectData
 // ******************************************************************
-OOVPA_XREF(XAudioSetEffectData, 5028, 2 + 3,
+OOVPA_SIG_HEADER_XREF(XAudioSetEffectData,
+                      5028,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // XAudioSetEffectData+0x79 : call [CDirectSound::GetEffectData]
     XREF_ENTRY(0x07A, XREF_CDirectSound_GetEffectData),
@@ -252,4 +271,5 @@ OOVPA_XREF(XAudioSetEffectData, 5028, 2 + 3,
 
     OV_MATCH(0x00, 0x55, 0x8B),
     OV_MATCH(0x03, 0x81),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/5344.inl
+++ b/src/OOVPADatabase/DSound/5344.inl
@@ -27,11 +27,12 @@
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetMinDistance
 // ******************************************************************
-OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 5344, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMinDistance,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetMinDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMinDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMinDistance+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -54,17 +55,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMinDistance, 5344, 1 + 12,
     // CDirectSoundVoice_SetMinDistance+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 5344, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDistanceFactor,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetDistanceFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetDistanceFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetDistanceFactor+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -87,17 +90,19 @@ OOVPA_XREF(CDirectSoundVoice_SetDistanceFactor, 5344, 1 + 12,
     // CDirectSoundVoice_SetDistanceFactor+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 5344, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetDopplerFactor,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetDopplerFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetDopplerFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetDopplerFactor+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -120,17 +125,19 @@ OOVPA_XREF(CDirectSoundVoice_SetDopplerFactor, 5344, 1 + 12,
     // CDirectSoundVoice_SetDopplerFactor+0x31 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetMaxDistance
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 5344, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMaxDistance,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetMaxDistance,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMaxDistance,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMaxDistance+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -153,17 +160,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMaxDistance, 5344, 1 + 12,
     // CDirectSoundVoice_SetMaxDistance+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // CDirectSoundVoice::SetMode
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetMode, 5344, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetMode,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetMode,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetMode,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetMode+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -186,17 +195,19 @@ OOVPA_XREF(CDirectSoundVoice_SetMode, 5344, 1 + 12,
 
     { 0x30, 0xC2 },
     { 0x31, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_SetPosition
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_SetPosition, 5344, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetPosition,
+                      5344,
 
-           XREF_CDirectSound_SetPosition,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetPosition+0x00 : push ebp; mov ebp, esp
     OV_MATCH(0x00, 0x55, 0x8B, 0xEC),
@@ -213,17 +224,19 @@ OOVPA_XREF(CDirectSound_SetPosition, 5344, 15,
     // CDirectSound_SetPosition+0x47 : mov [edx+0x44],edi
     OV_MATCH(0x47, 0x89, 0x7A, 0x44),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_SetVelocity, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetVelocity,
+                      5344,
 
-           XREF_CDirectSound_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetVelocity+0x00 : push ebp
     { 0x00, 0x55 },
@@ -252,17 +265,19 @@ OOVPA_XREF(CDirectSound_SetVelocity, 5344, 14,
     // CDirectSound_SetVelocity+0x70 : retn 0x14
     { 0x70, 0xC2 },
     { 0x71, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetPosition
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetPosition, 5344, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetPosition,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetPosition,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetPosition,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetPosition+0x0F : mov edx, [ebp+arg_4]
     { 0x0F, 0x8B },
@@ -283,17 +298,19 @@ OOVPA_XREF(CDirectSoundVoice_SetPosition, 5344, 12,
     { 0x30, 0x89 },
     { 0x31, 0x51 },
     { 0x32, 0x10 }, // SetConeOrientation vs SetPosition vs SetVelocity
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetVelocity
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetVelocity, 5344, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetVelocity,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetVelocity,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetVelocity,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetVelocity+0x0F : mov edx, [ebp+arg_4]
     { 0x0F, 0x8B },
@@ -314,17 +331,19 @@ OOVPA_XREF(CDirectSoundVoice_SetVelocity, 5344, 12,
     { 0x30, 0x89 },
     { 0x31, 0x51 },
     { 0x32, 0x1C }, // SetConeOrientation vs SetPosition vs SetVelocity
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SynchPlayback
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_SynchPlayback, 5344, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SynchPlayback,
+                      5344,
 
-           XREF_CDirectSound_SynchPlayback,
-           XRefOne)
-{
+                      XREF_CDirectSound_SynchPlayback,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x31, XREF_CMcpxAPU_SynchPlayback),
 
@@ -338,16 +357,18 @@ OOVPA_XREF(CDirectSound_SynchPlayback, 5344, 1 + 9,
     { 0x2F, 0x57 },
     { 0x36, 0xF6 },
     { 0x3B, 0x68 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::CommitDeferredSettings
 // ******************************************************************
-OOVPA_XREF(CDirectSound_CommitDeferredSettings, 5344, 2 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitDeferredSettings,
+                      5344,
 
-           XREF_CDirectSound_CommitDeferredSettings,
-           XRefTwo)
-{
+                      XREF_CDirectSound_CommitDeferredSettings,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CommitDeferredSettings+0x46 : call [CDirectSound3DCalculator::Calculate3D]
     XREF_ENTRY(0x47, XREF_CDirectSound3DCalculator_Calculate3D),
@@ -368,16 +389,18 @@ OOVPA_XREF(CDirectSound_CommitDeferredSettings, 5344, 2 + 8,
 
     // CDirectSound_CommitDeferredSettings+0x97 : leave
     { 0x97, 0xC9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSound::EnableHeadphones
 // ******************************************************************
-OOVPA_XREF(CDirectSound_EnableHeadphones, 5344, 9,
+OOVPA_SIG_HEADER_XREF(CDirectSound_EnableHeadphones,
+                      5344,
 
-           XREF_CDirectSound_EnableHeadphones,
-           XRefZero)
-{
+                      XREF_CDirectSound_EnableHeadphones,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x51 },
     { 0x05, 0x83 },
@@ -390,17 +413,19 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 5344, 9,
     { 0x2D, 0x05 },
     { 0x3D, 0x08 },
     { 0x4D, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetConeOutsideVolume
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 5344, 1 + 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOutsideVolume,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetConeOutsideVolume,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetConeOutsideVolume,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetConeOutsideVolume+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -423,17 +448,19 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOutsideVolume, 5344, 1 + 12,
     // CDirectSoundVoice_SetConeOutsideVolume+0x30 : retn 0Ch
     { 0x31, 0x0C },
     { 0x32, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetRolloffFactor, 5344, 1 + 13,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetRolloffFactor,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetRolloffFactor,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetRolloffFactor,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::SetConeOutsideVolume+0x29 : call [CDirectSoundVoice::CommitDeferredSettings]
     XREF_ENTRY(0x2A, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -459,17 +486,19 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffFactor, 5344, 1 + 13,
     // CDirectSoundVoice_SetRolloffFactor+0x30 : retn 0Ch
     { 0x30, 0xC2 },
     { 0x31, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetRolloffCurve
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetRolloffCurve, 5344, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetRolloffCurve,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetRolloffCurve,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetRolloffCurve,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -485,17 +514,19 @@ OOVPA_XREF(CDirectSoundVoice_SetRolloffCurve, 5344, 12,
 
     { 0x23, 0x54 }, // SetConeAngles 0x24 vs SetRolloffCurve 0x54
     { 0x30, 0x01 }, // SetConeAngles 0x04 vs SetRolloffCurve 0x01
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::SetConeAngles
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 5344, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeAngles,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetConeAngles,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeAngles,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -511,17 +542,19 @@ OOVPA_XREF(CDirectSoundVoice_SetConeAngles, 5344, 12,
 
     { 0x23, 0x24 }, // SetConeAngles 0x24 vs SetRolloffCurve 0x54
     { 0x30, 0x04 }, // SetConeAngles 0x04 vs SetRolloffCurve 0x01
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice_SetConeOrientation
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 5344, 12,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetConeOrientation,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetConeOrientation,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_SetConeOrientation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice_SetConeOrientation+0x0F : mov edx, [ebp+arg_4]
     { 0x0F, 0x8B },
@@ -542,17 +575,19 @@ OOVPA_XREF(CDirectSoundVoice_SetConeOrientation, 5344, 12,
     { 0x30, 0x89 },
     { 0x31, 0x51 },
     { 0x32, 0x30 }, // SetConeOrientation vs SetPosition vs SetVelocity
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Flush
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CMcpxStream_Flush, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Flush,
+                      5344,
 
-           XREF_CMcpxStream_Flush,
-           XRefZero)
-{
+                      XREF_CMcpxStream_Flush,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxStream_Flush+0x00 : push ebp; mov ebp, esp; sub esp, 10h
     { 0x00, 0x55 },
@@ -572,17 +607,19 @@ OOVPA_XREF(CMcpxStream_Flush, 5344, 14,
     { 0x0F, 0x00 },
     { 0x10, 0x00 },
     { 0x11, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::SetI3DL2Source
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 5344, 1 + 11,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_SetI3DL2Source,
+                      5344,
 
-           XREF_CDirectSoundVoice_SetI3DL2Source,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_SetI3DL2Source,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundBuffer_SetI3DL2Source+0xC0 : call [CDirectSoundVoice::SetI3DL2Source]
     XREF_ENTRY(0xC1, XREF_CDirectSoundVoice_CommitDeferredSettings),
@@ -607,17 +644,19 @@ OOVPA_XREF(CDirectSoundVoice_SetI3DL2Source, 5344, 1 + 11,
     // CDirectSoundVoice_SetI3DL2Source+0xC7 : retn 0Ch
     { 0xC7, 0xC2 },
     { 0xC8, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDistanceFactor
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_SetDistanceFactor, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDistanceFactor,
+                      5344,
 
-           XREF_CDirectSound_SetDistanceFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDistanceFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDistanceFactor+0x00 : push esi
     { 0x00, 0x56 },
@@ -645,17 +684,19 @@ OOVPA_XREF(CDirectSound_SetDistanceFactor, 5344, 14,
     // CDirectSound_SetDistanceFactor+0x4C : jz +0x0B
     { 0x4C, 0x74 },
     { 0x4D, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetDopplerFactor
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_SetDopplerFactor, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetDopplerFactor,
+                      5344,
 
-           XREF_CDirectSound_SetDopplerFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetDopplerFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetDopplerFactor+0x00 : push esi
     { 0x00, 0x56 },
@@ -683,17 +724,19 @@ OOVPA_XREF(CDirectSound_SetDopplerFactor, 5344, 14,
     // CDirectSound_SetDopplerFactor+0x4C : jz +0x0B
     { 0x4C, 0x74 },
     { 0x4D, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound::SetRolloffFactor
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_SetRolloffFactor, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_SetRolloffFactor,
+                      5344,
 
-           XREF_CDirectSound_SetRolloffFactor,
-           XRefZero)
-{
+                      XREF_CDirectSound_SetRolloffFactor,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_SetRolloffFactor+0x00 : push esi
     { 0x00, 0x56 },
@@ -721,17 +764,19 @@ OOVPA_XREF(CDirectSound_SetRolloffFactor, 5344, 14,
     // CDirectSound_SetRolloffFactor+0x4C : jz +0x0B
     { 0x4C, 0x74 },
     { 0x4D, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CFullHRTFSource::GetCenterVolume
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(CFullHRTFSource_GetCenterVolume, 5344, 7,
+OOVPA_SIG_HEADER_XREF(CFullHRTFSource_GetCenterVolume,
+                      5344,
 
-           XREF_CFullHRTFSource_GetCenterVolume,
-           XRefZero)
-{
+                      XREF_CFullHRTFSource_GetCenterVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x13, 0xD9 },
     { 0x29, 0xDF },
@@ -740,17 +785,19 @@ OOVPA_XREF(CFullHRTFSource_GetCenterVolume, 5344, 7,
     { 0x67, 0x4D },
     { 0x7E, 0xD9 },
     { 0x91, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * LightHRTFSource::GetCenterVolume
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(CLightHRTFSource_GetCenterVolume, 5344, 11,
+OOVPA_SIG_HEADER_XREF(CLightHRTFSource_GetCenterVolume,
+                      5344,
 
-           XREF_CLightHRTFSource_GetCenterVolume,
-           XRefZero)
-{
+                      XREF_CLightHRTFSource_GetCenterVolume,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CLightHRTFSource::GetCenterVolume+0x00 : push ebp
     OV_MATCH(0x00, 0x55),
@@ -766,17 +813,19 @@ OOVPA_XREF(CLightHRTFSource_GetCenterVolume, 5344, 11,
 
     // CLightHRTFSource::GetCenterVolume+0x66 : ret 0x0010
     OV_MATCH(0x66, 0xC2, 0x10),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHRTFSource::SetFullHRTF5Channel
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(CHRTFSource_SetFullHRTF5Channel, 5344, 1 + 16,
+OOVPA_SIG_HEADER_XREF(CHRTFSource_SetFullHRTF5Channel,
+                      5344,
 
-           XREF_CHRTFSource_SetFullHRTF5Channel,
-           XRefOne)
-{
+                      XREF_CHRTFSource_SetFullHRTF5Channel,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4C, XREF_CFullHRTFSource_GetCenterVolume),
 
@@ -798,17 +847,19 @@ OOVPA_XREF(CHRTFSource_SetFullHRTF5Channel, 5344, 1 + 16,
     { 0x6D, 0x00 },
 
     { 0x6E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHRTFSource::SetLightHRTF5Channel
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(CHRTFSource_SetLightHRTF5Channel, 5344, 1 + 16,
+OOVPA_SIG_HEADER_XREF(CHRTFSource_SetLightHRTF5Channel,
+                      5344,
 
-           XREF_CHRTFSource_SetLightHRTF5Channel,
-           XRefOne)
-{
+                      XREF_CHRTFSource_SetLightHRTF5Channel,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x4C, XREF_CLightHRTFSource_GetCenterVolume),
 
@@ -830,17 +881,19 @@ OOVPA_XREF(CHRTFSource_SetLightHRTF5Channel, 5344, 1 + 16,
     { 0x6D, 0x00 },
 
     { 0x6E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHRTFSource::SetFullHRTF4Channel
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(CHRTFSource_SetFullHRTF4Channel, 5344, 16,
+OOVPA_SIG_HEADER_XREF(CHRTFSource_SetFullHRTF4Channel,
+                      5344,
 
-           XREF_CHRTFSource_SetFullHRTF4Channel,
-           XRefZero)
-{
+                      XREF_CHRTFSource_SetFullHRTF4Channel,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xC7 },
     { 0x0A, 0xC7 },
@@ -860,17 +913,19 @@ OOVPA_XREF(CHRTFSource_SetFullHRTF4Channel, 5344, 16,
     { 0x6D, 0x00 },
 
     { 0x6E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CHRTFSource::SetLightHRTF4Channel
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(CHRTFSource_SetLightHRTF4Channel, 5344, 16,
+OOVPA_SIG_HEADER_XREF(CHRTFSource_SetLightHRTF4Channel,
+                      5344,
 
-           XREF_CHRTFSource_SetLightHRTF4Channel,
-           XRefZero)
-{
+                      XREF_CHRTFSource_SetLightHRTF4Channel,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xC7 },
     { 0x0A, 0xC7 },
@@ -890,17 +945,19 @@ OOVPA_XREF(CHRTFSource_SetLightHRTF4Channel, 5344, 16,
     { 0x6D, 0x00 },
 
     { 0x6E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseLightHRTF
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(DirectSoundUseLightHRTF, 5344, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseLightHRTF,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0A, XREF_CHRTFSource_SetLightHRTF5Channel),
 
@@ -911,17 +968,19 @@ OOVPA_XREF(DirectSoundUseLightHRTF, 5344, 1 + 7,
     { 0x12, 0x0B },
     { 0x18, 0xFF },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseFullHRTF4Channel
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(DirectSoundUseFullHRTF4Channel, 5344, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseFullHRTF4Channel,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0A, XREF_CHRTFSource_SetFullHRTF4Channel),
 
@@ -932,17 +991,19 @@ OOVPA_XREF(DirectSoundUseFullHRTF4Channel, 5344, 1 + 7,
     { 0x12, 0x0B },
     { 0x18, 0xFF },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSoundUseLightHRTF4Channel
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer.
-OOVPA_XREF(DirectSoundUseLightHRTF4Channel, 5344, 1 + 7,
+OOVPA_SIG_HEADER_XREF(DirectSoundUseLightHRTF4Channel,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0A, XREF_CHRTFSource_SetLightHRTF4Channel),
 
@@ -953,17 +1014,19 @@ OOVPA_XREF(DirectSoundUseLightHRTF4Channel, 5344, 1 + 7,
     { 0x12, 0x0B },
     { 0x18, 0xFF },
     { 0x1E, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound3DCalculator_GetVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound3DCalculator_GetVoiceData, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound3DCalculator_GetVoiceData,
+                      5344,
 
-           XREF_CDirectSound3DCalculator_GetVoiceData,
-           XRefZero)
-{
+                      XREF_CDirectSound3DCalculator_GetVoiceData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -985,17 +1048,19 @@ OOVPA_XREF(CDirectSound3DCalculator_GetVoiceData, 5344, 14,
     { 0x91, 0x40 },
 
     // After offset 0x131, major changes has occur.
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound3DCalculator_GetVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(IDirectSound3DCalculator_GetVoiceData, 5344, 1 + 3,
+OOVPA_SIG_HEADER_XREF(IDirectSound3DCalculator_GetVoiceData,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound3DCalculator_GetVoiceData+0x04 : jmp [CDirectSound3DCalculator_GetVoiceData]
     XREF_ENTRY(0x05, XREF_CDirectSound3DCalculator_GetVoiceData),
@@ -1008,17 +1073,19 @@ OOVPA_XREF(IDirectSound3DCalculator_GetVoiceData, 5344, 1 + 3,
 
     // IDirectSound3DCalculator_GetVoiceData+0x04 : jmp 0x........
     { 0x04, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound3DCalculator_GetPanData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound3DCalculator_GetPanData, 5344, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound3DCalculator_GetPanData,
+                      5344,
 
-           XREF_CDirectSound3DCalculator_GetPanData,
-           XRefZero)
-{
+                      XREF_CDirectSound3DCalculator_GetPanData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1045,17 +1112,19 @@ OOVPA_XREF(CDirectSound3DCalculator_GetPanData, 5344, 15,
     { 0x8F, 0x18 },
 
     // After offset 0x93, major changes has occur.
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound3DCalculator_GetPanData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(IDirectSound3DCalculator_GetPanData, 5344, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IDirectSound3DCalculator_GetPanData,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound3DCalculator_GetPanData+0x19 : call [CDirectSound3DCalculator_GetVoiceData]
     XREF_ENTRY(0x1A, XREF_CDirectSound3DCalculator_GetPanData),
@@ -1070,17 +1139,19 @@ OOVPA_XREF(IDirectSound3DCalculator_GetPanData, 5344, 1 + 7,
     // IDirectSound3DCalculator_GetPanData+0x1E : retn 0x10
     { 0x1E, 0xC2 },
     { 0x1F, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound3DCalculator_GetMixBinVolumes
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound3DCalculator_GetMixBinVolumes, 5344, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound3DCalculator_GetMixBinVolumes,
+                      5344,
 
-           XREF_CDirectSound3DCalculator_GetMixBinVolumes,
-           XRefZero)
-{
+                      XREF_CDirectSound3DCalculator_GetMixBinVolumes,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1099,34 +1170,38 @@ OOVPA_XREF(CDirectSound3DCalculator_GetMixBinVolumes, 5344, 14,
     { 0xA5, 0x07 },
     { 0xAA, 0x09 },
     { 0xAF, 0x0A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound3DCalculator_GetMixBinVolumes
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(IDirectSound3DCalculator_GetMixBinVolumes, 5344, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSound3DCalculator_GetMixBinVolumes,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound3DCalculator_GetMixBinVolumes+0x00 : jmp [CDirectSound3DCalculator_GetMixBinVolumes]
     XREF_ENTRY(0x01, XREF_CDirectSound3DCalculator_GetMixBinVolumes),
 
     // IDirectSound3DCalculator_GetMixBinVolumes+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound3DCalculator_Calculate3D
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound3DCalculator_Calculate3D, 5344, 15,
+OOVPA_SIG_HEADER_XREF(CDirectSound3DCalculator_Calculate3D,
+                      5344,
 
-           XREF_CDirectSound3DCalculator_Calculate3D,
-           XRefZero)
-{
+                      XREF_CDirectSound3DCalculator_Calculate3D,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8D },
@@ -1150,34 +1225,38 @@ OOVPA_XREF(CDirectSound3DCalculator_Calculate3D, 5344, 15,
     { 0xD5, 0x03 },
 
     // After offset 0xEE, major changes has occur.
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound3DCalculator_Calculate3D
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(IDirectSound3DCalculator_Calculate3D, 5344, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSound3DCalculator_Calculate3D,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound3DCalculator_Calculate3D+0x00 : jmp [CDirectSound3DCalculator_Calculate3D]
     XREF_ENTRY(0x01, XREF_CDirectSound3DCalculator_Calculate3D),
 
     // IDirectSound3DCalculator_Calculate3D+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioSetEffectData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(XAudioSetEffectData, 5344, 2 + 3,
+OOVPA_SIG_HEADER_XREF(XAudioSetEffectData,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // XAudioSetEffectData+0x79 : call [CDirectSound_GetEffectData]
     XREF_ENTRY(0x07A, XREF_CDirectSound_GetEffectData),
@@ -1188,17 +1267,19 @@ OOVPA_XREF(XAudioSetEffectData, 5344, 2 + 3,
     { 0x00, 0x55 },
     { 0x01, 0x8B },
     { 0x03, 0x81 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_MapBufferData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_MapBufferData, 5344, 10,
+OOVPA_SIG_HEADER_XREF(CDirectSound_MapBufferData,
+                      5344,
 
-           XREF_CDirectSound_MapBufferData,
-           XRefZero)
-{
+                      XREF_CDirectSound_MapBufferData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0C, 0x00 },
@@ -1214,17 +1295,19 @@ OOVPA_XREF(CDirectSound_MapBufferData, 5344, 10,
 
     { 0x66, 0xC2 },
     { 0x67, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_MapBufferData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(IDirectSound_MapBufferData, 5344, 1 + 6,
+OOVPA_SIG_HEADER_XREF(IDirectSound_MapBufferData,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_MapBufferData+0x1C : call [CDirectSound_MapBufferData]
     XREF_ENTRY(0x01D, XREF_CDirectSound_MapBufferData),
@@ -1235,17 +1318,19 @@ OOVPA_XREF(IDirectSound_MapBufferData, 5344, 1 + 6,
     { 0x14, 0xF8 },
     { 0x21, 0xC2 },
     { 0x22, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_UnmapBufferData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSound_UnmapBufferData, 5344, 10,
+OOVPA_SIG_HEADER_XREF(CDirectSound_UnmapBufferData,
+                      5344,
 
-           XREF_CDirectSound_UnmapBufferData,
-           XRefZero)
-{
+                      XREF_CDirectSound_UnmapBufferData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x0C, 0x00 },
@@ -1260,17 +1345,19 @@ OOVPA_XREF(CDirectSound_UnmapBufferData, 5344, 10,
 
     { 0x4D, 0xC2 },
     { 0x4E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSound_UnmapBufferData
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(IDirectSound_UnmapBufferData, 5344, 1 + 6,
+OOVPA_SIG_HEADER_XREF(IDirectSound_UnmapBufferData,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSound_UmapBufferData+0x14 : call [CDirectSound_UnmapBufferData]
     XREF_ENTRY(0x015, XREF_CDirectSound_UnmapBufferData),
@@ -1281,17 +1368,19 @@ OOVPA_XREF(IDirectSound_UnmapBufferData, 5344, 1 + 6,
     { 0x0C, 0xF8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 5344, 2 + 9,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      5344,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefTwo)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient::Commit3dSettings+0x2B : call [CDirectSound3DCalculator::Calculate3D]
     XREF_ENTRY(0x2C, XREF_CDirectSound3DCalculator_Calculate3D),
@@ -1317,17 +1406,19 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 5344, 2 + 9,
     //{ 0x6E, 0x00 },
     { 0x6F, 0x00 },
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSoundVoice::CommitDeferredSettings
 // ******************************************************************
 // Generic OOVPA as of 5344 and newer
-OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 5344, 1 + 6,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_CommitDeferredSettings,
+                      5344,
 
-           XREF_CDirectSoundVoice_CommitDeferredSettings,
-           XRefOne)
-{
+                      XREF_CDirectSoundVoice_CommitDeferredSettings,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // CDirectSoundVoice::CommitDeferredSettings+0x07 : call [CMcpxVoiceClient::Commit3dSettings]
     XREF_ENTRY(0x08, XREF_CMcpxVoiceClient_Commit3dSettings),
@@ -1338,4 +1429,5 @@ OOVPA_XREF(CDirectSoundVoice_CommitDeferredSettings, 5344, 1 + 6,
     { 0x0C, 0x33 },
     { 0x0D, 0xC0 },
     { 0x10, 0x00 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/5455.inl
+++ b/src/OOVPADatabase/DSound/5455.inl
@@ -27,11 +27,12 @@
 // * CDirectSound::CommitDeferredSettings
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CDirectSound_CommitDeferredSettings, 5455, 2 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSound_CommitDeferredSettings,
+                      5455,
 
-           XREF_CDirectSound_CommitDeferredSettings,
-           XRefTwo)
-{
+                      XREF_CDirectSound_CommitDeferredSettings,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_CommitDeferredSettings+0x45 : call [CDirectSound3DCalculator::Calculate3D]
     XREF_ENTRY(0x46, XREF_CDirectSound3DCalculator_Calculate3D),
@@ -52,17 +53,19 @@ OOVPA_XREF(CDirectSound_CommitDeferredSettings, 5455, 2 + 8,
 
     // CDirectSound_CommitDeferredSettings+0x96 : leave
     { 0x96, 0xC9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSound::EnableHeadphones
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CDirectSound_EnableHeadphones, 5455, 17,
+OOVPA_SIG_HEADER_XREF(CDirectSound_EnableHeadphones,
+                      5455,
 
-           XREF_CDirectSound_EnableHeadphones,
-           XRefZero)
-{
+                      XREF_CDirectSound_EnableHeadphones,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CDirectSound_EnableHeadphones+0x00 : push ebp
     { 0x00, 0x55 },
@@ -94,17 +97,19 @@ OOVPA_XREF(CDirectSound_EnableHeadphones, 5455, 17,
     //{ 0x117, 0xC9 },
     { 0x118, 0xC2 },
     { 0x119, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DSound_CRefCount_Release
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(DSound_CRefCount_Release, 5455, 10,
+OOVPA_SIG_HEADER_XREF(DSound_CRefCount_Release,
+                      5455,
 
-           XREF_DSound_CRefCount_Release,
-           XRefZero)
-{
+                      XREF_DSound_CRefCount_Release,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
 
@@ -124,16 +129,18 @@ OOVPA_XREF(DSound_CRefCount_Release, 5455, 10,
     // DSound_CRefCount_Release+0x20 : retn 0x04
     { 0x1E, 0xC2 },
     { 0x1F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxStream_Discontinuity
 // ******************************************************************
-OOVPA_XREF(CMcpxStream_Discontinuity, 5455, 1 + 9,
+OOVPA_SIG_HEADER_XREF(CMcpxStream_Discontinuity,
+                      5455,
 
-           XREF_CMcpxStream_Discontinuity,
-           XRefOne)
-{
+                      XREF_CMcpxStream_Discontinuity,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x22, XREF_CMcpxStream_Stop),
 
@@ -153,17 +160,19 @@ OOVPA_XREF(CMcpxStream_Discontinuity, 5455, 1 + 9,
     // CMcpxStream_Discontinuity+0x2B : pop esi; ret
     { 0x2B, 0x5E },
     { 0x2C, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CDirectSound_GetSpeakerConfig
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CDirectSound_GetSpeakerConfig, 5455, 14,
+OOVPA_SIG_HEADER_XREF(CDirectSound_GetSpeakerConfig,
+                      5455,
 
-           XREF_CDirectSound_GetSpeakerConfig,
-           XRefZero)
-{
+                      XREF_CDirectSound_GetSpeakerConfig,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xE8 },
 
@@ -185,17 +194,19 @@ OOVPA_XREF(CDirectSound_GetSpeakerConfig, 5455, 14,
 
     { 0x4A, 0xC2 },
     { 0x4B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundVoice::Set3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CDirectSoundVoice_Set3DVoiceData, 5455, 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_Set3DVoiceData,
+                      5455,
 
-           XREF_CDirectSoundVoice_Set3DVoiceData,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_Set3DVoiceData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x04, 0x8B },
@@ -207,17 +218,19 @@ OOVPA_XREF(CDirectSoundVoice_Set3DVoiceData, 5455, 9,
     { 0x96, 0x10 },
     { 0xB9, 0x20 },
     { 0xCD, 0x40 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundBuffer::Set3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CDirectSoundBuffer_Set3DVoiceData, 5455, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Set3DVoiceData,
+                      5455,
 
-           XREF_CDirectSoundBuffer_Set3DVoiceData,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Set3DVoiceData,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x32, XREF_CDirectSoundVoice_Set3DVoiceData),
 
@@ -229,16 +242,18 @@ OOVPA_XREF(CDirectSoundBuffer_Set3DVoiceData, 5455, 1 + 8,
     { 0x3C, 0x68 },
     { 0x4B, 0xC2 },
     { 0x4C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer::Set3DVoiceData
 // ******************************************************************
-OOVPA_XREF(IDirectSoundBuffer_Set3DVoiceData, 5455, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_Set3DVoiceData,
+                      5455,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_Set3DVoiceData),
 
@@ -250,17 +265,19 @@ OOVPA_XREF(IDirectSoundBuffer_Set3DVoiceData, 5455, 1 + 8,
     { 0x14, 0xE8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::Set3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CDirectSoundStream_Set3DVoiceData, 5455, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Set3DVoiceData,
+                      5455,
 
-           XREF_CDirectSoundStream_Set3DVoiceData,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_Set3DVoiceData,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x36, XREF_CDirectSoundVoice_Set3DVoiceData),
 
@@ -272,34 +289,38 @@ OOVPA_XREF(CDirectSoundStream_Set3DVoiceData, 5455, 1 + 8,
     { 0x40, 0x68 },
     { 0x4F, 0xC2 },
     { 0x50, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_Set3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer (note: is not introduced in 5344)
-OOVPA_XREF(IDirectSoundStream_Set3DVoiceData, 5455, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_Set3DVoiceData,
+                      5455,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_Set3DVoiceData+0x00 : jmp [CDirectSoundStream_Set3DVoiceData]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_Set3DVoiceData),
 
     // IDirectSoundStream_Set3DVoiceData+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAudioCalculatePitch
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(XAudioCalculatePitch, 5455, 12,
+OOVPA_SIG_HEADER_XREF(XAudioCalculatePitch,
+                      5455,
 
-           XREF_XAudioCalculatePitch,
-           XRefZero)
-{
+                      XREF_XAudioCalculatePitch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
 
@@ -321,17 +342,19 @@ OOVPA_XREF(XAudioCalculatePitch, 5455, 12,
     // XAudioCalculatePitch+0x47 : retn 0x04
     { 0x47, 0xC2 },
     { 0x48, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CMcpxAPU::ServiceDeferredCommandsLow
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer; whole asm had not been changed since.
-OOVPA_XREF(CMcpxAPU_ServiceDeferredCommandsLow, 5455, 9,
+OOVPA_SIG_HEADER_XREF(CMcpxAPU_ServiceDeferredCommandsLow,
+                      5455,
 
-           XREF_CMcpxAPU_ServiceDeferredCommandsLow,
-           XRefZero)
-{
+                      XREF_CMcpxAPU_ServiceDeferredCommandsLow,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // CMcpxAPU_ServiceDeferredCommandsLow+0x00: push ebp; mov ebp,esp
     { 0x00, 0x55 },
@@ -347,17 +370,19 @@ OOVPA_XREF(CMcpxAPU_ServiceDeferredCommandsLow, 5455, 9,
     { 0x17, 0x89 },
     { 0x18, 0x45 },
     { 0x19, 0xF8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CMcpxVoiceClient::Commit3dSettings
 // ******************************************************************
 // Generic OOVPA as of 5455 and newer
-OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 5455, 2 + 9,
+OOVPA_SIG_HEADER_XREF(CMcpxVoiceClient_Commit3dSettings,
+                      5455,
 
-           XREF_CMcpxVoiceClient_Commit3dSettings,
-           XRefTwo)
-{
+                      XREF_CMcpxVoiceClient_Commit3dSettings,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     // CMcpxVoiceClient::Commit3dSettings+0x2B : call [CDirectSound3DCalculator::Calculate3D]
     XREF_ENTRY(0x2C, XREF_CDirectSound3DCalculator_Calculate3D),
@@ -383,4 +408,5 @@ OOVPA_XREF(CMcpxVoiceClient_Commit3dSettings, 5455, 2 + 9,
     //{ 0x6D, 0x00 },
     { 0x6E, 0x00 },
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/DSound/5558.inl
+++ b/src/OOVPADatabase/DSound/5558.inl
@@ -29,11 +29,12 @@
 // * DirectSound::CDirectSoundVoice::Use3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5558 and newer
-OOVPA_XREF(CDirectSoundVoice_Use3DVoiceData, 5558, 9,
+OOVPA_SIG_HEADER_XREF(CDirectSoundVoice_Use3DVoiceData,
+                      5558,
 
-           XREF_CDirectSoundVoice_Use3DVoiceData,
-           XRefZero)
-{
+                      XREF_CDirectSoundVoice_Use3DVoiceData,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x00 },
     { 0x07, 0x24 },
@@ -44,17 +45,19 @@ OOVPA_XREF(CDirectSoundVoice_Use3DVoiceData, 5558, 9,
     { 0x18, 0x33 },
     { 0x1A, 0xC2 },
     { 0x1B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundBuffer::Use3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5558 and newer
-OOVPA_XREF(CDirectSoundBuffer_Use3DVoiceData, 5558, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundBuffer_Use3DVoiceData,
+                      5558,
 
-           XREF_CDirectSoundBuffer_Use3DVoiceData,
-           XRefOne)
-{
+                      XREF_CDirectSoundBuffer_Use3DVoiceData,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x31, XREF_CDirectSoundVoice_Use3DVoiceData),
 
@@ -66,17 +69,19 @@ OOVPA_XREF(CDirectSoundBuffer_Use3DVoiceData, 5558, 1 + 8,
     { 0x3B, 0x68 },
     { 0x49, 0xC2 },
     { 0x4A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundBuffer::Use3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5558 and newer
-OOVPA_XREF(IDirectSoundBuffer_Use3DVoiceData, 5558, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IDirectSoundBuffer_Use3DVoiceData,
+                      5558,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_CDirectSoundBuffer_Use3DVoiceData),
 
@@ -88,17 +93,19 @@ OOVPA_XREF(IDirectSoundBuffer_Use3DVoiceData, 5558, 1 + 8,
     { 0x14, 0xE8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DirectSound::CDirectSoundStream::Use3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5558 and newer
-OOVPA_XREF(CDirectSoundStream_Use3DVoiceData, 5558, 1 + 8,
+OOVPA_SIG_HEADER_XREF(CDirectSoundStream_Use3DVoiceData,
+                      5558,
 
-           XREF_CDirectSoundStream_Use3DVoiceData,
-           XRefOne)
-{
+                      XREF_CDirectSoundStream_Use3DVoiceData,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x35, XREF_CDirectSoundVoice_Use3DVoiceData),
 
@@ -110,21 +117,24 @@ OOVPA_XREF(CDirectSoundStream_Use3DVoiceData, 5558, 1 + 8,
     { 0x3F, 0x68 },
     { 0x4D, 0xC2 },
     { 0x4E, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IDirectSoundStream_Use3DVoiceData
 // ******************************************************************
 // Generic OOVPA as of 5558 and newer
-OOVPA_XREF(IDirectSoundStream_Use3DVoiceData, 5558, 1 + 1,
+OOVPA_SIG_HEADER_XREF(IDirectSoundStream_Use3DVoiceData,
+                      5558,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IDirectSoundStream_Use3DVoiceData+0x00 : jmp [CDirectSoundStream_Use3DVoiceData]
     XREF_ENTRY(0x01, XREF_CDirectSoundStream_Use3DVoiceData),
 
     // IDirectSoundStream_Use3DVoiceData+0x00 : jmp 0x........
     { 0x00, 0xE9 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/JVS/4831.inl
+++ b/src/OOVPADatabase/JVS/4831.inl
@@ -23,12 +23,12 @@
 // *
 // ******************************************************************
 
-OOVPA_XREF(JVS_SendCommand_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JVS_SendCommand_String,
+                      4831,
 
-           XREF_JVS_SendCommand_String,
-           XRefZero)
-{
-
+                      XREF_JVS_SendCommand_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // JVS_STATUS_ERROR_DEVICE_NOT_CONNECTED2 from JVS_SendCommand
     OV_MATCH(0x00, 'J', 'V', 'S'),
     OV_MATCH(0x04, 'S'),
@@ -41,15 +41,16 @@ OOVPA_XREF(JVS_SendCommand_String, 4831, 13,
     OV_MATCH(0x2C, 'J'),
     OV_MATCH(0x30, 'S'),
     OV_MATCH(0x34, 'C'),
-} OOVPA_END;
+    //
+);
 
 
-OOVPA_XREF(JvsBACKUP_Read_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Read_String,
+                      4831,
 
-           XREF_JvsBACKUP_Read_String,
-           XRefZero)
-{
-
+                      XREF_JvsBACKUP_Read_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error <JvsBACKUP_Read>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -58,14 +59,15 @@ OOVPA_XREF(JvsBACKUP_Read_String, 4831, 13,
     OV_MATCH(0x18, 'R'),
     OV_MATCH(0x1B, 'd'),
     OV_MATCH(0x1C, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsBACKUP_Write_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Write_String,
+                      4831,
 
-           XREF_JvsBACKUP_Write_String,
-           XRefZero)
-{
-
+                      XREF_JvsBACKUP_Write_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error <JvsBACKUP_Write>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -74,14 +76,15 @@ OOVPA_XREF(JvsBACKUP_Write_String, 4831, 13,
     OV_MATCH(0x18, 'W'),
     OV_MATCH(0x1C, 'e'),
     OV_MATCH(0x1D, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsEEPROM_Read_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Read_String,
+                      4831,
 
-           XREF_JvsEEPROM_Read_String,
-           XRefZero)
-{
-
+                      XREF_JvsEEPROM_Read_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error <JvsEEPROM_Read>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -90,14 +93,15 @@ OOVPA_XREF(JvsEEPROM_Read_String, 4831, 13,
     OV_MATCH(0x18, 'R'),
     OV_MATCH(0x1B, 'd'),
     OV_MATCH(0x1C, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsEEPROM_Write_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Write_String,
+                      4831,
 
-           XREF_JvsEEPROM_Write_String,
-           XRefZero)
-{
-
+                      XREF_JvsEEPROM_Write_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error <JvsEEPROM_Write>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -106,14 +110,15 @@ OOVPA_XREF(JvsEEPROM_Write_String, 4831, 13,
     OV_MATCH(0x18, 'W'),
     OV_MATCH(0x1C, 'e'),
     OV_MATCH(0x1D, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsFirmwareDownload_String, 4831, 14,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareDownload_String,
+                      4831,
 
-           XREF_JvsFirmwareDownload_String,
-           XRefZero)
-{
-
+                      XREF_JvsFirmwareDownload_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error1 <JvsFirmwareDownload>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -123,14 +128,15 @@ OOVPA_XREF(JvsFirmwareDownload_String, 4831, 14,
     OV_MATCH(0x1A, 'D'),
     OV_MATCH(0x21, 'd'),
     OV_MATCH(0x22, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsNodeReceivePacket_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsNodeReceivePacket_String,
+                      4831,
 
-           XREF_JvsNodeReceivePacket_String,
-           XRefZero)
-{
-
+                      XREF_JvsNodeReceivePacket_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status waiting <JvsNodeReceivePacket>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -139,14 +145,15 @@ OOVPA_XREF(JvsNodeReceivePacket_String, 4831, 13,
     OV_MATCH(0x17, 'R'),
     OV_MATCH(0x1E, 'P'),
     OV_MATCH(0x24, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsRTC_Read_String, 4831, 12,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Read_String,
+                      4831,
 
-           XREF_JvsRTC_Read_String,
-           XRefZero)
-{
-
+                      XREF_JvsRTC_Read_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status wait <JvsRTC_Read>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -154,14 +161,15 @@ OOVPA_XREF(JvsRTC_Read_String, 4831, 12,
     OV_MATCH(0x10, 'R'),
     OV_MATCH(0x14, 'R'),
     OV_MATCH(0x18, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsRTC_Write_String, 4831, 12,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Write_String,
+                      4831,
 
-           XREF_JvsRTC_Write_String,
-           XRefZero)
-{
-
+                      XREF_JvsRTC_Write_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status wait <JvsRTC_Write>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -169,14 +177,15 @@ OOVPA_XREF(JvsRTC_Write_String, 4831, 12,
     OV_MATCH(0x10, 'R'),
     OV_MATCH(0x14, 'W'),
     OV_MATCH(0x19, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsNodeSendPacket_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsNodeSendPacket_String,
+                      4831,
 
-           XREF_JvsNodeSendPacket_String,
-           XRefZero)
-{
-
+                      XREF_JvsNodeSendPacket_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status waiting <JvsNodeSendPacket>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -185,14 +194,15 @@ OOVPA_XREF(JvsNodeSendPacket_String, 4831, 13,
     OV_MATCH(0x17, 'S'),
     OV_MATCH(0x1B, 'P'),
     OV_MATCH(0x21, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsFirmwareUpload_String, 4831, 14,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareUpload_String,
+                      4831,
 
-           XREF_JvsFirmwareUpload_String,
-           XRefZero)
-{
-
+                      XREF_JvsFirmwareUpload_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error1 <JvsFirmwareUpload>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -202,14 +212,15 @@ OOVPA_XREF(JvsFirmwareUpload_String, 4831, 14,
     OV_MATCH(0x1A, 'U'),
     OV_MATCH(0x1F, 'd'),
     OV_MATCH(0x20, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsScFirmwareDownload_String, 4831, 15,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareDownload_String,
+                      4831,
 
-           XREF_JvsScFirmwareDownload_String,
-           XRefZero)
-{
-
+                      XREF_JvsScFirmwareDownload_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error1 <JvsScFirmwareDownload>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -220,14 +231,15 @@ OOVPA_XREF(JvsScFirmwareDownload_String, 4831, 15,
     OV_MATCH(0x1C, 'D'),
     OV_MATCH(0x23, 'd'),
     OV_MATCH(0x24, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsScFirmwareUpload_String, 4831, 14,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareUpload_String,
+                      4831,
 
-           XREF_JvsScFirmwareUpload_String,
-           XRefZero)
-{
-
+                      XREF_JvsScFirmwareUpload_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status waiting <JvsScFirmwareUpload>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -237,14 +249,15 @@ OOVPA_XREF(JvsScFirmwareUpload_String, 4831, 14,
     OV_MATCH(0x1D, 'U'),
     OV_MATCH(0x22, 'd'),
     OV_MATCH(0x23, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsScReceiveMidi_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsScReceiveMidi_String,
+                      4831,
 
-           XREF_JvsScReceiveMidi_String,
-           XRefZero)
-{
-
+                      XREF_JvsScReceiveMidi_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status waiting <JvsScReceiveMidi>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -253,14 +266,15 @@ OOVPA_XREF(JvsScReceiveMidi_String, 4831, 13,
     OV_MATCH(0x15, 'R'),
     OV_MATCH(0x1C, 'M'),
     OV_MATCH(0x20, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsScReceiveRs323c_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsScReceiveRs323c_String,
+                      4831,
 
-           XREF_JvsScReceiveRs323c_String,
-           XRefZero)
-{
-
+                      XREF_JvsScReceiveRs323c_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error <JvsScReceiveRs323c>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -269,14 +283,15 @@ OOVPA_XREF(JvsScReceiveRs323c_String, 4831, 13,
     OV_MATCH(0x13, 'R'),
     OV_MATCH(0x1A, 'R'),
     OV_MATCH(0x20, '>'),
-} OOVPA_END;
+    //
+);
 
-OOVPA_XREF(JvsScSendMidi_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsScSendMidi_String,
+                      4831,
 
-           XREF_JvsScSendMidi_String,
-           XRefZero)
-{
-
+                      XREF_JvsScSendMidi_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status waiting <JvsScSendMidi>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'w'),
@@ -285,15 +300,16 @@ OOVPA_XREF(JvsScSendMidi_String, 4831, 13,
     OV_MATCH(0x15, 'S'),
     OV_MATCH(0x19, 'M'),
     OV_MATCH(0x1D, '>'),
-} OOVPA_END;
+    //
+);
 
 
-OOVPA_XREF(JvsScSendRs323c_String, 4831, 13,
+OOVPA_SIG_HEADER_XREF(JvsScSendRs323c_String,
+                      4831,
 
-           XREF_JvsScSendRs323c_String,
-           XRefZero)
-{
-
+                      XREF_JvsScSendRs323c_String,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     // Status error <JvsScSendRs323c>
     OV_MATCH(0x00, 'S', 't', 'a', 't', 'u', 's'),
     OV_MATCH(0x07, 'e'),
@@ -302,17 +318,18 @@ OOVPA_XREF(JvsScSendRs323c_String, 4831, 13,
     OV_MATCH(0x13, 'S'),
     OV_MATCH(0x17, 'R'),
     OV_MATCH(0x1D, '>'),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JVS_SendCommand
 // ******************************************************************
-OOVPA_XREF(JVS_SendCommand, 4831, 1 + 12,
+OOVPA_SIG_HEADER_XREF(JVS_SendCommand,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x250, XREF_JVS_SendCommand_String),
 
     OV_MATCH(0x00, 0x81, 0xEC),
@@ -328,51 +345,54 @@ OOVPA_XREF(JVS_SendCommand, 4831, 1 + 12,
     OV_MATCH(0x90, 0x0F),
 
     OV_MATCH(0x96, 0xA8),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JVS_SendCommand2
 // * Variation of JVS_SendCommand
 // ******************************************************************
-OOVPA_XREF(JVS_SendCommand2, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JVS_SendCommand2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x2C0, XREF_JVS_SendCommand_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x58, 0x53),
 
     OV_MATCH(0x86, 0x88, 0x44, 0x24, 0x70),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JVS_SendCommand3
 // * Variation of JVS_SendCommand
 // ******************************************************************
-OOVPA_XREF(JVS_SendCommand3, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JVS_SendCommand3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x28B, XREF_JVS_SendCommand_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x58, 0x53),
 
     OV_MATCH(0x86, 0x88, 0x44, 0x24, 0x70),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsBACKUP_Read
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Read, 4831, 1 + 9,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Read,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x6E, XREF_JvsBACKUP_Read_String),
 
     OV_MATCH(0x00, 0x8B),
@@ -384,19 +404,20 @@ OOVPA_XREF(JvsBACKUP_Read, 4831, 1 + 9,
     OV_MATCH(0x43, 0xBE, 0x00),
 
     OV_MATCH(0x4C, 0x05, 0x00),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsBACKUP_Read2
 // * Seems to be specfic to Crazy Taxi: Same function as above
 // * Very different code structure, needs different signature
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Read2, 4831, 1 + 9,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Read2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x6F, XREF_JvsBACKUP_Read_String),
 
     OV_MATCH(0x00, 0x53),
@@ -410,17 +431,18 @@ OOVPA_XREF(JvsBACKUP_Read2, 4831, 1 + 9,
     OV_MATCH(0x43, 0x55, 0x52),
 
     OV_MATCH(0x4C, 0x8D, 0x87),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsBACKUP_Read3
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Read3, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Read3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x5E, XREF_JvsBACKUP_Read_String),
 
     OV_MATCH(0x00, 0x8B),
@@ -428,17 +450,18 @@ OOVPA_XREF(JvsBACKUP_Read3, 4831, 1 + 5,
     OV_MATCH(0x43, 0xBE, 0x00),
 
     OV_MATCH(0x4C, 0x05, 0x00),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsBACKUP_Write
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Write, 4831, 1 + 15,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Write,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x6E, XREF_JvsBACKUP_Write_String),
 
     OV_MATCH(0x00, 0x8B, 0x44, 0x24, 0x04),
@@ -454,17 +477,18 @@ OOVPA_XREF(JvsBACKUP_Write, 4831, 1 + 15,
     OV_MATCH(0x31, 0x51, 0x6A),
 
     OV_MATCH(0x90, 0x0C, 0x2E),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsBACKUP_Write2
 // ******************************************************************
-OOVPA_XREF(JvsBACKUP_Write2, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsBACKUP_Write2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x5E, XREF_JvsBACKUP_Write_String),
 
     OV_MATCH(0x00, 0x8B),
@@ -472,18 +496,19 @@ OOVPA_XREF(JvsBACKUP_Write2, 4831, 1 + 5,
     OV_MATCH(0x43, 0xBE, 0x00),
 
     OV_MATCH(0x4C, 0x05, 0x00),
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * JvsEEPROM_Read
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Read, 4831, 1 + 9,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Read,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x188, XREF_JvsEEPROM_Read_String),
 
     OV_MATCH(0x00, 0x51),
@@ -495,18 +520,19 @@ OOVPA_XREF(JvsEEPROM_Read, 4831, 1 + 9,
     OV_MATCH(0x43, 0x6A, 0x17),
 
     OV_MATCH(0x4C, 0x6A, 0x40),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsEEPROM_Read2
 // * Almost identical to JvsEEPROM_Read, but some bytes are shifted
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Read2, 4831, 1 + 9,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Read2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1B0, XREF_JvsEEPROM_Read_String),
 
     OV_MATCH(0x00, 0x51),
@@ -518,17 +544,18 @@ OOVPA_XREF(JvsEEPROM_Read2, 4831, 1 + 9,
     OV_MATCH(0x43, 0x6A, 0x17),
 
     OV_MATCH(0x4C, 0x6A, 0x40),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsEEPROM_Read3
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Read3, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Read3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x199, XREF_JvsEEPROM_Read_String),
 
     OV_MATCH(0x00, 0x83),
@@ -540,18 +567,19 @@ OOVPA_XREF(JvsEEPROM_Read3, 4831, 1 + 5,
     OV_MATCH(0x48, 0x6A),
 
     OV_MATCH(0x4A, 0x8D),
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * JvsEEPROM_Write
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Write, 4831, 1 + 10,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Write,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x18E, XREF_JvsEEPROM_Write_String),
 
     OV_MATCH(0x13, 0x08),
@@ -563,18 +591,19 @@ OOVPA_XREF(JvsEEPROM_Write, 4831, 1 + 10,
     OV_MATCH(0x6B, 0xE1, 0xFF),
 
     OV_MATCH(0x70, 0x81, 0xFA),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsEEPROM_Write2
 // * Almost identical to JvsEEPROM_Write2, but some bytes are shifted
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Write2, 4831, 1 + 10,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Write2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1B6, XREF_JvsEEPROM_Write_String),
     OV_MATCH(0x12, 0x08),
 
@@ -585,33 +614,35 @@ OOVPA_XREF(JvsEEPROM_Write2, 4831, 1 + 10,
     OV_MATCH(0x6B, 0xE1, 0xFF),
 
     OV_MATCH(0x70, 0x81, 0xFA),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsEEPROM_Write3
 // ******************************************************************
-OOVPA_XREF(JvsEEPROM_Write3, 4831, 1 + 3,
+OOVPA_SIG_HEADER_XREF(JvsEEPROM_Write3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x199, XREF_JvsEEPROM_Write_String),
 
     OV_MATCH(0x00, 0x83, 0xEC),
 
     OV_MATCH(0x34, 0x8B),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsFirmwareDownload
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareDownload,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1D4, XREF_JvsFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
@@ -619,17 +650,18 @@ OOVPA_XREF(JvsFirmwareDownload, 4831, 1 + 8,
     OV_MATCH(0x0F, 0x83),
 
     OV_MATCH(0x58, 0x6A, 0x20),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsFirmwareDownload2
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload2, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareDownload2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x203, XREF_JvsFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
@@ -637,46 +669,49 @@ OOVPA_XREF(JvsFirmwareDownload2, 4831, 1 + 8,
     OV_MATCH(0x0F, 0x83),
 
     OV_MATCH(0x58, 0x6A, 0x20),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsFirmwareDownload3
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload3, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareDownload3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1E3, XREF_JvsFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * JvsFirmwareDownload4
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareDownload4, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareDownload4,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1CF, XREF_JvsFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsFirmwareUpload
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareUpload,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1B7, XREF_JvsFirmwareUpload_String),
 
     OV_MATCH(0x00, 0x83),
@@ -684,17 +719,18 @@ OOVPA_XREF(JvsFirmwareUpload, 4831, 1 + 8,
     OV_MATCH(0x12, 0x83, 0xF9, 0x20),
 
     OV_MATCH(0x40, 0x8D, 0x44, 0x24, 0x4C),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsFirmwareUpload2
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload2, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareUpload2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1DE, XREF_JvsFirmwareUpload_String),
 
     OV_MATCH(0x00, 0x83),
@@ -702,47 +738,50 @@ OOVPA_XREF(JvsFirmwareUpload2, 4831, 1 + 8,
     OV_MATCH(0x12, 0x83, 0xF9, 0x20),
 
     OV_MATCH(0x40, 0x8D, 0x44, 0x24, 0x4C),
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * JvsFirmwareUpload3
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload3, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareUpload3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1DA, XREF_JvsFirmwareUpload_String),
 
     OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
-} OOVPA_END;
+    //
+);
 
 
 // ******************************************************************
 // * JvsFirmwareUpload4
 // ******************************************************************
-OOVPA_XREF(JvsFirmwareUpload4, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsFirmwareUpload4,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1BF, XREF_JvsFirmwareUpload_String),
 
     OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsNodeReceivePacket
 // ******************************************************************
-OOVPA_XREF(JvsNodeReceivePacket, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsNodeReceivePacket,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x6D, XREF_JvsNodeReceivePacket_String),
 
     OV_MATCH(0x28, 0x6A, 0x19),
@@ -754,31 +793,33 @@ OOVPA_XREF(JvsNodeReceivePacket, 4831, 1 + 8,
     OV_MATCH(0x55, 0xC3, 0x01),
 
     OV_MATCH(0xC9, 0xC2),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsNodeReceivePacket2
 // ******************************************************************
-OOVPA_XREF(JvsNodeReceivePacket2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsNodeReceivePacket2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x55, XREF_JvsNodeReceivePacket_String),
 
     OV_MATCH(0x00, 0x53, 0x55, 0x56, 0x57),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsNodeSendPacket
 // ******************************************************************
-OOVPA_XREF(JvsNodeSendPacket, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsNodeSendPacket,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x6D, XREF_JvsNodeSendPacket_String),
 
     OV_MATCH(0x23, 0x6A, 0x20),
@@ -788,31 +829,33 @@ OOVPA_XREF(JvsNodeSendPacket, 4831, 1 + 8,
     OV_MATCH(0x54, 0xF6, 0xC3, 0x01),
 
     OV_MATCH(0xC9, 0xC2),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsNodeSendPacket2
 // ******************************************************************
-OOVPA_XREF(JvsNodeSendPacket2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsNodeSendPacket2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x55, XREF_JvsNodeSendPacket_String),
 
     OV_MATCH(0x00, 0x53, 0x55, 0x56, 0x57),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsRTC_Read
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Read, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Read,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x81, XREF_JvsRTC_Read_String),
 
     OV_MATCH(0x05, 0x00, 0x53),
@@ -820,17 +863,18 @@ OOVPA_XREF(JvsRTC_Read, 4831, 1 + 8,
     OV_MATCH(0x10, 0x1C, 0x8B, 0x6C, 0x24),
 
     OV_MATCH(0x2B, 0x55, 0xE8),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsRTC_Read2
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Read2, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Read2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x96, XREF_JvsRTC_Read_String),
 
     OV_MATCH(0x05, 0x00, 0x53),
@@ -838,17 +882,18 @@ OOVPA_XREF(JvsRTC_Read2, 4831, 1 + 8,
     OV_MATCH(0x10, 0x1C, 0x8B, 0x6C, 0x24),
 
     OV_MATCH(0x2B, 0x55, 0xE8),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsRTC_Read3
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Read3, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Read3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x68, XREF_JvsRTC_Read_String),
 
     OV_MATCH(0x00, 0x8B),
@@ -856,17 +901,18 @@ OOVPA_XREF(JvsRTC_Read3, 4831, 1 + 4,
     OV_MATCH(0x10, 0x8B),
 
     OV_MATCH(0x14, 0x56, 0x57),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareDownload
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareDownload,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1D4, XREF_JvsScFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
@@ -874,17 +920,18 @@ OOVPA_XREF(JvsScFirmwareDownload, 4831, 1 + 8,
     OV_MATCH(0x0F, 0x83),
 
     OV_MATCH(0x58, 0x6A, 0x20),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsRTC_Write
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Write, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Write,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x96, XREF_JvsRTC_Write_String),
 
     OV_MATCH(0x05, 0x00, 0x53),
@@ -892,17 +939,18 @@ OOVPA_XREF(JvsRTC_Write, 4831, 1 + 8,
     OV_MATCH(0x10, 0x1C, 0x8B, 0x6C, 0x24),
 
     OV_MATCH(0x2B, 0x55, 0xE8),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsRTC_Write2
 // ******************************************************************
-OOVPA_XREF(JvsRTC_Write2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsRTC_Write2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x68, XREF_JvsRTC_Write_String),
 
     OV_MATCH(0x00, 0x8B),
@@ -910,17 +958,18 @@ OOVPA_XREF(JvsRTC_Write2, 4831, 1 + 4,
     OV_MATCH(0x10, 0x8B),
 
     OV_MATCH(0x14, 0x56, 0x57),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareDownload2
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload2, 4831, 1 + 8,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareDownload2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x203, XREF_JvsScFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x4C, 0x24, 0x30, 0x53),
@@ -928,76 +977,81 @@ OOVPA_XREF(JvsScFirmwareDownload2, 4831, 1 + 8,
     OV_MATCH(0x0F, 0x83),
 
     OV_MATCH(0x58, 0x6A, 0x20),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareDownload3
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload3, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareDownload3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1E3, XREF_JvsScFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareDownload4
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareDownload4, 4831, 1 + 5,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareDownload4,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x1CF, XREF_JvsScFirmwareDownload_String),
 
     OV_MATCH(0x03, 0x8B, 0x44, 0x24, 0x30, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareUpload
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareUpload, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareUpload,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0xA9, XREF_JvsScFirmwareUpload_String),
 
     OV_MATCH(0x00, 0x51, 0x8B),
     OV_MATCH(0x05, 0x53, 0x8B),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareUpload2
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareUpload2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareUpload2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0xBE, XREF_JvsScFirmwareUpload_String),
 
     OV_MATCH(0x00, 0x51, 0x8B),
 
     OV_MATCH(0x05, 0x53, 0x8B),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScFirmwareUpload3
 // ******************************************************************
-OOVPA_XREF(JvsScFirmwareUpload3, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScFirmwareUpload3,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x9E, XREF_JvsScFirmwareUpload_String),
 
     OV_MATCH(0x00, 0x83),
@@ -1005,116 +1059,125 @@ OOVPA_XREF(JvsScFirmwareUpload3, 4831, 1 + 4,
     OV_MATCH(0x03, 0x8B),
 
     OV_MATCH(0x07, 0x53, 0x55),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScReceiveMidi
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveMidi, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScReceiveMidi,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x7D, XREF_JvsScReceiveMidi_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScReceiveMidi2
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveMidi2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScReceiveMidi2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x65, XREF_JvsScReceiveMidi_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScReceiveRs323c
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveRs323c, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScReceiveRs323c,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x63, XREF_JvsScReceiveRs323c_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x56),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScReceiveRs323c2
 // ******************************************************************
-OOVPA_XREF(JvsScReceiveRs323c2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScReceiveRs323c2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x4F, XREF_JvsScReceiveRs323c_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x56),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScSendMidi
 // ******************************************************************
-OOVPA_XREF(JvsScSendMidi, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScSendMidi,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x7D, XREF_JvsScSendMidi_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScSendMidi2
 // ******************************************************************
-OOVPA_XREF(JvsScSendMidi2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScSendMidi2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x5D, XREF_JvsScSendMidi_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x53),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScReceiveRs323c
 // ******************************************************************
-OOVPA_XREF(JvsScSendRs323c, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScSendRs323c,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x5E, XREF_JvsScSendRs323c_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0xC7),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * JvsScReceiveRs323c2
 // ******************************************************************
-OOVPA_XREF(JvsScSendRs323c2, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(JvsScSendRs323c2,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
-
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
     XREF_ENTRY(0x4D, XREF_JvsScSendRs323c_String),
 
     OV_MATCH(0x00, 0x83, 0xEC, 0x08, 0x56),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XActEng/4627.inl
+++ b/src/OOVPADatabase/XActEng/4627.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XACTEngineCreate
 // ******************************************************************
-OOVPA_NO_XREF(XACTEngineCreate, 4627, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XACTEngineCreate,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // XACTEngineCreate+0x0C : movzx ebx, al
     { 0x0C, 0x0F },
@@ -47,16 +48,18 @@ OOVPA_NO_XREF(XACTEngineCreate, 4627, 11)
     // XACTEngineCreate+0x9A : retn 0x8
     { 0x9A, 0xC2 },
     { 0x9B, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::RegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterWaveBank, 4627, 7,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterWaveBank,
+                      4627,
 
-           XREF_XACT_CEngine_RegisterWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x11, 0x33 },
     { 0x24, 0xC6 },
@@ -65,16 +68,18 @@ OOVPA_XREF(XACT_CEngine_RegisterWaveBank, 4627, 7,
     { 0x5D, 0x83 },
     { 0x70, 0x33 },
     { 0x84, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_RegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_RegisterWaveBank, 4627, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_RegisterWaveBank,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_XACT_CEngine_RegisterWaveBank),
 
@@ -85,13 +90,15 @@ OOVPA_XREF(IXACTEngine_RegisterWaveBank, 4627, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACTEngineDoWork
 // ******************************************************************
-OOVPA_NO_XREF(XACTEngineDoWork, 4627, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XACTEngineDoWork,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x0D, 0x85 },
@@ -100,16 +107,18 @@ OOVPA_NO_XREF(XACTEngineDoWork, 4627, 7)
     { 0x21, 0xFF },
     { 0x29, 0xFF },
     { 0x2F, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::RegisterStreamedWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterStreamedWaveBank, 4627, 8,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterStreamedWaveBank,
+                      4627,
 
-           XREF_XACT_CEngine_RegisterStreamedWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterStreamedWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x10, 0x01 },
     { 0x23, 0x3B },
@@ -119,16 +128,18 @@ OOVPA_XREF(XACT_CEngine_RegisterStreamedWaveBank, 4627, 8,
     { 0x6A, 0x41 },
     { 0x7C, 0x68 },
     { 0x8E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_RegisterStreamedWaveBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_RegisterStreamedWaveBank, 4627, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_RegisterStreamedWaveBank,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_XACT_CEngine_RegisterStreamedWaveBank),
 
@@ -140,16 +151,18 @@ OOVPA_XREF(IXACTEngine_RegisterStreamedWaveBank, 4627, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::CreateSoundBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_CreateSoundBank, 4627, 8,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_CreateSoundBank,
+                      4627,
 
-           XREF_XACT_CEngine_CreateSoundBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_CreateSoundBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0xA0 },
     { 0x1E, 0x8B },
@@ -159,16 +172,18 @@ OOVPA_XREF(XACT_CEngine_CreateSoundBank, 4627, 8,
     { 0x5E, 0xC7 },
     { 0x72, 0xFF },
     { 0x7E, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_CreateSoundBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_CreateSoundBank, 4627, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_CreateSoundBank,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1D, XREF_XACT_CEngine_CreateSoundBank),
 
@@ -179,16 +194,18 @@ OOVPA_XREF(IXACTEngine_CreateSoundBank, 4627, 1 + 7,
     { 0x17, 0x1B },
     { 0x1C, 0xE8 },
     { 0x21, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::DownloadEffectsImage
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_DownloadEffectsImage, 4627, 7,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_DownloadEffectsImage,
+                      4627,
 
-           XREF_XACT_CEngine_DownloadEffectsImage,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_DownloadEffectsImage,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     { 0x0B, 0x8B },
     { 0x12, 0xFF },
     { 0x1C, 0x46 },
@@ -196,16 +213,18 @@ OOVPA_XREF(XACT_CEngine_DownloadEffectsImage, 4627, 7,
     { 0x30, 0x89 },
     { 0x3A, 0x68 },
     { 0x45, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_DownloadEffectsImage
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_DownloadEffectsImage, 4627, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_DownloadEffectsImage,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_XACT_CEngine_DownloadEffectsImage),
 
@@ -217,16 +236,18 @@ OOVPA_XREF(IXACTEngine_DownloadEffectsImage, 4627, 1 + 8,
     { 0x1C, 0xC8 },
     { 0x23, 0x5D },
     { 0x26, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::CreateSoundSource
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_CreateSoundSource, 4627, 8,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_CreateSoundSource,
+                      4627,
 
-           XREF_XACT_CEngine_CreateSoundSource,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_CreateSoundSource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     { 0x0A, 0x0F },
     { 0x14, 0x8B },
     { 0x1F, 0x50 },
@@ -235,16 +256,18 @@ OOVPA_XREF(XACT_CEngine_CreateSoundSource, 4627, 8,
     { 0x40, 0x08 },
     { 0x4B, 0x15 },
     { 0x56, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_CreateSoundSource
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_CreateSoundSource, 4627, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_CreateSoundSource,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_XACT_CEngine_CreateSoundSource),
 
@@ -256,16 +279,18 @@ OOVPA_XREF(IXACTEngine_CreateSoundSource, 4627, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CSoundBank::GetSoundCueIndexFromFriendlyName
 // ******************************************************************
-OOVPA_XREF(XACT_CSoundBank_GetSoundCueIndexFromFriendlyName, 4627, 7,
+OOVPA_SIG_HEADER_XREF(XACT_CSoundBank_GetSoundCueIndexFromFriendlyName,
+                      4627,
 
-           XREF_XACT_CSoundBank_GetSoundCueIndexFromFriendlyName,
-           XRefZero)
-{
+                      XREF_XACT_CSoundBank_GetSoundCueIndexFromFriendlyName,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     { 0x12, 0x8B },
     { 0x22, 0x46 },
     { 0x34, 0x68 },
@@ -273,16 +298,18 @@ OOVPA_XREF(XACT_CSoundBank_GetSoundCueIndexFromFriendlyName, 4627, 7,
     { 0x58, 0x39 },
     { 0x6A, 0x45 },
     { 0x7E, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTSoundBank_GetSoundCueIndexFromFriendlyName
 // ******************************************************************
-OOVPA_XREF(IXACTSoundBank_GetSoundCueIndexFromFriendlyName, 4627, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTSoundBank_GetSoundCueIndexFromFriendlyName,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_XACT_CSoundBank_GetSoundCueIndexFromFriendlyName),
 
@@ -294,13 +321,15 @@ OOVPA_XREF(IXACTSoundBank_GetSoundCueIndexFromFriendlyName, 4627, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTSoundBank_Play
 // ******************************************************************
-OOVPA_NO_XREF(IXACTSoundBank_Play, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(IXACTSoundBank_Play,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0xFF },
     { 0x08, 0x08 },
@@ -310,16 +339,18 @@ OOVPA_NO_XREF(IXACTSoundBank_Play, 4627, 8)
     { 0x1C, 0xC8 },
     { 0x23, 0x5D },
     { 0x26, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::RegisterNotification
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterNotification, 4627, 7,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterNotification,
+                      4627,
 
-           XREF_XACT_CEngine_RegisterNotification,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterNotification,
+                      XRefZero)
+OOVPA_SIG_MATCH(
     { 0x07, 0x8B },
     { 0x0C, 0x01 },
     { 0x13, 0xF0 },
@@ -327,16 +358,18 @@ OOVPA_XREF(XACT_CEngine_RegisterNotification, 4627, 7,
     { 0x24, 0xFF },
     { 0x2A, 0x8B },
     { 0x2F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_RegisterNotification
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_RegisterNotification, 4627, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_RegisterNotification,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_XACT_CEngine_RegisterNotification),
 
@@ -347,16 +380,18 @@ OOVPA_XREF(IXACTEngine_RegisterNotification, 4627, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::GetNotification
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_GetNotification, 4627, 8,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_GetNotification,
+                      4627,
 
-           XREF_XACT_CEngine_GetNotification,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_GetNotification,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x11, 0x8D },
     { 0x24, 0x5A },
@@ -366,16 +401,18 @@ OOVPA_XREF(XACT_CEngine_GetNotification, 4627, 8,
     { 0x74, 0x8B },
     { 0x83, 0x40 },
     { 0x96, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_GetNotification
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_GetNotification, 4627, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_GetNotification,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x19, XREF_XACT_CEngine_GetNotification),
 
@@ -387,16 +424,18 @@ OOVPA_XREF(IXACTEngine_GetNotification, 4627, 1 + 8,
     { 0x16, 0xC8 },
     { 0x1D, 0xC2 },
     { 0x1E, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::UnRegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_UnRegisterWaveBank, 4627, 8,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_UnRegisterWaveBank,
+                      4627,
 
-           XREF_XACT_CEngine_UnRegisterWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_UnRegisterWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x8B },
     { 0x10, 0x58 },
@@ -406,16 +445,18 @@ OOVPA_XREF(XACT_CEngine_UnRegisterWaveBank, 4627, 8,
     { 0x34, 0x5F },
     { 0x3D, 0xFF },
     { 0x46, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_UnRegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_UnRegisterWaveBank, 4627, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_UnRegisterWaveBank,
+                      4627,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x15, XREF_XACT_CEngine_UnRegisterWaveBank),
 
@@ -426,4 +467,5 @@ OOVPA_XREF(IXACTEngine_UnRegisterWaveBank, 4627, 1 + 7,
     { 0x12, 0xC8 },
     { 0x19, 0xC2 },
     { 0x1A, 0x08 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XActEng/4928.inl
+++ b/src/OOVPADatabase/XActEng/4928.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XACTEngineCreate
 // ******************************************************************
-OOVPA_NO_XREF(XACTEngineCreate, 4928, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XACTEngineCreate,
+                         4928)
+OOVPA_SIG_MATCH(
 
     // XACTEngineCreate+0x09 : movzx ebx, al
     { 0x09, 0x0F },
@@ -47,16 +48,18 @@ OOVPA_NO_XREF(XACTEngineCreate, 4928, 11)
     // XACTEngineCreate+0x9E : retn 0x8
     { 0x9E, 0xC2 },
     { 0x9F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::RegisterStreamedWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterStreamedWaveBank, 4928, 11,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterStreamedWaveBank,
+                      4928,
 
-           XREF_XACT_CEngine_RegisterStreamedWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterStreamedWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x10 }, //RegisterStreamedWaveBank 0x10 vs RegisterWaveBank 0x14
     { 0x22, 0x8B },
@@ -71,16 +74,18 @@ OOVPA_XREF(XACT_CEngine_RegisterStreamedWaveBank, 4928, 11,
     { 0x3E, 0xE8 },
 
     { 0x64, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_RegisterStreamedWaveBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_RegisterStreamedWaveBank, 4928, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_RegisterStreamedWaveBank,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IXACTEngine_RegisterStreamedWaveBank+0x22 : call XACT::CEngine::RegisterStreamedWaveBank
     XREF_ENTRY(0x23, XREF_XACT_CEngine_RegisterStreamedWaveBank),
@@ -97,16 +102,18 @@ OOVPA_XREF(IXACTEngine_RegisterStreamedWaveBank, 4928, 1 + 9,
     // IXACTEngine_RegisterStreamedWaveBank+0x3C : retn 0x0C
     { 0x3C, 0xC2 },
     { 0x3D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::CreateSoundBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_CreateSoundBank, 4928, 11,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_CreateSoundBank,
+                      4928,
 
-           XREF_XACT_CEngine_CreateSoundBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_CreateSoundBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x85 },
     { 0x1F, 0x8B },
@@ -120,16 +127,18 @@ OOVPA_XREF(XACT_CEngine_CreateSoundBank, 4928, 11,
     { 0x55, 0x49 },
     { 0x56, 0x04 },
     { 0x57, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_CreateSoundBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_CreateSoundBank, 4928, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_CreateSoundBank,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x27, XREF_XACT_CEngine_CreateSoundBank),
 
@@ -145,16 +154,18 @@ OOVPA_XREF(IXACTEngine_CreateSoundBank, 4928, 1 + 9,
     // IXACTEngine_CreateSoundBank+0x40 : retn 0x10
     { 0x40, 0xC2 },
     { 0x41, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::UnRegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_UnRegisterWaveBank, 4928, 8,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_UnRegisterWaveBank,
+                      4928,
 
-           XREF_XACT_CEngine_UnRegisterWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_UnRegisterWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // XACT_CEngine_UnRegisterWaveBank+0x06 : lea eax, [ecx+0x58]
     { 0x06, 0x8D },
@@ -167,16 +178,18 @@ OOVPA_XREF(XACT_CEngine_UnRegisterWaveBank, 4928, 8,
     // XACT_CEngine_UnRegisterWaveBank+0xBF : retn 0x8
     { 0xBF, 0xC2 },
     { 0xC0, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_UnRegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_UnRegisterWaveBank, 4928, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_UnRegisterWaveBank,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // IXACTEngine_UnRegisterWaveBank+0x1E : call XACT::CEngine::UnRegisterWaveBank
     XREF_ENTRY(0x1F, XREF_XACT_CEngine_UnRegisterWaveBank),
@@ -188,16 +201,18 @@ OOVPA_XREF(IXACTEngine_UnRegisterWaveBank, 4928, 1 + 7,
     { 0x26, 0xF8 },
     { 0x2E, 0xFF },
     { 0x36, 0x5F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::CreateSoundSource
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_CreateSoundSource, 4928, 11,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_CreateSoundSource,
+                      4928,
 
-           XREF_XACT_CEngine_CreateSoundSource,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_CreateSoundSource,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0A, 0x8B },
     { 0x15, 0xE8 },
@@ -211,16 +226,18 @@ OOVPA_XREF(XACT_CEngine_CreateSoundSource, 4928, 11,
     { 0x32, 0x5E },
     { 0x33, 0x5D },
     { 0x34, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_CreateSoundSource
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_CreateSoundSource, 4928, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_CreateSoundSource,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x23, XREF_XACT_CEngine_CreateSoundSource),
 
@@ -232,16 +249,18 @@ OOVPA_XREF(IXACTEngine_CreateSoundSource, 4928, 1 + 8,
     { 0x20, 0xC8 },
     { 0x3C, 0xC2 },
     { 0x3D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_GetNotification
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_GetNotification, 4928, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_GetNotification,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x23, XREF_XACT_CEngine_GetNotification),
 
@@ -253,16 +272,18 @@ OOVPA_XREF(IXACTEngine_GetNotification, 4928, 1 + 8,
     { 0x20, 0xC8 },
     { 0x3C, 0xC2 },
     { 0x3D, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CSoundBank::GetSoundCueIndexFromFriendlyName
 // ******************************************************************
-OOVPA_XREF(XACT_CSoundBank_GetSoundCueIndexFromFriendlyName, 4928, 13,
+OOVPA_SIG_HEADER_XREF(XACT_CSoundBank_GetSoundCueIndexFromFriendlyName,
+                      4928,
 
-           XREF_XACT_CSoundBank_GetSoundCueIndexFromFriendlyName,
-           XRefZero)
-{
+                      XREF_XACT_CSoundBank_GetSoundCueIndexFromFriendlyName,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x51 },
     { 0x1F, 0x80 },
@@ -279,16 +300,18 @@ OOVPA_XREF(XACT_CSoundBank_GetSoundCueIndexFromFriendlyName, 4928, 13,
 
     { 0x4A, 0x03 },
     { 0x5F, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTSoundBank_GetSoundCueIndexFromFriendlyName
 // ******************************************************************
-OOVPA_XREF(IXACTSoundBank_GetSoundCueIndexFromFriendlyName, 4928, 1 + 8,
+OOVPA_SIG_HEADER_XREF(IXACTSoundBank_GetSoundCueIndexFromFriendlyName,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x17, XREF_XACT_CSoundBank_GetSoundCueIndexFromFriendlyName),
 
@@ -300,16 +323,18 @@ OOVPA_XREF(IXACTSoundBank_GetSoundCueIndexFromFriendlyName, 4928, 1 + 8,
     { 0x2C, 0x8B },
     { 0x30, 0xC2 },
     { 0x31, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_RegisterNotification
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_RegisterNotification, 4928, 1 + 7,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_RegisterNotification,
+                      4928,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_XACT_CEngine_RegisterNotification),
 
@@ -320,4 +345,5 @@ OOVPA_XREF(IXACTEngine_RegisterNotification, 4928, 1 + 7,
     { 0x1C, 0xC8 },
     { 0x38, 0xC2 },
     { 0x39, 0x08 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XActEng/5120.inl
+++ b/src/OOVPADatabase/XActEng/5120.inl
@@ -26,8 +26,9 @@
 // *****************************************************************
 // * XACTEngineCreate
 // ******************************************************************
-OOVPA_NO_XREF(XACTEngineCreate, 5120, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XACTEngineCreate,
+                         5120)
+OOVPA_SIG_MATCH(
 
     { 0x11, 0x85 },
     { 0x29, 0xEB },
@@ -43,16 +44,18 @@ OOVPA_NO_XREF(XACTEngineCreate, 5120, 12)
 
     { 0xA2, 0xC2 },
     { 0xA3, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::UnRegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_UnRegisterWaveBank, 5120, 13,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_UnRegisterWaveBank,
+                      5120,
 
-           XREF_XACT_CEngine_UnRegisterWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_UnRegisterWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x51 },
     { 0x1F, 0x00 },
@@ -69,16 +72,18 @@ OOVPA_XREF(XACT_CEngine_UnRegisterWaveBank, 5120, 13,
 
     { 0x45, 0xF6 },
     { 0x62, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::RegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterWaveBank, 5120, 12,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterWaveBank,
+                      5120,
 
-           XREF_XACT_CEngine_RegisterWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x14 }, //RegisterStreamedWaveBank 0x10 vs RegisterWaveBank 0x14
     { 0x17, 0x3B },
@@ -94,16 +99,18 @@ OOVPA_XREF(XACT_CEngine_RegisterWaveBank, 5120, 12,
 
     { 0x79, 0xC2 },
     { 0x7A, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_RegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_RegisterWaveBank, 5120, 1 + 9,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_RegisterWaveBank,
+                      5120,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x27, XREF_XACT_CEngine_RegisterWaveBank),
 
@@ -121,4 +128,5 @@ OOVPA_XREF(IXACTEngine_RegisterWaveBank, 5120, 1 + 9,
     // IXACTEngine_RegisterWaveBank+0x40 : retn 0x10
     { 0x40, 0xC2 },
     { 0x41, 0x10 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XActEng/5233.inl
+++ b/src/OOVPADatabase/XActEng/5233.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XACT::CEngine::RegisterStreamedWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterStreamedWaveBank, 5233, 11,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterStreamedWaveBank,
+                      5233,
 
-           XREF_XACT_CEngine_RegisterStreamedWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterStreamedWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x10 }, //RegisterStreamedWaveBank 0x10 vs RegisterWaveBank 0x14
     { 0x25, 0x8B },
@@ -45,16 +46,18 @@ OOVPA_XREF(XACT_CEngine_RegisterStreamedWaveBank, 5233, 11,
     { 0x41, 0xE8 },
 
     { 0x67, 0xEB },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CEngine::RegisterWaveBank
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_RegisterWaveBank, 5233, 12,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_RegisterWaveBank,
+                      5233,
 
-           XREF_XACT_CEngine_RegisterWaveBank,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_RegisterWaveBank,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x14 }, //RegisterStreamedWaveBank 0x10 vs RegisterWaveBank 0x14
     { 0x1A, 0x3B },
@@ -70,4 +73,5 @@ OOVPA_XREF(XACT_CEngine_RegisterWaveBank, 5233, 12,
 
     { 0x7C, 0xC2 },
     { 0x7D, 0x10 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XActEng/5344.inl
+++ b/src/OOVPADatabase/XActEng/5344.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XACT::CEngine::DownloadEffectsImage
 // ******************************************************************
-OOVPA_XREF(XACT_CEngine_DownloadEffectsImage, 5344, 12,
+OOVPA_SIG_HEADER_XREF(XACT_CEngine_DownloadEffectsImage,
+                      5344,
 
-           XREF_XACT_CEngine_DownloadEffectsImage,
-           XRefZero)
-{
+                      XREF_XACT_CEngine_DownloadEffectsImage,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -46,16 +47,18 @@ OOVPA_XREF(XACT_CEngine_DownloadEffectsImage, 5344, 12,
     { 0x1E, 0x85 },
     { 0x2A, 0xC2 },
     { 0x2B, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTEngine_DownloadEffectsImage
 // ******************************************************************
-OOVPA_XREF(IXACTEngine_DownloadEffectsImage, 5344, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IXACTEngine_DownloadEffectsImage,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x29, XREF_XACT_CEngine_DownloadEffectsImage),
 
@@ -71,16 +74,18 @@ OOVPA_XREF(IXACTEngine_DownloadEffectsImage, 5344, 1 + 10,
 
     { 0x43, 0xC2 },
     { 0x44, 0x14 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XACT::CSoundBank::Play
 // ******************************************************************
-OOVPA_XREF(XACT_CSoundBank_Play, 5344, 12,
+OOVPA_SIG_HEADER_XREF(XACT_CSoundBank_Play,
+                      5344,
 
-           XREF_XACT_CSoundBank_Play,
-           XRefZero)
-{
+                      XREF_XACT_CSoundBank_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x57 },
     { 0x1F, 0x89 },
@@ -96,16 +101,18 @@ OOVPA_XREF(XACT_CSoundBank_Play, 5344, 12,
 
     { 0x9B, 0x68 },
     { 0xA5, 0x83 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * IXACTSoundBank_PlayEx
 // ******************************************************************
-OOVPA_XREF(IXACTSoundBank_PlayEx, 5344, 1 + 10,
+OOVPA_SIG_HEADER_XREF(IXACTSoundBank_PlayEx,
+                      5344,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x17, XREF_XACT_CSoundBank_Play),
 
@@ -119,4 +126,5 @@ OOVPA_XREF(IXACTSoundBank_PlayEx, 5344, 1 + 10,
     { 0x1D, 0x8B },
     { 0x30, 0xC2 },
     { 0x31, 0x0C },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XActEng/5558.inl
+++ b/src/OOVPADatabase/XActEng/5558.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XACT::CSoundBank::Play
 // ******************************************************************
-OOVPA_XREF(XACT_CSoundBank_Play, 5558, 12,
+OOVPA_SIG_HEADER_XREF(XACT_CSoundBank_Play,
+                      5558,
 
-           XREF_XACT_CSoundBank_Play,
-           XRefZero)
-{
+                      XREF_XACT_CSoundBank_Play,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x06, 0x8B },
 
@@ -46,4 +47,5 @@ OOVPA_XREF(XACT_CSoundBank_Play, 5558, 12,
     { 0x27, 0x85 },
     { 0x3B, 0xE9 },
     { 0x55, 0x35 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XGraphic/3911.inl
+++ b/src/OOVPADatabase/XGraphic/3911.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XGIsSwizzledFormat
 // ******************************************************************
-OOVPA_NO_XREF(XGIsSwizzledFormat, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGIsSwizzledFormat,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x7F },
     { 0x10, 0x7C },
@@ -36,13 +37,15 @@ OOVPA_NO_XREF(XGIsSwizzledFormat, 3911, 7)
     { 0x2B, 0x83 },
     { 0x34, 0x0A },
     { 0x3D, 0x7F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGSwizzleRect
 // ******************************************************************
-OOVPA_NO_XREF(XGSwizzleRect, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSwizzleRect,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x03 },
     { 0x3E, 0x89 },
@@ -52,13 +55,15 @@ OOVPA_NO_XREF(XGSwizzleRect, 3911, 8)
     { 0xBE, 0xFF },
     { 0xDE, 0x89 },
     { 0xFE, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGSwizzleBox
 // ******************************************************************
-OOVPA_NO_XREF(XGSwizzleBox, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSwizzleBox,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x75 },
     { 0x3E, 0x4D },
@@ -68,13 +73,15 @@ OOVPA_NO_XREF(XGSwizzleBox, 3911, 8)
     { 0xC0, 0x83 },
     { 0xDE, 0xAF },
     { 0xFE, 0x45 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGUnswizzleRect
 // ******************************************************************
-OOVPA_NO_XREF(XGUnswizzleRect, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGUnswizzleRect,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x03 },
     { 0x3E, 0x00 },
@@ -84,13 +91,15 @@ OOVPA_NO_XREF(XGUnswizzleRect, 3911, 8)
     { 0xC1, 0xE9 },
     { 0xDE, 0x89 },
     { 0xFE, 0x60 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGWriteSurfaceOrTextureToXPR
 // ******************************************************************
-OOVPA_NO_XREF(XGWriteSurfaceOrTextureToXPR, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGWriteSurfaceOrTextureToXPR,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x0C, 0x08 },
     { 0x1E, 0x3D },
@@ -115,13 +124,15 @@ OOVPA_NO_XREF(XGWriteSurfaceOrTextureToXPR, 3911, 12)
     { 0x9E, 0xC2 },
     { 0xAE, 0x4D },
     { 0xBE, 0xF0 },*/
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGSetTextureHeader
 // ******************************************************************
-OOVPA_NO_XREF(XGSetTextureHeader, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSetTextureHeader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x75 },
     { 0x0A, 0x00 },
@@ -130,13 +141,15 @@ OOVPA_NO_XREF(XGSetTextureHeader, 3911, 7)
     { 0x1C, 0x75 },
     { 0x26, 0x5D },
     { 0x28, 0x24 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGUnswizzleBox
 // ******************************************************************
-OOVPA_NO_XREF(XGUnswizzleBox, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGUnswizzleBox,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x26 },
     { 0x3E, 0x55 },
@@ -146,14 +159,16 @@ OOVPA_NO_XREF(XGUnswizzleBox, 3911, 8)
     { 0xBE, 0x2C },
     { 0xDE, 0x24 },
     { 0xFE, 0x20 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGCompressRect
 // ******************************************************************
 //Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(XGCompressRect, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGCompressRect,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8D },
@@ -169,13 +184,15 @@ OOVPA_NO_XREF(XGCompressRect, 3911, 12)
 
     { 0xC0, 0x7E },
     { 0xC1, 0x01 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGSetIndexBufferHeader
 // ******************************************************************
-OOVPA_NO_XREF(XGSetIndexBufferHeader, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSetIndexBufferHeader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x44 },
     { 0x04, 0x8B },
@@ -192,13 +209,15 @@ OOVPA_NO_XREF(XGSetIndexBufferHeader, 3911, 13)
     { 0x10, 0x04 },
     { 0x11, 0xC2 },
     { 0x12, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGSetVertexBufferHeader
 // ******************************************************************
-OOVPA_NO_XREF(XGSetVertexBufferHeader, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSetVertexBufferHeader,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x44 },
     { 0x04, 0x8B },
@@ -215,4 +234,5 @@ OOVPA_NO_XREF(XGSetVertexBufferHeader, 3911, 13)
     { 0x10, 0x04 },
     { 0x11, 0xC2 },
     { 0x12, 0x18 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XGraphic/4134.inl
+++ b/src/OOVPADatabase/XGraphic/4134.inl
@@ -27,8 +27,9 @@
 // * XGSetVertexBufferHeader
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_NO_XREF(XGSetVertexBufferHeader, 4134, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSetVertexBufferHeader,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x44 },
     { 0x04, 0x8B },
@@ -46,14 +47,16 @@ OOVPA_NO_XREF(XGSetVertexBufferHeader, 4134, 15)
     { 0x14, 0x04 },
     { 0x15, 0xC2 },
     { 0x16, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGSetIndexBufferHeader
 // ******************************************************************
 //Generic OOVPA as of 4134 and newer.
-OOVPA_NO_XREF(XGSetIndexBufferHeader, 4134, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGSetIndexBufferHeader,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0x44 },
     { 0x04, 0x8B },
@@ -71,4 +74,5 @@ OOVPA_NO_XREF(XGSetIndexBufferHeader, 4134, 15)
     { 0x14, 0x04 },
     { 0x15, 0xC2 },
     { 0x16, 0x18 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XGraphic/4361.inl
+++ b/src/OOVPADatabase/XGraphic/4361.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XFONT_OpenBitmapFontFromMemory
 // ******************************************************************
-OOVPA_NO_XREF(XFONT_OpenBitmapFontFromMemory, 4361, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XFONT_OpenBitmapFontFromMemory,
+                         4361)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x75 },
     { 0x1A, 0x8B },
@@ -37,4 +38,5 @@ OOVPA_NO_XREF(XFONT_OpenBitmapFontFromMemory, 4361, 8)
     { 0x4C, 0x8B },
     { 0x59, 0x45 },
     { 0x66, 0x0C },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XNet/3911.inl
+++ b/src/OOVPADatabase/XNet/3911.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XNetStartup
 // ******************************************************************
-OOVPA_XREF(XNetStartup, 3911, 1 + 8,
+OOVPA_SIG_HEADER_XREF(XNetStartup,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // XNetStartup+0x07 : call [XnInit]
     XREF_ENTRY(0x07, XREF_XnInit),
@@ -48,16 +49,18 @@ OOVPA_XREF(XNetStartup, 3911, 1 + 8,
     // XNetStartup+0x0B : retn 0x04
     { 0x0B, 0xC2 },
     { 0x0C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * WSAStartup
 // ******************************************************************
-OOVPA_XREF(WSAStartup, 3911, 1 + 10,
+OOVPA_SIG_HEADER_XREF(WSAStartup,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // WSAStartup+0x07 : call [XnInit]
     XREF_ENTRY(0x07, XREF_XnInit),
@@ -75,17 +78,19 @@ OOVPA_XREF(WSAStartup, 3911, 1 + 10,
     { 0x1E, 0x02 },
     { 0x1F, 0x02 },
     { 0x20, 0x02 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XnInit
 // ******************************************************************
 // For only XNETS library, XNET library is different OOVPA.
-OOVPA_XREF(XnInit, 3911, 11,
+OOVPA_SIG_HEADER_XREF(XnInit,
+                      3911,
 
-           XREF_XnInit,
-           XRefZero)
-{
+                      XREF_XnInit,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // XnInit+0x31 : push 0x3554454E
     { 0x31, 0x68 },
@@ -103,13 +108,15 @@ OOVPA_XREF(XnInit, 3911, 11,
     // XnInit+0xBD : retn 0x08
     { 0xBD, 0xC2 },
     { 0xBE, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XNetGetEthernetLinkStatus
 // ******************************************************************
-OOVPA_NO_XREF(XNetGetEthernetLinkStatus, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XNetGetEthernetLinkStatus,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x01, 0x33 },
@@ -128,13 +135,15 @@ OOVPA_NO_XREF(XNetGetEthernetLinkStatus, 3911, 14)
     { 0x2C, 0x15 },
 
     { 0x3F, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::socket
 // ******************************************************************
-OOVPA_NO_XREF(socket, 3911, 9)
-{
+OOVPA_SIG_HEADER_NO_XREF(socket,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // socket+0x10 : push 0x276D
     { 0x10, 0x68 },
@@ -150,13 +159,15 @@ OOVPA_NO_XREF(socket, 3911, 9)
     { 0xD9, 0x89 },
     { 0xDA, 0x4E },
     { 0xDB, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::bind
 // ******************************************************************
-OOVPA_NO_XREF(bind, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(bind,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // bind+0x11 : push 0x276D
     { 0x11, 0x68 },
@@ -175,13 +186,15 @@ OOVPA_NO_XREF(bind, 3911, 10)
     // bind+0x80 : retn 0x0C
     { 0x80, 0xC2 },
     { 0x81, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::listen
 // ******************************************************************
-OOVPA_NO_XREF(listen, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(listen,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // listen+0x00 : push edi
     { 0x00, 0x57 },
@@ -202,13 +215,15 @@ OOVPA_NO_XREF(listen, 3911, 10)
     // listen+0x7F : retn 0x08
     { 0x7F, 0xC2 },
     { 0x80, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::ioctlsocket
 // ******************************************************************
-OOVPA_NO_XREF(ioctlsocket, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(ioctlsocket,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // ioctlsocket+0x00 : push ebp
     { 0x00, 0x55 },
@@ -230,14 +245,16 @@ OOVPA_NO_XREF(ioctlsocket, 3911, 11)
     // ioctlsocket+0xC5 : retn 0x0C
     { 0xC5, 0xC2 },
     { 0xC6, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::send
 // ******************************************************************
 //Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(send, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(send,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -254,13 +271,15 @@ OOVPA_NO_XREF(send, 3911, 14)
 
     { 0x12, 0x00 },
     { 0x1A, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::connect
 // ******************************************************************
-OOVPA_NO_XREF(connect, 3911, 14) // Up to 5028
-{
+OOVPA_SIG_HEADER_NO_XREF(connect,
+                         3911) // Up to 5028
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -277,14 +296,16 @@ OOVPA_NO_XREF(connect, 3911, 14) // Up to 5028
 
     { 0x12, 0x00 },
     { 0x19, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::recv
 // ******************************************************************
 //Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(recv, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(recv,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -301,4 +322,5 @@ OOVPA_NO_XREF(recv, 3911, 14)
 
     { 0x12, 0x00 },
     { 0x1A, 0x00 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XNet/4361.inl
+++ b/src/OOVPADatabase/XNet/4361.inl
@@ -27,11 +27,12 @@
 // * XnInit
 // ******************************************************************
 //Generic OOVPA as of 4361 and newer.
-OOVPA_XREF(XnInit, 4361, 15,
+OOVPA_SIG_HEADER_XREF(XnInit,
+                      4361,
 
-           XREF_XnInit,
-           XRefZero)
-{
+                      XREF_XnInit,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0xB9 },
@@ -52,16 +53,18 @@ OOVPA_XREF(XnInit, 4361, 15,
     { 0x23, 0xE8 },
     { 0x28, 0xEB },
     { 0x3F, 0x54 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * WSAStartup
 // ******************************************************************
-OOVPA_XREF(WSAStartup, 4361, 1 + 8,
+OOVPA_SIG_HEADER_XREF(WSAStartup,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // WSAStartup+0x0F : call [XnInit]
     XREF_ENTRY(0x14, XREF_XnInit),
@@ -77,16 +80,18 @@ OOVPA_XREF(WSAStartup, 4361, 1 + 8,
     { 0x05, 0x74 },
     { 0x06, 0x24 },
     { 0x07, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XNetStartup
 // ******************************************************************
-OOVPA_XREF(XNetStartup, 4361, 1 + 7,
+OOVPA_SIG_HEADER_XREF(XNetStartup,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // XNetStartup+0x0F : call [XnInit]
     XREF_ENTRY(0x10, XREF_XnInit),
@@ -107,4 +112,5 @@ OOVPA_XREF(XNetStartup, 4361, 1 + 7,
     // XNetStartup+0x14 : retn 0x04
     { 0x14, 0xC2 },
     { 0x15, 0x04 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XNet/4627.inl
+++ b/src/OOVPADatabase/XNet/4627.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * CXnSock::socket
 // ******************************************************************
-OOVPA_NO_XREF(socket, 4627, 14) // Up to 5344
-{
+OOVPA_SIG_HEADER_NO_XREF(socket,
+                         4627) // Up to 5344
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x01, 0x85 },
@@ -44,13 +45,15 @@ OOVPA_NO_XREF(socket, 4627, 14) // Up to 5344
 
     { 0x1E, 0xC8 },
     { 0x1F, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::connect
 // ******************************************************************
-OOVPA_NO_XREF(connect, 4627, 24)
-{
+OOVPA_SIG_HEADER_NO_XREF(connect,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // connect+0x00 : push ebp
     { 0x00, 0x55 },
@@ -91,13 +94,15 @@ OOVPA_NO_XREF(connect, 4627, 24)
     { 0xE6, 0xC2 },
     { 0xE7, 0x0C },
     { 0xE8, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::send
 // ******************************************************************
-OOVPA_NO_XREF(send, 4627, 24)
-{
+OOVPA_SIG_HEADER_NO_XREF(send,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // send+0x00 : push ebp
     { 0x00, 0x55 },
@@ -138,13 +143,15 @@ OOVPA_NO_XREF(send, 4627, 24)
     { 0x92, 0xC2 },
     { 0x93, 0x10 },
     { 0x94, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::recv
 // ******************************************************************
-OOVPA_NO_XREF(recv, 4627, 24)
-{
+OOVPA_SIG_HEADER_NO_XREF(recv,
+                         4627)
+OOVPA_SIG_MATCH(
 
     // recv+0x00 : push ebp
     { 0x00, 0x55 },
@@ -185,14 +192,16 @@ OOVPA_NO_XREF(recv, 4627, 24)
     { 0x8E, 0xC2 },
     { 0x8F, 0x10 },
     { 0x90, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::ioctlsocket
 // ******************************************************************
 //Generic OOVPA as of 4627 and newer.
-OOVPA_NO_XREF(ioctlsocket, 4627, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(ioctlsocket,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0C, 0x99 },
@@ -209,14 +218,16 @@ OOVPA_NO_XREF(ioctlsocket, 4627, 13)
     { 0x38, 0x87 },
 
     { 0x57, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::bind
 // ******************************************************************
 //Generic OOVPA as of 4627 and newer.
-OOVPA_NO_XREF(bind, 4627, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(bind,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x56 },
     { 0x1D, 0xE8 },
@@ -232,14 +243,16 @@ OOVPA_NO_XREF(bind, 4627, 12)
     { 0x38, 0x10 },
 
     { 0x53, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXnSock::listen
 // ******************************************************************
 //Generic OOVPA as of 4627 and newer.
-OOVPA_NO_XREF(listen, 4627, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(listen,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x57 },
     { 0x09, 0xBF },
@@ -256,13 +269,15 @@ OOVPA_NO_XREF(listen, 4627, 13)
     { 0x38, 0xA8 },
 
     { 0x55, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XNetGetEthernetLinkStatus
 // ******************************************************************
-OOVPA_NO_XREF(XNetGetEthernetLinkStatus, 4627, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XNetGetEthernetLinkStatus,
+                         4627)
+OOVPA_SIG_MATCH(
 
     { 0x08, 0x33 },
     { 0x10, 0x8A },
@@ -272,4 +287,5 @@ OOVPA_NO_XREF(XNetGetEthernetLinkStatus, 4627, 8)
     { 0x34, 0xF0 },
     { 0x3D, 0x24 },
     { 0x46, 0x5B },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XNet/5120.inl
+++ b/src/OOVPADatabase/XNet/5120.inl
@@ -27,8 +27,9 @@
 // * CXnSock::connect
 // ******************************************************************
 //Generic OOVPA as of 5120 and newer.
-OOVPA_NO_XREF(connect, 5120, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(connect,
+                         5120)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x19, 0xE8 },
@@ -44,4 +45,5 @@ OOVPA_NO_XREF(connect, 5120, 12)
     { 0x38, 0xE9 },
 
     { 0x61, 0xE8 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XNet/5455.inl
+++ b/src/OOVPADatabase/XNet/5455.inl
@@ -27,8 +27,9 @@
 // * CXnSock::socket
 // ******************************************************************
 //Generic OOVPA as of 5455 and newer.
-OOVPA_NO_XREF(socket, 5455, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(socket,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x51 },
     { 0x0A, 0xB9 },
@@ -41,4 +42,5 @@ OOVPA_NO_XREF(socket, 5455, 10)
     { 0xBD, 0x53 },
     { 0xBE, 0xFF },
     { 0xBF, 0x15 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/4361.inl
+++ b/src/OOVPADatabase/XOnline/4361.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 4361, 12,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      4361,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -46,16 +47,18 @@ OOVPA_XREF(CXo_XOnlineLogon, 4361, 12,
 
     { 0x24, 0xA8 },
     { 0x32, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(XOnlineLogon, 4361, 1 + 4,
+OOVPA_SIG_HEADER_XREF(XOnlineLogon,
+                      4361,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_CXo_XOnlineLogon),
 
@@ -63,4 +66,5 @@ OOVPA_XREF(XOnlineLogon, 4361, 1 + 4,
     { 0x01, 0x8B },
     { 0x02, 0xEC },
     { 0x0A, 0xE9 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/4627.inl
+++ b/src/OOVPADatabase/XOnline/4627.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XoUpdateLaunchNewImageInternal
 // ******************************************************************
-OOVPA_XREF(XoUpdateLaunchNewImageInternal, 4627, 11,
+OOVPA_SIG_HEADER_XREF(XoUpdateLaunchNewImageInternal,
+                      4627,
 
-           XREF_XoUpdateLaunchNewImageInternal,
-           XRefZero)
-{
+                      XREF_XoUpdateLaunchNewImageInternal,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x03, 0x81 },
@@ -45,16 +46,18 @@ OOVPA_XREF(XoUpdateLaunchNewImageInternal, 4627, 11,
     { 0x5F, 0x45 },
 
     { 0x65, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 4627, 13,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      4627,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -71,4 +74,5 @@ OOVPA_XREF(CXo_XOnlineLogon, 4627, 13,
     { 0x42, 0x73 },
     { 0x43, 0x68 },
     { 0x44, 0x68 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/4831.inl
+++ b/src/OOVPADatabase/XOnline/4831.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 4831, 15,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      4831,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -49,16 +50,18 @@ OOVPA_XREF(CXo_XOnlineLogon, 4831, 15,
     { 0x2A, 0x15 },
     { 0x2B, 0x80 },
     { 0x2C, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo::XOnlineMatchSearch
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSearch, 4831, 13,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSearch,
+                      4831,
 
-           XREF_CXo_XOnlineMatchSearch,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSearch,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -71,16 +74,18 @@ OOVPA_XREF(CXo_XOnlineMatchSearch, 4831, 13,
     // pop ebp
     // jmp ...
     OV_MATCH(0x0C, 0x5D, 0xC2, 0x1C, 0x00, 0x5D, 0xE9),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XOnlineMatchSearch
 // ******************************************************************
-OOVPA_XREF(XOnlineMatchSearch, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(XOnlineMatchSearch,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_CXo_XOnlineMatchSearch),
 
@@ -90,16 +95,18 @@ OOVPA_XREF(XOnlineMatchSearch, 4831, 1 + 4,
 
     // jmp ...
     OV_MATCH(0x0A, 0xE9),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo_XOnlineMatchSearchResultsLen
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSearchResultsLen, 4831, 14,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSearchResultsLen,
+                      4831,
 
-           XREF_CXo_XOnlineMatchSearchResultsLen,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSearchResultsLen,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // test ecx, ecx
     // jnz ...
@@ -115,16 +122,18 @@ OOVPA_XREF(CXo_XOnlineMatchSearchResultsLen, 4831, 14,
     // test esi, esi
     // push 54h
     OV_MATCH(0x10, 0x85, 0xF6, 0x6A, 0x54),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XOnlineMatchSearchResultsLen
 // ******************************************************************
-OOVPA_XREF(XOnlineMatchSearchResultsLen, 4831, 1 + 3,
+OOVPA_SIG_HEADER_XREF(XOnlineMatchSearchResultsLen,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x07, XREF_CXo_XOnlineMatchSearchResultsLen),
 
@@ -133,16 +142,18 @@ OOVPA_XREF(XOnlineMatchSearchResultsLen, 4831, 1 + 3,
 
     // jmp ...
     OV_MATCH(0x06, 0xE9),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo::XOnlineMatchSearchGetResults
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSearchGetResults, 4831, 12,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSearchGetResults,
+                      4831,
 
-           XREF_CXo_XOnlineMatchSearchGetResults,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSearchGetResults,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -154,16 +165,18 @@ OOVPA_XREF(CXo_XOnlineMatchSearchGetResults, 4831, 12,
     // mov dword ptr [ebp - 0x04], ...
     OV_MATCH(0x21, 0x89),
     OV_MATCH(0x23, 0xFC),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XOnlineMatchSearchGetResults
 // ******************************************************************
-OOVPA_XREF(XOnlineMatchSearchGetResults, 4831, 1 + 3,
+OOVPA_SIG_HEADER_XREF(XOnlineMatchSearchGetResults,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x07, XREF_CXo_XOnlineMatchSearchGetResults),
 
@@ -172,16 +185,18 @@ OOVPA_XREF(XOnlineMatchSearchGetResults, 4831, 1 + 3,
 
     // jmp ...
     OV_MATCH(0x06, 0xE9),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo::XOnlineMatchSessionUpdate
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSessionUpdate, 4831, 22,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSessionUpdate,
+                      4831,
 
-           XREF_CXo_XOnlineMatchSessionUpdate,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSessionUpdate,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -197,16 +212,18 @@ OOVPA_XREF(CXo_XOnlineMatchSessionUpdate, 4831, 22,
     OV_MATCH(0x14, 0xFF, 0x75, 0x24, 0xFF, 0x75, 0x20),
     // push dword ptr [ebp + param_6]
     OV_MATCH(0x1A, 0xFF, 0x75, 0x1C),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XOnlineMatchSessionUpdate
 // ******************************************************************
-OOVPA_XREF(XOnlineMatchSessionUpdate, 4831, 1 + 11,
+OOVPA_SIG_HEADER_XREF(XOnlineMatchSessionUpdate,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x28, XREF_CXo_XOnlineMatchSessionUpdate),
 
@@ -218,16 +235,18 @@ OOVPA_XREF(XOnlineMatchSessionUpdate, 4831, 1 + 11,
 
     // push dword ptr [ebp + param_9]
     OV_MATCH(0x0C, 0xFF, 0x75, 0x28),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo::XOnlineMatchSessionCreate
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSessionCreate, 4831, 12,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSessionCreate,
+                      4831,
 
-           XREF_CXo_XOnlineMatchSessionCreate,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSessionCreate,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -244,16 +263,18 @@ OOVPA_XREF(CXo_XOnlineMatchSessionCreate, 4831, 12,
 
     // jbe eip + 0x14
     OV_MATCH(0x30, 0x76, 0x14),
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XOnlineMatchSessionCreate
 // ******************************************************************
-OOVPA_XREF(XOnlineMatchSessionCreate, 4831, 1 + 4,
+OOVPA_SIG_HEADER_XREF(XOnlineMatchSessionCreate,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x0B, XREF_CXo_XOnlineMatchSessionCreate),
 
@@ -263,4 +284,5 @@ OOVPA_XREF(XOnlineMatchSessionCreate, 4831, 1 + 4,
 
     // jmp ...
     OV_MATCH(0x0A, 0xE9),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5028.inl
+++ b/src/OOVPADatabase/XOnline/5028.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 5028, 15,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      5028,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -49,4 +50,5 @@ OOVPA_XREF(CXo_XOnlineLogon, 5028, 15,
     { 0x2A, 0x15 },
     { 0x2B, 0x80 },
     { 0x2C, 0xE9 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5233.inl
+++ b/src/OOVPADatabase/XOnline/5233.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineMatchSessionUpdate
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSessionUpdate, 5233, 19,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSessionUpdate,
+                      5233,
 
-           XREF_CXo_XOnlineMatchSessionUpdate,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSessionUpdate,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -47,4 +48,5 @@ OOVPA_XREF(CXo_XOnlineMatchSessionUpdate, 5233, 19,
     OV_MATCH(0x11, 0x6A, 0x00, 0xFF, 0x75, 0x0C, 0x8B, 0xCE),
     // push dword ptr [ebp + param_1]
     OV_MATCH(0x18, 0xFF, 0x75, 0x08),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5455.inl
+++ b/src/OOVPADatabase/XOnline/5455.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 5455, 14,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      5455,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
     { 0x15, 0xE9 },
@@ -47,4 +48,5 @@ OOVPA_XREF(CXo_XOnlineLogon, 5455, 14,
     { 0x2C, 0x15 },
     { 0x2D, 0x80 },
     { 0x2E, 0xE9 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5558.inl
+++ b/src/OOVPADatabase/XOnline/5558.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 5558, 14,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      5558,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -49,4 +50,5 @@ OOVPA_XREF(CXo_XOnlineLogon, 5558, 14,
     { 0x30, 0x15 },
     { 0x31, 0x80 },
     { 0x32, 0xE9 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5659.inl
+++ b/src/OOVPADatabase/XOnline/5659.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XoUpdateLaunchNewImageInternal
 // ******************************************************************
-OOVPA_XREF(XoUpdateLaunchNewImageInternal, 5659, 11,
+OOVPA_SIG_HEADER_XREF(XoUpdateLaunchNewImageInternal,
+                      5659,
 
-           XREF_XoUpdateLaunchNewImageInternal,
-           XRefZero)
-{
+                      XREF_XoUpdateLaunchNewImageInternal,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x03, 0x81 },
@@ -45,4 +46,5 @@ OOVPA_XREF(XoUpdateLaunchNewImageInternal, 5659, 11,
     { 0x73, 0x45 },
 
     { 0x79, 0xE8 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5788.inl
+++ b/src/OOVPADatabase/XOnline/5788.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * XoUpdateLaunchNewImageInternal
 // ******************************************************************
-OOVPA_XREF(XoUpdateLaunchNewImageInternal, 5788, 16,
+OOVPA_SIG_HEADER_XREF(XoUpdateLaunchNewImageInternal,
+                      5788,
 
-           XREF_XoUpdateLaunchNewImageInternal,
-           XRefZero)
-{
+                      XREF_XoUpdateLaunchNewImageInternal,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -49,4 +50,5 @@ OOVPA_XREF(XoUpdateLaunchNewImageInternal, 5788, 16,
 
     { 0x6E, 0xEB },
     { 0x88, 0x3D },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/XOnline/5849.inl
+++ b/src/OOVPADatabase/XOnline/5849.inl
@@ -26,11 +26,12 @@
 // ******************************************************************
 // * CXo::XOnlineLogon
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineLogon, 5849, 15,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineLogon,
+                      5849,
 
-           XREF_CXo_XOnlineLogon,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineLogon,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
 
@@ -49,16 +50,18 @@ OOVPA_XREF(CXo_XOnlineLogon, 5849, 15,
     { 0x40, 0x15 },
     { 0x41, 0x80 },
     { 0x42, 0xE9 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CXo::XOnlineMatchSessionCreate
 // ******************************************************************
-OOVPA_XREF(CXo_XOnlineMatchSessionCreate, 5849, 12,
+OOVPA_SIG_HEADER_XREF(CXo_XOnlineMatchSessionCreate,
+                      5849,
 
-           XREF_CXo_XOnlineMatchSessionCreate,
-           XRefZero)
-{
+                      XREF_CXo_XOnlineMatchSessionCreate,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -75,4 +78,5 @@ OOVPA_XREF(CXo_XOnlineMatchSessionCreate, 5849, 12,
 
     // jbe eip + 0x12
     OV_MATCH(0x3E, 0x76, 0x12),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/3911.inl
+++ b/src/OOVPADatabase/Xapi/3911.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * GetExitCodeThread
 // ******************************************************************
-OOVPA_NO_XREF(GetExitCodeThread, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(GetExitCodeThread,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // GetExitCodeThread+0x03 : lea eax, [ebp+0x08]
     { 0x03, 0x8D },
@@ -47,7 +48,8 @@ OOVPA_NO_XREF(GetExitCodeThread, 3911, 11)
     // GetExitCodeThread+0x49 : retn 0x08
     { 0x49, 0xC2 },
     { 0x4A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInitDevices
@@ -55,8 +57,9 @@ OOVPA_NO_XREF(GetExitCodeThread, 3911, 11)
 // * NOTE: We are actually intercepting USBD_Init, because
 // *       XInitDevices Simply redirects to that function
 // ******************************************************************
-OOVPA_NO_XREF(XInitDevices, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInitDevices,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XInitDevices+0x03 : push 0xB4
     { 0x03, 0x68 },
@@ -75,13 +78,15 @@ OOVPA_NO_XREF(XInitDevices, 3911, 10)
     // XInitDevices+0x8B : retn 8
     { 0x8B, 0xC2 },
     { 0x8C, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CreateMutex
 // ******************************************************************
-OOVPA_NO_XREF(CreateMutex, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(CreateMutex,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // CreateMutex+0x03 : sub esp, 0x14
     { 0x03, 0x83 },
@@ -103,13 +108,15 @@ OOVPA_NO_XREF(CreateMutex, 3911, 13)
     { 0x47, 0x8B },
     { 0x48, 0x45 },
     { 0x49, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CreateThread
 // ******************************************************************
-OOVPA_NO_XREF(CreateThread, 3911, 21)
-{
+OOVPA_SIG_HEADER_NO_XREF(CreateThread,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -133,13 +140,15 @@ OOVPA_NO_XREF(CreateThread, 3911, 21)
 
     { 0x32, 0x50 },
     { 0x33, 0x6A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * SetThreadPriority
 // ******************************************************************
-OOVPA_NO_XREF(SetThreadPriority, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(SetThreadPriority,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // SetThreadPriority+0x0D : push [ebp+0x08]
     { 0x0D, 0xFF },
@@ -158,13 +167,15 @@ OOVPA_NO_XREF(SetThreadPriority, 3911, 10)
     { 0x26, 0x83 },
     { 0x27, 0xF8 },
     { 0x28, 0xF1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * OutputDebugStringA
 // ******************************************************************
-OOVPA_NO_XREF(OutputDebugStringA, 3911, 32)
-{
+OOVPA_SIG_HEADER_NO_XREF(OutputDebugStringA,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -198,13 +209,15 @@ OOVPA_NO_XREF(OutputDebugStringA, 3911, 32)
     { 0x1D, 0xF8 },
     { 0x1E, 0x40 },
     { 0x1F, 0x66 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiInitProcess
 // ******************************************************************
-OOVPA_NO_XREF(XapiInitProcess, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiInitProcess,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XapiInitProcess+0x03 : sub esp, 30h
     { 0x05, 0x30 },
@@ -220,13 +233,15 @@ OOVPA_NO_XREF(XapiInitProcess, 3911, 7)
     // XapiInitProcess+0x42 : jnz +0x0A
     { 0x42, 0x75 },
     { 0x43, 0x0A },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiBootDash
 // ******************************************************************
-OOVPA_NO_XREF(XapiBootDash, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiBootDash,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XapiBootDash+0x03 : sub esp, 0x0C00
     { 0x03, 0x81 },
@@ -246,13 +261,15 @@ OOVPA_NO_XREF(XapiBootDash, 3911, 11)
     // XapiBootDash+0x59 : retn 0x0C
     { 0x59, 0xC2 },
     { 0x5A, 0x0C },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XRegisterThreadNotifyRoutine
 // ******************************************************************
-OOVPA_NO_XREF(XRegisterThreadNotifyRoutine, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XRegisterThreadNotifyRoutine,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XRegisterThreadNotifyRoutine+0x0D : cmp [esp+0x0C], 0
     { 0x0D, 0x83 },
@@ -272,13 +289,15 @@ OOVPA_NO_XREF(XRegisterThreadNotifyRoutine, 3911, 11)
     // XRegisterThreadNotifyRoutine+0x46 : retn 0x08
     { 0x46, 0xC2 },
     { 0x47, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * GetTimeZoneInformation
 // ******************************************************************
-OOVPA_NO_XREF(GetTimeZoneInformation, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(GetTimeZoneInformation,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x05, 0x28 },
     { 0x2E, 0x28 },
@@ -287,14 +306,16 @@ OOVPA_NO_XREF(GetTimeZoneInformation, 3911, 7)
     { 0x8C, 0xC0 },
     { 0xB9, 0x80 },
     { 0xF7, 0x99 },
-} OOVPA_END;
+    //
+);
 
 // not necessary?
 // ******************************************************************
 // * XCalculateSignatureBegin
 // ******************************************************************
-OOVPA_NO_XREF(XCalculateSignatureBegin, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(XCalculateSignatureBegin,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XCalculateSignatureBegin+0x01 : push 0x7C; push 0
     { 0x01, 0x6A },
@@ -313,13 +334,15 @@ OOVPA_NO_XREF(XCalculateSignatureBegin, 3911, 10)
     // XCalculateSignatureBegin+0x3B : retn 0x04
     { 0x3B, 0xC2 },
     { 0x3C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGetDevices
 // ******************************************************************
-OOVPA_NO_XREF(XGetDevices, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGetDevices,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XGetDevices+0x07 : mov edx, [esp+arg_0]
     { 0x07, 0x8B },
@@ -344,13 +367,15 @@ OOVPA_NO_XREF(XGetDevices, 3911, 14)
     // XGetDevices+0x1F : retn 4
     { 0x1F, 0xC2 },
     { 0x20, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGetDeviceChanges
 // ******************************************************************
-OOVPA_NO_XREF(XGetDeviceChanges, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGetDeviceChanges,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XGetDeviceChanges+0x07 : xor eax, eax
     { 0x07, 0x33 },
@@ -367,13 +392,15 @@ OOVPA_NO_XREF(XGetDeviceChanges, 3911, 8)
     // XGetDeviceChanges+0x51 : mov cl, al
     { 0x51, 0x8A },
     { 0x52, 0xC8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputOpen
 // ******************************************************************
-OOVPA_NO_XREF(XInputOpen, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputOpen,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XInputOpen+0x20 : jmp +0x0B
     { 0x20, 0xEB },
@@ -395,16 +422,18 @@ OOVPA_NO_XREF(XInputOpen, 3911, 11)
     // XInputOpen+0x68 : push 0x57
     { 0x68, 0x6A },
     { 0x69, 0x57 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XID_fCloseDevice
 // ******************************************************************
-OOVPA_XREF(XID_fCloseDevice, 3911, 16,
+OOVPA_SIG_HEADER_XREF(XID_fCloseDevice,
+                      3911,
 
-           XREF_XID_fCloseDevice,
-           XRefZero)
-{
+                      XREF_XID_fCloseDevice,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -424,16 +453,18 @@ OOVPA_XREF(XID_fCloseDevice, 3911, 16,
 
     { 0x44, 0x8D },
     { 0x45, 0x45 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputClose
 // ******************************************************************
-OOVPA_XREF(XInputClose, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(XInputClose,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     // XInputClose+0x05 : call [fCloseDevice]
     XREF_ENTRY(0x05, XREF_XID_fCloseDevice),
@@ -450,13 +481,15 @@ OOVPA_XREF(XInputClose, 3911, 1 + 7,
     // XInputClose+0x09 : retn 0x04
     { 0x09, 0xC2 },
     { 0x0A, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputGetCapabilities
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetCapabilities, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetCapabilities,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x0F, 0x15 },
@@ -472,13 +505,15 @@ OOVPA_NO_XREF(XInputGetCapabilities, 3911, 13)
     { 0x3C, 0x46 },
     { 0x3D, 0x0B },
     { 0x3E, 0x88 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputGetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetState, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetState,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XInputGetState+0x0E : cmp byte ptr [edx+0x0A3], 1
     { 0x0E, 0x80 },
@@ -502,13 +537,15 @@ OOVPA_NO_XREF(XInputGetState, 3911, 13)
     // XInputGetState+0x6E : retn 8
     { 0x6E, 0xC2 },
     { 0x6F, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputSetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputSetState, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputSetState,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XInputSetState+0x04 : lea eax, [ecx+0x0A3]
     { 0x04, 0x8D },
@@ -531,13 +568,15 @@ OOVPA_NO_XREF(XInputSetState, 3911, 12)
     // XInputSetState+0x35 : retn 0x08
     { 0x35, 0xC2 },
     { 0x36, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * SetThreadPriorityBoost
 // ******************************************************************
-OOVPA_NO_XREF(SetThreadPriorityBoost, 3911, 10) // generic version
-{
+OOVPA_SIG_HEADER_NO_XREF(SetThreadPriorityBoost,
+                         3911) // generic version
+OOVPA_SIG_MATCH(
 
     // SetThreadPriorityBoost+0x0D : push [ebp+0x08]
     { 0x0D, 0xFF },
@@ -556,13 +595,15 @@ OOVPA_NO_XREF(SetThreadPriorityBoost, 3911, 10) // generic version
     // SetThreadPriorityBoost+0x2C : mov ecx, [ebp+0x08]
     { 0x2C, 0x8B },
     { 0x2D, 0x4D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * GetThreadPriority
 // ******************************************************************
-OOVPA_NO_XREF(GetThreadPriority, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(GetThreadPriority,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // GetThreadPriority+0x0D : push [ebp+0x08]
     { 0x0D, 0xFF },
@@ -581,13 +622,15 @@ OOVPA_NO_XREF(GetThreadPriority, 3911, 10)
     // GetThreadPriority+0x37 : mov ecx, [ebp+0x08]
     { 0x37, 0x8B },
     { 0x38, 0x4D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CreateFiber
 // ******************************************************************
-OOVPA_NO_XREF(CreateFiber, 3911, 32)
-{
+OOVPA_SIG_HEADER_NO_XREF(CreateFiber,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -621,13 +664,15 @@ OOVPA_NO_XREF(CreateFiber, 3911, 32)
     { 0x1D, 0xB0 },
     { 0x1E, 0xFF },
     { 0x1F, 0x0F },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * DeleteFiber
 // ******************************************************************
-OOVPA_NO_XREF(DeleteFiber, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(DeleteFiber,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x44 },
@@ -645,13 +690,15 @@ OOVPA_NO_XREF(DeleteFiber, 3911, 15)
     { 0x10, 0xC2 },
     { 0x11, 0x04 },
     { 0x12, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * SwitchToFiber
 // ******************************************************************
-OOVPA_NO_XREF(SwitchToFiber, 3911, 28)
-{
+OOVPA_SIG_HEADER_NO_XREF(SwitchToFiber,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x15 },
@@ -682,13 +729,15 @@ OOVPA_NO_XREF(SwitchToFiber, 3911, 28)
     { 0x1D, 0x14 },
     { 0x1E, 0x91 },
     { 0x1F, 0x8B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * ConvertThreadToFiber
 // ******************************************************************
-OOVPA_NO_XREF(ConvertThreadToFiber, 3911, 20)
-{
+OOVPA_SIG_HEADER_NO_XREF(ConvertThreadToFiber,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
 
@@ -713,13 +762,15 @@ OOVPA_NO_XREF(ConvertThreadToFiber, 3911, 20)
     { 0x1D, 0x28 },
     { 0x1E, 0x00 },
     { 0x1F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * SignalObjectAndWait
 // ******************************************************************
-OOVPA_NO_XREF(SignalObjectAndWait, 3911, 8) // generic version
-{
+OOVPA_SIG_HEADER_NO_XREF(SignalObjectAndWait,
+                         3911) // generic version
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x75 },
     { 0x12, 0x8B },
@@ -729,13 +780,15 @@ OOVPA_NO_XREF(SignalObjectAndWait, 3911, 8) // generic version
     { 0x34, 0x00 },
     { 0x3F, 0x83 },
     { 0x46, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * QueueUserAPC
 // ******************************************************************
-OOVPA_NO_XREF(QueueUserAPC, 3911, 7) // generic version
-{
+OOVPA_SIG_HEADER_NO_XREF(QueueUserAPC,
+                         3911) // generic version
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x74 },
     { 0x08, 0x24 },
@@ -744,13 +797,15 @@ OOVPA_NO_XREF(QueueUserAPC, 3911, 7) // generic version
     { 0x19, 0x33 },
     { 0x1C, 0xC0 },
     { 0x21, 0xC1 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * QueryPerformanceCounter
 // ******************************************************************
-OOVPA_NO_XREF(QueryPerformanceCounter, 3911, 17) // generic version
-{
+OOVPA_SIG_HEADER_NO_XREF(QueryPerformanceCounter,
+                         3911) // generic version
+OOVPA_SIG_MATCH(
     { 0x00, 0x8B },
     { 0x01, 0x4C },
     { 0x02, 0x24 },
@@ -768,13 +823,15 @@ OOVPA_NO_XREF(QueryPerformanceCounter, 3911, 17) // generic version
     { 0x0E, 0xC2 },
     { 0x0F, 0x04 },
     { 0x10, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * lstrcmpiW
 // ******************************************************************
-OOVPA_NO_XREF(lstrcmpiW, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(lstrcmpiW,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0x56 },
     { 0x0F, 0x01 },
@@ -784,13 +841,15 @@ OOVPA_NO_XREF(lstrcmpiW, 3911, 8)
     { 0x2D, 0x59 },
     { 0x34, 0xEB },
     { 0x3D, 0x03 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountAlternateTitleA
 // ******************************************************************
-OOVPA_NO_XREF(XMountAlternateTitleA, 3911, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XMountAlternateTitleA,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0xEC },
 
@@ -808,16 +867,18 @@ OOVPA_NO_XREF(XMountAlternateTitleA, 3911, 13)
     { 0x34, 0x09 },
 
     { 0x3D, 0xEC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XUnmountAlternateTitleA
 // ******************************************************************
-OOVPA_XREF(XUnmountAlternateTitleA, 3911, 7,
+OOVPA_SIG_HEADER_XREF(XUnmountAlternateTitleA,
+                      3911,
 
-           XREF_XUnmountAlternateTitleA,
-           XRefZero)
-{
+                      XREF_XUnmountAlternateTitleA,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x0A, 0x65 },
     { 0x16, 0xFF },
@@ -826,16 +887,18 @@ OOVPA_XREF(XUnmountAlternateTitleA, 3911, 7,
     { 0x3A, 0x50 },
     { 0x46, 0x0B },
     { 0x52, 0x50 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountMUA
 // ******************************************************************
-OOVPA_XREF(XMountMUA, 3911, 2 + 7,
+OOVPA_SIG_HEADER_XREF(XMountMUA,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2E, XREF_g_XapiMountedMUs), // derived
     XREF_ENTRY(0xCE, XREF_XapiMapLetterToDirectory),
@@ -847,13 +910,15 @@ OOVPA_XREF(XMountMUA, 3911, 2 + 7,
     { 0xA2, 0x0F },
     { 0xBE, 0x50 },
     { 0xDE, 0x74 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CloseHandle
 // ******************************************************************
-OOVPA_NO_XREF(CloseHandle, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(CloseHandle,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0x24 },
     { 0x03, 0x04 },
@@ -863,14 +928,16 @@ OOVPA_NO_XREF(CloseHandle, 3911, 8)
     { 0x12, 0x08 },
     { 0x19, 0x33 },
     { 0x1A, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // Generic OOVPA as of 3911 and newer.
 // ******************************************************************
 // * ExitThread
 // ******************************************************************
-OOVPA_NO_XREF(ExitThread, 3911, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(ExitThread,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x6A },
     { 0x01, 0x00 },
@@ -882,13 +949,15 @@ OOVPA_NO_XREF(ExitThread, 3911, 10)
     { 0x0B, 0xFF },
     { 0x0C, 0x15 },
     { 0x11, 0xCC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XLaunchNewImageA
 // ******************************************************************
-OOVPA_NO_XREF(XLaunchNewImageA, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(XLaunchNewImageA,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x1E, 0x80 },
     { 0x3E, 0xC0 },
@@ -898,13 +967,15 @@ OOVPA_NO_XREF(XLaunchNewImageA, 3911, 8)
     { 0xBE, 0x50 },
     { 0xDE, 0x05 },
     { 0xFE, 0x85 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGetLaunchInfo
 // ******************************************************************
-OOVPA_NO_XREF(XGetLaunchInfo, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGetLaunchInfo,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x8B },
     { 0x18, 0x15 },
@@ -913,14 +984,16 @@ OOVPA_NO_XREF(XGetLaunchInfo, 3911, 7)
     { 0x3F, 0x00 },
     { 0x4C, 0x83 },
     { 0x59, 0x5E },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGetSectionHandleA
 //   558BEC83EC10538B1D........5657FF75088D45F050FFD38B351C0101008B3D
 // ******************************************************************
-OOVPA_NO_XREF(XGetSectionHandleA, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGetSectionHandleA,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -935,14 +1008,16 @@ OOVPA_NO_XREF(XGetSectionHandleA, 3911, 12)
     { 0x0D, 0x56 },
     { 0x0E, 0x57 },
     { 0x0F, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XLoadSectionByHandle
 //  568B74240856FF15........85C07D0A50E8........33C0EB038B46045EC204
 // ******************************************************************
-OOVPA_NO_XREF(XLoadSectionByHandle, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XLoadSectionByHandle,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XLoadSectionByHandle+0x01 : mov esi, [esp+4+arg_0]
     { 0x01, 0x8B },
@@ -962,14 +1037,16 @@ OOVPA_NO_XREF(XLoadSectionByHandle, 3911, 11)
     // XLoadSectionByHandle+0x1E : retn 4
     { 0x1E, 0xC2 },
     { 0x1F, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFreeSectionByHandle
 // FF742404FF15........85C07D0A50E8........33C0EB0333C040C20400....
 // ******************************************************************
-OOVPA_NO_XREF(XFreeSectionByHandle, 3911, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XFreeSectionByHandle,
+                         3911)
+OOVPA_SIG_MATCH(
 
     // XFreeSectionByHandle+0x00 : push esp
     { 0x00, 0xFF },
@@ -991,14 +1068,16 @@ OOVPA_NO_XREF(XFreeSectionByHandle, 3911, 11)
     // XFreeSectionByHandle+0x1B : retn 4
     { 0x1B, 0xC2 },
     { 0x1C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XAutoPowerDownResetTimer
 // ******************************************************************
 // Assembly line at 0x00 and 0x09 are unique. It will prevent any false detection it might find in the future.
-OOVPA_NO_XREF(XAutoPowerDownResetTimer, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XAutoPowerDownResetTimer,
+                         3911)
+OOVPA_SIG_MATCH(
 
     //XAutoPowerDownResetTimer+0x00 : push 0FFFFFFCDh
     { 0x00, 0x6A },
@@ -1024,16 +1103,18 @@ OOVPA_NO_XREF(XAutoPowerDownResetTimer, 3911, 12)
 
     //XAutoPowerDownResetTimer+0x1A : ret
     { 0x1A, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountMURootA
 // ******************************************************************
-OOVPA_XREF(XMountMURootA, 3911, 1 + 7,
+OOVPA_SIG_HEADER_XREF(XMountMURootA,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2D, XREF_g_XapiMountedMUs), // derived
 
@@ -1044,13 +1125,15 @@ OOVPA_XREF(XMountMURootA, 3911, 1 + 7,
     { 0x9E, 0x00 },
     { 0xBE, 0xFF },
     { 0xDE, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountUtilityDrive
 // ******************************************************************
-OOVPA_NO_XREF(XMountUtilityDrive, 3911, 26)
-{
+OOVPA_SIG_HEADER_NO_XREF(XMountUtilityDrive,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1079,13 +1162,15 @@ OOVPA_NO_XREF(XMountUtilityDrive, 3911, 26)
 
     { 0x56, 0x83 },
     { 0x57, 0xC4 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * ReadFileEx@20
 // ******************************************************************
-OOVPA_NO_XREF(ReadFileEx, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(ReadFileEx,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x48 },
     { 0x14, 0x8D },
@@ -1095,13 +1180,15 @@ OOVPA_NO_XREF(ReadFileEx, 3911, 8)
     { 0x35, 0x00 },
     { 0x40, 0x50 },
     { 0x4B, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * WriteFileEx
 // ******************************************************************
-OOVPA_NO_XREF(WriteFileEx, 3911, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(WriteFileEx,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x48 },
     { 0x14, 0x8D },
@@ -1111,13 +1198,15 @@ OOVPA_NO_XREF(WriteFileEx, 3911, 8)
     { 0x35, 0x00 },
     { 0x40, 0x50 },
     { 0x4B, 0xC0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputPoll
 // ******************************************************************
-OOVPA_NO_XREF(XInputPoll, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputPoll,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x56 },
@@ -1134,13 +1223,15 @@ OOVPA_NO_XREF(XInputPoll, 3911, 14)
     { 0x1D, 0x80 },
     { 0x1E, 0xA2 },
     { 0x1F, 0x00 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * timeSetEvent
 // ******************************************************************
-OOVPA_NO_XREF(timeSetEvent, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(timeSetEvent,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1156,13 +1247,15 @@ OOVPA_NO_XREF(timeSetEvent, 3911, 12)
 
     { 0x2A, 0x45 },
     { 0x55, 0x53 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * timeKillEvent
 // ******************************************************************
-OOVPA_NO_XREF(timeKillEvent, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(timeKillEvent,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xBF },
     { 0x13, 0x0D },
@@ -1178,13 +1271,15 @@ OOVPA_NO_XREF(timeKillEvent, 3911, 12)
 
     { 0x4A, 0x6A },
     { 0x55, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * GetOverlappedResult
 // ******************************************************************
-OOVPA_NO_XREF(GetOverlappedResult, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(GetOverlappedResult,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x75 },
     { 0x18, 0xC0 },
@@ -1193,13 +1288,15 @@ OOVPA_NO_XREF(GetOverlappedResult, 3911, 7)
     { 0x3F, 0xEB },
     { 0x4C, 0x89 },
     { 0x59, 0x56 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * RaiseException
 // ******************************************************************
-OOVPA_NO_XREF(RaiseException, 3911, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(RaiseException,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x09, 0x83 },
     { 0x14, 0x8B },
@@ -1208,14 +1305,16 @@ OOVPA_NO_XREF(RaiseException, 3911, 7)
     { 0x35, 0x89 },
     { 0x40, 0x5F },
     { 0x4B, 0xFF },
-} OOVPA_END;
+    //
+);
 
 // Generic OOVPA as of 3911 and newer.
 // ******************************************************************
 // * SwitchToThread
 // ******************************************************************
-OOVPA_NO_XREF(SwitchToThread, 3911, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(SwitchToThread,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xFF },
     { 0x01, 0x15 },
@@ -1232,14 +1331,16 @@ OOVPA_NO_XREF(SwitchToThread, 3911, 15)
     { 0x10, 0x8B },
     { 0x11, 0xC1 },
     { 0x12, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiThreadStartup
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_NO_XREF(XapiThreadStartup, 3911, 17)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiThreadStartup,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x6A },
     { 0x01, 0x18 },
@@ -1260,14 +1361,16 @@ OOVPA_NO_XREF(XapiThreadStartup, 3911, 17)
     //{ 0x18, 0xE4 }, 3911 0xE4 vs 5558 0xE0
 
     { 0x1F, 0x89 },
-} OOVPA_END;
+    //
+);
 
 // Generic OOVPA as of 3911 and newer.
 // ******************************************************************
 // * MoveFileA
 // ******************************************************************
-OOVPA_NO_XREF(MoveFileA, 3911, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(MoveFileA,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -1282,14 +1385,16 @@ OOVPA_NO_XREF(MoveFileA, 3911, 12)
     { 0x1F, 0x8D },
     { 0x93, 0xC2 },
     { 0x94, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // Generic OOVPA as of 3911 and newer.
 // ******************************************************************
 // * XapiFiberStartup
 // ******************************************************************
-OOVPA_NO_XREF(XapiFiberStartup, 3911, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiFiberStartup,
+                         3911)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x6A },
     { 0x01, 0x08 },
@@ -1307,16 +1412,18 @@ OOVPA_NO_XREF(XapiFiberStartup, 3911, 14)
     { 0x2F, 0xE8 },
 
     { 0x44, 0xCC },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XUnmountMU
 // ******************************************************************
-OOVPA_XREF(XUnmountMU, 3911, 2 + 9,
+OOVPA_SIG_HEADER_XREF(XUnmountMU,
+                      3911,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x1F, XREF_g_XapiMountedMUs), // derived
     XREF_ENTRY(0x38, XREF_XUnmountAlternateTitleA),
@@ -1330,16 +1437,18 @@ OOVPA_XREF(XUnmountMU, 3911, 2 + 9,
     // xor edi, edi
     OV_MATCH(0x5D, 0x6A, 0x20, 0x6A, 0x01, 0x33, 0xFF),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * MU_Init
 // ******************************************************************
-OOVPA_XREF(MU_Init, 3911, 14,
+OOVPA_SIG_HEADER_XREF(MU_Init,
+                      3911,
 
-           XREF_MU_Init,
-           XRefZero)
-{
+                      XREF_MU_Init,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -1352,17 +1461,19 @@ OOVPA_XREF(MU_Init, 3911, 14,
     // lea eax, [ebp-0x10]
     OV_MATCH(0x95, 0x50, 0x6A, 0x00, 0x6A, 0x3A, 0x8D, 0x45, 0xF0),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiMapLetterToDirectory
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(XapiMapLetterToDirectory, 3911, 15,
+OOVPA_SIG_HEADER_XREF(XapiMapLetterToDirectory,
+                      3911,
 
-           XREF_XapiMapLetterToDirectory,
-           XRefZero)
-{
+                      XREF_XapiMapLetterToDirectory,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -1374,17 +1485,19 @@ OOVPA_XREF(XapiMapLetterToDirectory, 3911, 15,
     // mov edi, 0x80
     OV_MATCH(0x14, 0x6A, 0x03, 0x6A, 0x03, 0xBF, 0x80, 0x00 /*, 0x00, 0x00*/),
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiMapLetterToDirectory
 // ******************************************************************
 // Generic OOVPA as of 3911 and newer.
-OOVPA_XREF(IUsbInit_GetMaxDeviceTypeCount, 3911, 12,
+OOVPA_SIG_HEADER_XREF(IUsbInit_GetMaxDeviceTypeCount,
+                      3911,
 
-           XREF_IUsbInit_GetMaxDeviceTypeCount,
-           XRefZero)
-{
+                      XREF_IUsbInit_GetMaxDeviceTypeCount,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // mov edx, [ecx + 0x9C]
     OV_MATCH(0x00, 0x8B, 0x91, 0x9C, 0x00, 0x00 /*, 0x00*/),
@@ -1395,4 +1508,5 @@ OOVPA_XREF(IUsbInit_GetMaxDeviceTypeCount, 3911, 12,
     // ret 0x4
     OV_MATCH(0x2E, 0xC2, 0x04 /*, 0x00*/)
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/3950.inl
+++ b/src/OOVPADatabase/Xapi/3950.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XapiInitProcess
 // ******************************************************************
-OOVPA_NO_XREF(XapiInitProcess, 3950, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiInitProcess,
+                         3950)
+OOVPA_SIG_MATCH(
 
     // XapiInitProcess+0x03 : sub esp, 30h
     { 0x05, 0x30 },
@@ -43,4 +44,5 @@ OOVPA_NO_XREF(XapiInitProcess, 3950, 7)
     // XapiInitProcess+0x42 : jnz +0x0A
     { 0x43, 0x75 },
     { 0x44, 0x0A },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4039.inl
+++ b/src/OOVPADatabase/Xapi/4039.inl
@@ -27,8 +27,9 @@
 // ******************************************************************
 // * XCalculateSignatureBegin
 // ******************************************************************
-OOVPA_NO_XREF(XCalculateSignatureBegin, 4039, 16)
-{
+OOVPA_SIG_HEADER_NO_XREF(XCalculateSignatureBegin,
+                         4039)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xA1 },
     { 0x01, 0x18 },
@@ -47,4 +48,5 @@ OOVPA_NO_XREF(XCalculateSignatureBegin, 4039, 16)
     { 0x11, 0xC2 },
     { 0x12, 0x04 },
     { 0x13, 0x00 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4134.inl
+++ b/src/OOVPADatabase/Xapi/4134.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XMountUtilityDrive
 // ******************************************************************
-OOVPA_NO_XREF(XMountUtilityDrive, 4134, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(XMountUtilityDrive,
+                         4134)
+OOVPA_SIG_MATCH(
 
     // XMountUtilityDrive+0x03 : sub esp, 0x0114
     { 0x03, 0x81 },
@@ -44,13 +45,15 @@ OOVPA_NO_XREF(XMountUtilityDrive, 4134, 10)
     { 0xAA, 0x8D },
     { 0xAB, 0x45 },
     { 0xAC, 0xF0 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XSetProcessQuantumLength
 // ******************************************************************
-OOVPA_NO_XREF(XSetProcessQuantumLength, 4134, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XSetProcessQuantumLength,
+                         4134)
+OOVPA_SIG_MATCH(
 
     { 0x01, 0xA1 },
     { 0x04, 0x00 },
@@ -59,16 +62,18 @@ OOVPA_NO_XREF(XSetProcessQuantumLength, 4134, 7)
     { 0x0D, 0x8D },
     { 0x10, 0x89 },
     { 0x13, 0xC2 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * GetTypeInformation
 // ******************************************************************
-OOVPA_XREF(GetTypeInformation, 4134, 24,
+OOVPA_SIG_HEADER_XREF(GetTypeInformation,
+                      4134,
 
-           XREF_XAPI_GetTypeInformation,
-           XRefZero)
-{
+                      XREF_XAPI_GetTypeInformation,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xB8 },
     { 0x05, 0x56 },
@@ -94,4 +99,5 @@ OOVPA_XREF(GetTypeInformation, 4134, 24,
     { 0x1D, 0xC0 },
     { 0x1E, 0x04 },
     { 0x1F, 0x3B },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4242.inl
+++ b/src/OOVPADatabase/Xapi/4242.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XInputOpen
 // ******************************************************************
-OOVPA_NO_XREF(XInputOpen, 4242, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputOpen,
+                         4242)
+OOVPA_SIG_MATCH(
 
     // XInputOpen+0x14 : push 0x57
     { 0x14, 0x6A },
@@ -52,13 +53,15 @@ OOVPA_NO_XREF(XInputOpen, 4242, 12)
     // XInputOpen+0x53 : retn 0x10
     { 0x53, 0xC2 },
     { 0x54, 0x10 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputGetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetState, 4242, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetState,
+                         4242)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x53 },
     { 0x01, 0x56 },
@@ -75,13 +78,15 @@ OOVPA_NO_XREF(XInputGetState, 4242, 13)
     { 0x13, 0x00 },
 
     { 0x5B, 0xF3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputSetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputSetState, 4242, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputSetState,
+                         4242)
+OOVPA_SIG_MATCH(
 
     // XInputSetState+0x04 : lea eax, [ecx+0x0A3]
     { 0x04, 0x8D },
@@ -104,16 +109,18 @@ OOVPA_NO_XREF(XInputSetState, 4242, 12)
     // XInputSetState+0x33 : retn 0x08
     { 0x33, 0xC2 },
     { 0x34, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountMUA
 // ******************************************************************
-OOVPA_XREF(XMountMUA, 4242, 2 + 8,
+OOVPA_SIG_HEADER_XREF(XMountMUA,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_g_XapiMountedMUs), // derived
     XREF_ENTRY(0xE7, XREF_XapiMapLetterToDirectory),
@@ -126,13 +133,15 @@ OOVPA_XREF(XMountMUA, 4242, 2 + 8,
     { 0xBE, 0xF8 },
     { 0xDE, 0x8D },
     { 0xFE, 0x09 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XFormatUtilityDrive
 // ******************************************************************
-OOVPA_NO_XREF(XFormatUtilityDrive, 4242, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XFormatUtilityDrive,
+                         4242)
+OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
     { 0x10, 0x50 },
@@ -148,16 +157,18 @@ OOVPA_NO_XREF(XFormatUtilityDrive, 4242, 12)
     { 0x47, 0xF4 },
 
     { 0x6D, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountMURootA
 // ******************************************************************
-OOVPA_XREF(XMountMURootA, 4242, 1 + 12,
+OOVPA_SIG_HEADER_XREF(XMountMURootA,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x3A, XREF_g_XapiMountedMUs), // derived
 
@@ -175,13 +186,15 @@ OOVPA_XREF(XMountMURootA, 4242, 1 + 12,
     { 0x57, 0x66 },
 
     { 0x72, 0xE8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiInitProcess
 // ******************************************************************
-OOVPA_NO_XREF(XapiInitProcess, 4242, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiInitProcess,
+                         4242)
+OOVPA_SIG_MATCH(
 
     // XapiInitProcess+0x03 : sub esp, 30h
     { 0x05, 0x30 },
@@ -197,17 +210,19 @@ OOVPA_NO_XREF(XapiInitProcess, 4242, 7)
     // XapiInitProcess+0x42 : jnz +0x0B
     { 0x42, 0x75 },
     { 0x43, 0x0B },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XUnmountMU
 // ******************************************************************
 // Generic OOVPA as of 4242 and newer.
-OOVPA_XREF(XUnmountMU, 4242, 2 + 9,
+OOVPA_SIG_HEADER_XREF(XUnmountMU,
+                      4242,
 
-           XRefNoSaveIndex,
-           XRefTwo)
-{
+                      XRefNoSaveIndex,
+                      XRefTwo)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x2C, XREF_g_XapiMountedMUs), // derived
     XREF_ENTRY(0x50, XREF_XUnmountAlternateTitleA), // Was 3911 offset 0x38
@@ -221,16 +236,18 @@ OOVPA_XREF(XUnmountMU, 4242, 2 + 9,
     // xor edi, edi
     OV_MATCH(0x74, 0x6A, 0x20, 0x6A, 0x01, 0x33, 0xFF), // Was 3911 offset 0x5D
 
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * MU_Init
 // ******************************************************************
-OOVPA_XREF(MU_Init, 4242, 14,
+OOVPA_SIG_HEADER_XREF(MU_Init,
+                      4242,
 
-           XREF_MU_Init,
-           XRefZero)
-{
+                      XREF_MU_Init,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -243,4 +260,5 @@ OOVPA_XREF(MU_Init, 4242, 14,
     // lea eax, [ebp-0x0C] // Was 3911 opcode ...-0x10]
     OV_MATCH(0x8A, 0x50, 0x6A, 0x00, 0x6A, 0x3A, 0x8D, 0x45, 0xF4), // Was 3911 offset 0x95
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4361.inl
+++ b/src/OOVPADatabase/Xapi/4361.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * CreateThread
 // ******************************************************************
-OOVPA_NO_XREF(CreateThread, 4361, 8)
-{
+OOVPA_SIG_HEADER_NO_XREF(CreateThread,
+                         4361)
+OOVPA_SIG_MATCH(
 
     // CreateThread+0x0A : mov eax, ds:10130h
     { 0x0A, 0xA1 },
@@ -42,13 +43,15 @@ OOVPA_NO_XREF(CreateThread, 4361, 8)
     // CreateThread+0x6B : retn 0x18
     { 0x6B, 0xC2 },
     { 0x6C, 0x18 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * CloseHandle
 // ******************************************************************
-OOVPA_NO_XREF(CloseHandle, 4361, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(CloseHandle,
+                         4361)
+OOVPA_SIG_MATCH(
 
     // CloseHandle+0x00 : push [esp+4]
     { 0x00, 0xFF },
@@ -67,13 +70,15 @@ OOVPA_NO_XREF(CloseHandle, 4361, 10)
     // CloseHandle+0x1B : retn 4
     { 0x1B, 0xC2 },
     { 0x1C, 0x04 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiSetupPerTitleDriveLetters
 // ******************************************************************
-OOVPA_NO_XREF(XapiSetupPerTitleDriveLetters, 4361, 10)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiSetupPerTitleDriveLetters,
+                         4361)
+OOVPA_SIG_MATCH(
 
     // XapiSetupPerTitleDriveLetters+0x09 : lea eax, [ebp-0x0C]
     { 0x09, 0x8D },
@@ -92,4 +97,5 @@ OOVPA_NO_XREF(XapiSetupPerTitleDriveLetters, 4361, 10)
     // XapiSetupPerTitleDriveLetters+0x52 : retn 0x08
     { 0x52, 0xC2 },
     { 0x53, 0x08 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4432.inl
+++ b/src/OOVPADatabase/Xapi/4432.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XMountUtilityDrive
 // ******************************************************************
-OOVPA_NO_XREF(XMountUtilityDrive, 4432, 27)
-{
+OOVPA_SIG_HEADER_NO_XREF(XMountUtilityDrive,
+                         4432)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -57,4 +58,5 @@ OOVPA_NO_XREF(XMountUtilityDrive, 4432, 27)
     { 0x51, 0x68 },
     { 0x52, 0x04 },
     { 0x53, 0x01 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4721.inl
+++ b/src/OOVPADatabase/Xapi/4721.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XLaunchNewImageA
 // ******************************************************************
-OOVPA_NO_XREF(XLaunchNewImageA, 4721, 15)
-{
+OOVPA_SIG_HEADER_NO_XREF(XLaunchNewImageA,
+                         4721)
+OOVPA_SIG_MATCH(
 
     { 0x03, 0x81 },
     { 0x04, 0xEC },
@@ -47,4 +48,5 @@ OOVPA_NO_XREF(XLaunchNewImageA, 4721, 15)
     { 0xA5, 0x8D },
 
     { 0xC1, 0x15 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/4831.inl
+++ b/src/OOVPADatabase/Xapi/4831.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XInputSetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputSetState, 4831, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputSetState,
+                         4831)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x01, 0x4C },
@@ -45,16 +46,18 @@ OOVPA_NO_XREF(XInputSetState, 4831, 14)
 
     { 0x30, 0xC2 },
     { 0x31, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XID_fCloseDevice
 // ******************************************************************
-OOVPA_XREF(XID_fCloseDevice, 4831, 16,
+OOVPA_SIG_HEADER_XREF(XID_fCloseDevice,
+                      4831,
 
-           XREF_XID_fCloseDevice,
-           XRefZero)
-{
+                      XREF_XID_fCloseDevice,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -74,13 +77,15 @@ OOVPA_XREF(XID_fCloseDevice, 4831, 16,
 
     { 0x38, 0x45 },
     { 0x39, 0xF4 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputGetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetState, 4831, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetState,
+                         4831)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x8B },
     { 0x0F, 0x8A },
@@ -98,13 +103,15 @@ OOVPA_NO_XREF(XInputGetState, 4831, 12)
 
     { 0x69, 0xC2 },
     { 0x6A, 0x08 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputGetCapabilities
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetCapabilities, 4831, 13)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetCapabilities,
+                         4831)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x1F, 0x0F },
@@ -121,13 +128,15 @@ OOVPA_NO_XREF(XInputGetCapabilities, 4831, 13)
 
     { 0x59, 0x0F },
     { 0x5A, 0xB6 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGetDeviceEnumerationStatus
 // ******************************************************************
-OOVPA_NO_XREF(XGetDeviceEnumerationStatus, 4831, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGetDeviceEnumerationStatus,
+                         4831)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0x15 },
     { 0x0A, 0x35 },
@@ -145,13 +154,15 @@ OOVPA_NO_XREF(XGetDeviceEnumerationStatus, 4831, 14)
 
     { 0x25, 0x8B },
     { 0x28, 0xC3 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiInitProcess
 // ******************************************************************
-OOVPA_NO_XREF(XapiInitProcess, 4831, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiInitProcess,
+                         4831)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -167,13 +178,15 @@ OOVPA_NO_XREF(XapiInitProcess, 4831, 12)
 
     { 0x1D, 0x8D },
     { 0x1E, 0x45 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XInputGetDeviceDescription
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetDeviceDescription, 4831, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetDeviceDescription,
+                         4831)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0xEC },
     { 0x0B, 0x15 },
@@ -192,16 +205,18 @@ OOVPA_NO_XREF(XInputGetDeviceDescription, 4831, 14)
 
     { 0x30, 0x45 },
     //{ 0x31, 0xF8 }, // 4831 0xF4 vs 5344 0xF8
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XReadMUMetaData
 // ******************************************************************
-OOVPA_XREF(XReadMUMetaData, 4831, 1 + 9,
+OOVPA_SIG_HEADER_XREF(XReadMUMetaData,
+                      4831,
 
-           XRefNoSaveIndex,
-           XRefOne)
-{
+                      XRefNoSaveIndex,
+                      XRefOne)
+OOVPA_SIG_MATCH(
 
     XREF_ENTRY(0x31, XREF_g_XapiMountedMUs),
 
@@ -211,4 +226,5 @@ OOVPA_XREF(XReadMUMetaData, 4831, 1 + 9,
 
     // mov WORD PTR [ebp-0x0E],0x3E
     OV_MATCH(0x51, 0x66, 0xC7, 0x45, 0xF2, 0x3E, 0x00),
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/5028.inl
+++ b/src/OOVPADatabase/Xapi/5028.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XMountAlternateTitleA
 // ******************************************************************
-OOVPA_NO_XREF(XMountAlternateTitleA, 5028, 14)
-{
+OOVPA_SIG_HEADER_NO_XREF(XMountAlternateTitleA,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x04, 0xEC },
 
@@ -46,13 +47,15 @@ OOVPA_NO_XREF(XMountAlternateTitleA, 5028, 14)
     { 0x91, 0x15 },
 
     { 0x96, 0x8D },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XapiInitProcess
 // ******************************************************************
-OOVPA_NO_XREF(XapiInitProcess, 5028, 12)
-{
+OOVPA_SIG_HEADER_NO_XREF(XapiInitProcess,
+                         5028)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x55 },
     { 0x01, 0x8B },
@@ -68,4 +71,5 @@ OOVPA_NO_XREF(XapiInitProcess, 5028, 12)
     { 0x27, 0x8D },
     { 0x28, 0x7D },
     { 0x29, 0xCC },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/5120.inl
+++ b/src/OOVPADatabase/Xapi/5120.inl
@@ -29,8 +29,9 @@
 // * NOTE: We are actually intercepting USBD_Init, because
 // *       XInitDevices Simply redirects to that function
 // ******************************************************************
-OOVPA_NO_XREF(XInitDevices, 5120, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInitDevices,
+                         5120)
+OOVPA_SIG_MATCH(
 
     { 0x0E, 0x75 },
     { 0x20, 0xBE },
@@ -39,4 +40,5 @@ OOVPA_NO_XREF(XInitDevices, 5120, 7)
     { 0x50, 0x0F },
     { 0x5F, 0xE8 },
     { 0x70, 0x5F },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/5233.inl
+++ b/src/OOVPADatabase/Xapi/5233.inl
@@ -25,11 +25,12 @@
 // * MU_Init
 // ******************************************************************
 // Generic OOVPA as of 5233 and newer.
-OOVPA_XREF(MU_Init, 5233, 14,
+OOVPA_SIG_HEADER_XREF(MU_Init,
+                      5233,
 
-           XREF_MU_Init,
-           XRefZero)
-{
+                      XREF_MU_Init,
+                      XRefZero)
+OOVPA_SIG_MATCH(
 
     // push ebp
     // mov ebp, esp
@@ -42,4 +43,5 @@ OOVPA_XREF(MU_Init, 5233, 14,
     // lea eax, [ebp-0x0C]
     OV_MATCH(0x8E, 0x50, 0x6A, 0x00, 0x6A, 0x3A, 0x8D, 0x45, 0xF4), // Was 5233 offset 0x8A
 
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/5344.inl
+++ b/src/OOVPADatabase/Xapi/5344.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XLaunchNewImageA
 // ******************************************************************
-OOVPA_NO_XREF(XLaunchNewImageA, 5344, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XLaunchNewImageA,
+                         5344)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0xB8 },
 
@@ -42,4 +43,5 @@ OOVPA_NO_XREF(XLaunchNewImageA, 5344, 11)
 
     { 0x30, 0xC2 },
     { 0x41, 0xEE },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/5455.inl
+++ b/src/OOVPADatabase/Xapi/5455.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * XInputGetState
 // ******************************************************************
-OOVPA_NO_XREF(XInputGetState, 5455, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(XInputGetState,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x0D, 0x0C },
     { 0x1C, 0x5E },
@@ -36,13 +37,15 @@ OOVPA_NO_XREF(XInputGetState, 5455, 7)
     { 0x49, 0x08 },
     { 0x58, 0xF3 },
     { 0x67, 0x15 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XMountAlternateTitleA
 // ******************************************************************
-OOVPA_NO_XREF(XMountAlternateTitleA, 5455, 11)
-{
+OOVPA_SIG_HEADER_NO_XREF(XMountAlternateTitleA,
+                         5455)
+OOVPA_SIG_MATCH(
 
     { 0x0B, 0x08 },
 
@@ -57,4 +60,5 @@ OOVPA_NO_XREF(XMountAlternateTitleA, 5455, 11)
 
     { 0xC1, 0x83 },
     { 0xD0, 0x15 },
-} OOVPA_END;
+    //
+);

--- a/src/OOVPADatabase/Xapi/5788.inl
+++ b/src/OOVPADatabase/Xapi/5788.inl
@@ -26,8 +26,9 @@
 // ******************************************************************
 // * GetThreadPriority
 // ******************************************************************
-OOVPA_NO_XREF(GetThreadPriority, 5788, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(GetThreadPriority,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x0D, 0xFF },
     { 0x16, 0x85 },
@@ -36,13 +37,15 @@ OOVPA_NO_XREF(GetThreadPriority, 5788, 7)
     { 0x35, 0xF1 },
     { 0x40, 0x8B },
     { 0x4B, 0xB8 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * SetThreadPriorityBoost
 // ******************************************************************
-OOVPA_NO_XREF(SetThreadPriorityBoost, 5788, 7)
-{
+OOVPA_SIG_HEADER_NO_XREF(SetThreadPriorityBoost,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x07, 0xFF },
     { 0x10, 0xFF },
@@ -51,17 +54,20 @@ OOVPA_NO_XREF(SetThreadPriorityBoost, 5788, 7)
     { 0x2C, 0x8B },
     { 0x35, 0x33 },
     { 0x40, 0x33 },
-} OOVPA_END;
+    //
+);
 
 // ******************************************************************
 // * XGetSectionSize
 // ******************************************************************
-OOVPA_NO_XREF(XGetSectionSize, 5788, 5)
-{
+OOVPA_SIG_HEADER_NO_XREF(XGetSectionSize,
+                         5788)
+OOVPA_SIG_MATCH(
 
     { 0x00, 0x8B },
     { 0x02, 0x24 },
     { 0x04, 0x8B },
     { 0x06, 0x08 },
     { 0x08, 0x04 },
-} OOVPA_END;
+    //
+);


### PR DESCRIPTION
With pull request #147 merged, this pull request remove manual labor of counting how many OVP arrays there are. It does not change any of OVP arrays. The only changes affected are header and array's constructor for each OOVPA signature.

However, not every signatures are converted to use new signature due to macro does not allow compile statements, aka `#ifdef, #if, etc`. I only made reverts to those signatures cannot use new signature format until they are resolve.

Following three affected libraries are:
 - D3D8
 - D3D8LTCG
 - DSound

I have documented which signatures in each commits are not converted.

---

Automatic conversion via regex replacement method:

Src: `^OOVPA(_NO)?_XREF([_A-Z]*)?\(([a-zA-Z0-9_]*), ([0-9]*), ([0-9+ ]*)([\),])`
Rpl: `OOVPA_SIG_HEADER$1_XREF$2($3,\n$4$6`

Src: `{`
Rpl: `OOVPA_SIG_MATCH(`

Src: `}(\r\n[ ]*)? OOVPA_END`
Rpl: `//\r\n)`

Then perform format each files to comply with given clang-format standard expectation.