### PR TITLE
Implement Dependency API (removed Mutex callback API)

### DIFF
--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -265,28 +265,6 @@ void XbSymbolContext_SetContinuousSigScan(XbSymbolContextHandle pHandle, bool en
 void XbSymbolContext_SetFirstDetectAddressOnly(XbSymbolContextHandle pHandle, bool enable);
 
 /// <summary>
-/// To register mutex lock callback functions.
-/// </summary>
-/// <param name="opaque_ptr">Retrieve opaque pointer if set from XbSymbolContext_SetMutex registration.</param>
-/// <returns>True: Successful lock. False: Failure to lock.</returns>
-typedef bool (*xb_mutex_lock_t)(XbSymbolContextHandle pHandle, void* opaque_ptr);
-
-/// <summary>
-/// To register mutex unlock callback functions.
-/// </summary>
-/// <param name="opaque_ptr">Retrieve opaque pointer if set from XbSymbolContext_SetMutex registration.</param>
-typedef void (*xb_mutex_unlock_t)(XbSymbolContextHandle pHandle, void* opaque_ptr);
-
-/// <summary>
-/// To register mutex (un)lock callback functions for multi-thread safe purpose.
-/// </summary>
-/// <param name="opaque_ptr">Set pointer to be used to retrieve during (un)lock callback events.</param>
-/// <param name="mutex_lock">Set mutex lock to a callback function.</param>
-/// <param name="mutex_unlock">Set mutex unlock to a callback function.</param>
-/// <returns>Return true if success, or else will return false for invalid parameter.</returns>
-bool XbSymbolContext_SetMutex(XbSymbolContextHandle pHandle, void* opaque_ptr, xb_mutex_lock_t mutex_lock, xb_mutex_unlock_t mutex_unlock);
-
-/// <summary>
 /// Get library flag's dependencies.
 /// </summary>
 /// <param name="pHandle">Input XbSymbolContextHandle handler.</param>

--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -287,6 +287,15 @@ typedef void (*xb_mutex_unlock_t)(XbSymbolContextHandle pHandle, void* opaque_pt
 bool XbSymbolContext_SetMutex(XbSymbolContextHandle pHandle, void* opaque_ptr, xb_mutex_lock_t mutex_lock, xb_mutex_unlock_t mutex_unlock);
 
 /// <summary>
+/// Get library flag's dependencies.
+/// </summary>
+/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
+/// <param name="library_flag">Input specific library flag.</param>
+/// <param name="library_filters">Input generated library filters.</param>
+/// <returns>Return either none, one, or more library flag dependencies.</returns>
+uint32_t XbSymbolDatabase_GetLibraryDependencies(uint32_t library_flag, XbSDBLibraryHeader library_filters);
+
+/// <summary>
 /// Step 1: Generate library array for LibraryHeader input.
 /// First call with <paramref name="library_out"/> as null pointer will return total count. Then second call will insert information to <paramref name="library_out"/>.filters field.
 /// </summary>
@@ -330,8 +339,19 @@ bool XbSymbolDatabase_CreateXbSymbolContext(XbSymbolContextHandle* ppHandle, xb_
 void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle);
 
 /// <summary>
-/// Step 6a: (multi-thread safe, optional) Process individual library input by third-party.
-/// NOTE: If planned to use multi-thread purpose, please register mutex (un)lock callbacks to XbSymbolContext_SetMutex.
+/// Step 6: Get library flag's dependencies.
+/// </summary>
+/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
+/// <param name="library_flag">Input specific library flag.</param>
+/// <param name="library_filters">Input generated library filters.</param>
+/// <returns>Return either none, one, or more library flag dependencies.</returns>
+uint32_t XbSymbolContext_GetLibraryDependencies(XbSymbolContextHandle pHandle, uint32_t library_flag);
+
+#define XbSymbolDatabase_CheckDependencyCompletion(completion_flag, dependencies) ((completion_flag & dependencies) == dependencies)
+
+/// <summary>
+/// Step 7a: (multi-thread safe, optional) Process individual library input by third-party.
+/// NOTE: If planned to use multi-thread purpose, please use thread-safe method for library dependency checkup.
 /// </summary>
 /// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
 /// <param name="pLibrary">Input pointer of a library to start a scan process.</param>
@@ -339,14 +359,16 @@ void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle);
 /// <returns>Return total xref count found. Unless it return zero, then there's nothing left to find.</returns>
 unsigned int XbSymbolContext_ScanLibrary(XbSymbolContextHandle pHandle, const XbSDBLibrary* pLibrary, bool xref_first_pass);
 
+#define XbSymbolDatabase_SetLibraryCompletion(completion_flag, library_flag) (completion_flag |= library_flag)
+
 /// <summary>
-/// Step 6b: (single-thread usage) Process all of filter libraries internally.
+/// Step 7b: (single-thread usage) Process all of filter libraries internally.
 /// </summary>
 /// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
 void XbSymbolContext_ScanAllLibraryFilter(XbSymbolContextHandle pHandle);
 
 /// <summary>
-/// Step 7: Register any references, XRefDatabase, may not had been output during the scan process.
+/// Step 8: Register any references, XRefDatabase, may not had been output during the scan process.
 /// NOTE: Currently a stub at the moment.
 /// </summary>
 /// <param name="pHandle">Input XbSymbolContextHandle handler.</param>

--- a/src/lib/internal_functions.h
+++ b/src/lib/internal_functions.h
@@ -595,8 +595,6 @@ static bool internal_SetLibraryTypeStart(iXbSymbolContext* pContext, eLibraryTyp
 
     bool ret = false;
 
-    iXbSymbolContext_Lock(pContext);
-
     // Accept request if library type is inactive.
     if (!pContext->library_contexts[library_type].is_active) {
         // Then accept the scan request.
@@ -605,15 +603,11 @@ static bool internal_SetLibraryTypeStart(iXbSymbolContext* pContext, eLibraryTyp
         output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, "Library type active: %u", library_type);
     }
 
-    iXbSymbolContext_Unlock(pContext);
-
     return ret;
 }
 
 static void internal_SetLibraryTypeEnd(iXbSymbolContext* pContext, eLibraryType library_type)
 {
-    (void)iXbSymbolContext_Lock(pContext);
-
     // If library is active, deny the scan request.
     if (!pContext->library_contexts[library_type].is_active) {
         output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "Attempted to set already inactive library type %u.", library_type);
@@ -621,8 +615,6 @@ static void internal_SetLibraryTypeEnd(iXbSymbolContext* pContext, eLibraryType 
 
     pContext->library_contexts[library_type].is_active = false;
     output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, "Library type inactive: %u", library_type);
-
-    iXbSymbolContext_Unlock(pContext);
 }
 
 static memptr_t internal_section_VirtToHostAddress(iXbSymbolContext* pContext, xbaddr virt_addr)

--- a/src/lib/internal_functions.h
+++ b/src/lib/internal_functions.h
@@ -652,3 +652,11 @@ static xbaddr internal_section_HostToVirtAddress(iXbSymbolContext* pContext, mem
     }
     return virt_addr;
 }
