### PR TITLE
XOnline: Move 4831 signatures to 4721

### DIFF
--- a/src/OOVPADatabase/XOnline/4721.inl
+++ b/src/OOVPADatabase/XOnline/4721.inl
@@ -1,6 +1,6 @@
 // ******************************************************************
 // *
-// *   OOVPADatabase->XOnline->4831.inl
+// *   OOVPADatabase->XOnline->4721.inl
 // *
 // *  XbSymbolDatabase is free software; you can redistribute them
 // *  and/or modify them under the terms of the GNU General Public
@@ -27,7 +27,7 @@
 // * CXo::XOnlineLogon
 // ******************************************************************
 OOVPA_SIG_HEADER_NO_XREF(CXo_XOnlineLogon,
-                         4831)
+                         4721)
 OOVPA_SIG_MATCH(
 
     { 0x02, 0xEC },
@@ -54,7 +54,7 @@ OOVPA_SIG_MATCH(
 // * CXo::XOnlineMatchSearch
 // ******************************************************************
 OOVPA_SIG_HEADER_NO_XREF(CXo_XOnlineMatchSearch,
-                         4831)
+                         4721)
 OOVPA_SIG_MATCH(
 
     // push ebp
@@ -75,7 +75,7 @@ OOVPA_SIG_MATCH(
 // * XOnlineMatchSearch
 // ******************************************************************
 OOVPA_SIG_HEADER_XREF(XOnlineMatchSearch,
-                      4831,
+                      4721,
                       XRefOne)
 OOVPA_SIG_MATCH(
 
@@ -94,7 +94,7 @@ OOVPA_SIG_MATCH(
 // * CXo_XOnlineMatchSearchResultsLen
 // ******************************************************************
 OOVPA_SIG_HEADER_NO_XREF(CXo_XOnlineMatchSearchResultsLen,
-                         4831)
+                         4721)
 OOVPA_SIG_MATCH(
 
     // test ecx, ecx
@@ -118,7 +118,7 @@ OOVPA_SIG_MATCH(
 // * XOnlineMatchSearchResultsLen
 // ******************************************************************
 OOVPA_SIG_HEADER_XREF(XOnlineMatchSearchResultsLen,
-                      4831,
+                      4721,
                       XRefOne)
 OOVPA_SIG_MATCH(
 
@@ -136,7 +136,7 @@ OOVPA_SIG_MATCH(
 // * CXo::XOnlineMatchSearchGetResults
 // ******************************************************************
 OOVPA_SIG_HEADER_NO_XREF(CXo_XOnlineMatchSearchGetResults,
-                         4831)
+                         4721)
 OOVPA_SIG_MATCH(
 
     // push ebp
@@ -156,7 +156,7 @@ OOVPA_SIG_MATCH(
 // * XOnlineMatchSearchGetResults
 // ******************************************************************
 OOVPA_SIG_HEADER_XREF(XOnlineMatchSearchGetResults,
-                      4831,
+                      4721,
                       XRefOne)
 OOVPA_SIG_MATCH(
 
@@ -174,7 +174,7 @@ OOVPA_SIG_MATCH(
 // * CXo::XOnlineMatchSessionUpdate
 // ******************************************************************
 OOVPA_SIG_HEADER_NO_XREF(CXo_XOnlineMatchSessionUpdate,
-                         4831)
+                         4721)
 OOVPA_SIG_MATCH(
 
     // push ebp
@@ -198,7 +198,7 @@ OOVPA_SIG_MATCH(
 // * XOnlineMatchSessionUpdate
 // ******************************************************************
 OOVPA_SIG_HEADER_XREF(XOnlineMatchSessionUpdate,
-                      4831,
+                      4721,
                       XRefOne)
 OOVPA_SIG_MATCH(
 
@@ -219,7 +219,7 @@ OOVPA_SIG_MATCH(
 // * CXo::XOnlineMatchSessionCreate
 // ******************************************************************
 OOVPA_SIG_HEADER_NO_XREF(CXo_XOnlineMatchSessionCreate,
-                         4831)
+                         4721)
 OOVPA_SIG_MATCH(
 
     // push ebp
@@ -244,7 +244,7 @@ OOVPA_SIG_MATCH(
 // * XOnlineMatchSessionCreate
 // ******************************************************************
 OOVPA_SIG_HEADER_XREF(XOnlineMatchSessionCreate,
-                      4831,
+                      4721,
                       XRefOne)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/XOnline_OOVPA.inl
+++ b/src/OOVPADatabase/XOnline_OOVPA.inl
@@ -57,7 +57,7 @@
 
 #include "XOnline/4361.inl"
 #include "XOnline/4627.inl"
-#include "XOnline/4831.inl"
+#include "XOnline/4721.inl"
 #include "XOnline/5028.inl"
 #include "XOnline/5233.inl"
 #include "XOnline/5455.inl"
@@ -72,18 +72,18 @@
 OOVPATable XONLINE_OOVPA[] = {
 
     // XOnline section
-    REGISTER_OOVPAS(CXo_XOnlineLogon, 4361, 4627, 4831, 5455, 5558, 5849),
+    REGISTER_OOVPAS(CXo_XOnlineLogon, 4361, 4627, 4721, 5455, 5558, 5849),
     REGISTER_OOVPAS(XOnlineLogon, 4361),
-    REGISTER_OOVPAS(CXo_XOnlineMatchSearch, 4831),
-    REGISTER_OOVPAS(XOnlineMatchSearch, 4831),
-    REGISTER_OOVPAS(CXo_XOnlineMatchSearchResultsLen, 4831),
-    REGISTER_OOVPAS(XOnlineMatchSearchResultsLen, 4831),
-    REGISTER_OOVPAS(CXo_XOnlineMatchSearchGetResults, 4831),
-    REGISTER_OOVPAS(XOnlineMatchSearchGetResults, 4831),
-    REGISTER_OOVPAS(CXo_XOnlineMatchSessionUpdate, 4831, 5233),
-    REGISTER_OOVPAS(XOnlineMatchSessionUpdate, 4831),
-    REGISTER_OOVPAS(CXo_XOnlineMatchSessionCreate, 4831, 5849),
-    REGISTER_OOVPAS(XOnlineMatchSessionCreate, 4831),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSearch, 4721),
+    REGISTER_OOVPAS(XOnlineMatchSearch, 4721),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSearchResultsLen, 4721),
+    REGISTER_OOVPAS(XOnlineMatchSearchResultsLen, 4721),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSearchGetResults, 4721),
+    REGISTER_OOVPAS(XOnlineMatchSearchGetResults, 4721),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSessionUpdate, 4721, 5233),
+    REGISTER_OOVPAS(XOnlineMatchSessionUpdate, 4721),
+    REGISTER_OOVPAS(CXo_XOnlineMatchSessionCreate, 4721, 5849),
+    REGISTER_OOVPAS(XOnlineMatchSessionCreate, 4721),
     REGISTER_OOVPAS(XoUpdateLaunchNewImageInternal, 4627, 5659, 5788),
 };
 


### PR DESCRIPTION
This moves the `XOnline` signatures from XDK version 4831 to 4721, allowing `XOnline` symbol detection to work with the Re-Volt Xbox Live Beta.