### PR TITLE
Enable XOnline symbol detection when XONLINLS library is found

### DIFF
--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -70,6 +70,7 @@ extern "C" {
 #define Lib_XONLINE  "XONLINE"
 #define Sec_XONLINE  Lib_XONLINE
 #define Lib_XONLINES "XONLINES"
+#define Lib_XONLINLS "XONLINLS"
 #define Sec_XNET     "XNET"
 
 #define XbSymbolLib_D3D8     (1 << 0)
@@ -85,13 +86,14 @@ extern "C" {
 #define XbSymbolLib_XNETS    (1 << 10)
 #define XbSymbolLib_XONLINE  (1 << 11)
 #define XbSymbolLib_XONLINES (1 << 12)
+#define XbSymbolLib_XONLINLS (1 << 13)
 
 // clang-format off
 // TODO: Need to find a way keep below intact.
 #define XbSymbolLib_ALL ( XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG | XbSymbolLib_D3DX8 | XbSymbolLib_DSOUND \
                         | XbSymbolLib_JVS | XbSymbolLib_XACTENG | XbSymbolLib_XAPILIB | XbSymbolLib_XGRAPHC \
                         | XbSymbolLib_XNET | XbSymbolLib_XNETN | XbSymbolLib_XNETS | XbSymbolLib_XONLINE \
-                        | XbSymbolLib_XONLINES)
+                        | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS)
 // clang-format on
 
 typedef enum _xb_output_message {

--- a/src/lib/internal_functions.h
+++ b/src/lib/internal_functions.h
@@ -573,6 +573,7 @@ static eLibraryType internal_GetLibraryType(uint32_t library)
             return LT_GRAPHIC;
         case XbSymbolLib_XONLINE:
         case XbSymbolLib_XONLINES:
+        case XbSymbolLib_XONLINLS:
         case XbSymbolLib_XNET:
         case XbSymbolLib_XNETS:
         case XbSymbolLib_XNETN:

--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -207,13 +207,13 @@ SymbolDatabaseList SymbolDBList[] = {
     // TODO: Do we need to keep Sec_XNET in here?
     // TODO: Need to find out which function is only part of XOnlines.
     // Fun fact, XONLINES are split into 2 header sections.
-    { XbSymbolLib_XONLINE | XbSymbolLib_XONLINES, { Sec_text, Sec_XONLINE, Sec_XNET, Sec_FLASHROM }, XONLINE_OOVPA, XONLINE_OOVPA_COUNT },
+    { XbSymbolLib_XONLINE | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS, { Sec_text, Sec_XONLINE, Sec_XNET, Sec_FLASHROM }, XONLINE_OOVPA, XONLINE_OOVPA_COUNT },
 
     // Added Sec_text just in case.
     // TODO: Need to find out which function is only part of XNets.
     // XNETS only has XNET, might be true.
     // XNETN's test case: Stake
-    { XbSymbolLib_XNET | XbSymbolLib_XNETS | XbSymbolLib_XNETN | XbSymbolLib_XONLINE | XbSymbolLib_XONLINES, { Sec_text, Sec_XNET, Sec_FLASHROM }, XNET_OOVPA, XNET_OOVPA_COUNT },
+    { XbSymbolLib_XNET | XbSymbolLib_XNETS | XbSymbolLib_XNETN | XbSymbolLib_XONLINE | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS, { Sec_text, Sec_XNET, Sec_FLASHROM }, XNET_OOVPA, XNET_OOVPA_COUNT },
 };
 
 // ******************************************************************
@@ -417,6 +417,9 @@ const char* XbSymbolDatabase_LibraryToString(uint32_t library_flag)
         case XbSymbolLib_XONLINES: {
             return Lib_XONLINES;
         }
+        case XbSymbolLib_XONLINLS: {
+            return Lib_XONLINLS;
+        }
         default: {
             return Lib_UNKNOWN;
         }
@@ -462,6 +465,9 @@ uint32_t XbSymbolDatabase_LibraryToFlag(const char* library_name)
     }
     if (strncmp(library_name, Lib_XONLINES, 8) == 0) {
         return XbSymbolLib_XONLINES;
+    }
+    if (strncmp(library_name, Lib_XONLINLS, 8) == 0) {
+        return XbSymbolLib_XONLINLS;
     }
     return 0;
 }


### PR DESCRIPTION
This enables detection of XOnline symbols when the `XONLINLS` library is found. I don't know how exactly it differs from `XONLINES`, but the current signatures seem to be enough for symbol detection to work. The library version seems to always be `5849`, and it can be found in games such as `TOCA Race Driver 2`, `Trivial Pursuit` and `RalliSport Challenge 2`.