+
+static bool internal_LibraryFilterPermitScan(iXbSymbolContext* pContext, uint32_t library_flag)
+{
+    if (pContext->library_filter == 0 || (pContext->library_filter & library_flag) > 0) {
+        return true;
+    }
+    return false;
+}

--- a/src/lib/internal_functions.h
+++ b/src/lib/internal_functions.h
@@ -561,6 +561,7 @@ static eLibraryType internal_GetLibraryType(uint32_t library)
             return LT_UNKNOWN;
         case XbSymbolLib_D3D8:
         case XbSymbolLib_D3D8LTCG:
+        case XbSymbolLib_D3DX8:
             return LT_D3D;
         case XbSymbolLib_DSOUND:
         case XbSymbolLib_XACTENG:

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -23,6 +23,7 @@
 #ifndef DISABLE_MULTI_THREAD
 #include <thread>
 #include <mutex>
+std::mutex mtx_context;
 #endif
 
 #include <libXbSymbolDatabase.h>
@@ -194,20 +195,8 @@ static int cliInputInteractive(int argc, char** argv)
 }
 
 #ifndef DISABLE_MULTI_THREAD
-std::mutex mtx_context;
-static bool XbSDbContext_Lock(XbSymbolContextHandle pHandle, void* mtx_ptr)
-{
-    reinterpret_cast<std::mutex*>(mtx_ptr)->lock();
-    return true;
-}
-static void XbSDbContext_Unlock(XbSymbolContextHandle pHandle, void* mtx_ptr)
-{
-    reinterpret_cast<std::mutex*>(mtx_ptr)->unlock();
-}
-
 std::mutex mtx_message;
 #endif
-
 template<bool doCache>
 void Generic_OutputMessage(xb_output_message mFlag, const char* section, const std::string& message)
 {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -23,7 +23,9 @@
 #ifndef DISABLE_MULTI_THREAD
 #include <thread>
 #include <mutex>
-std::mutex mtx_context;
+static std::mutex mtx_context;
+static std::mutex mtx_message;
+static std::mutex mtx_symbol_register;
 #endif
 
 #include <libXbSymbolDatabase.h>
@@ -194,9 +196,6 @@ static int cliInputInteractive(int argc, char** argv)
     return 0;
 }
 
-#ifndef DISABLE_MULTI_THREAD
-std::mutex mtx_message;
-#endif
 template<bool doCache>
 void Generic_OutputMessage(xb_output_message mFlag, const char* section, const std::string& message)
 {
@@ -299,6 +298,10 @@ static void EmuRegisterSymbol(const char* library_str,
         return;
     }
 
+#ifndef DISABLE_MULTI_THREAD
+    // TODO: Find a way to make this more thread safe without locking.
+    std::lock_guard lck(mtx_symbol_register);
+#endif
     // Ignore registered symbol in current database.
     symbol_result hasSymbol = g_SymbolAddresses[xref_index];
 


### PR DESCRIPTION
With Dependency API feature, there is no more of random occur failures for any partial library's symbols. Dependency API is require for using `XbSymbolContext_ScanLibrary` API.

I am requesting reviews on the API naming or even discovery of faulty code.

I have personally tested this new change on single thread and multi-threads and confirm random failures of missing symbols has stopped except for one weird bug not relative to this pull request.

Weird bug report is: (fixed in commit 3eb125546e9d7c195aef690b1d96a7258fddd22e)
`ERROR  : g_SymbolAddresses(Raw) is missing UNKNOWN (b0000) 0x00000000 ->`

fixed #168