### PR TITLE
Bump Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       do-build: ${{ steps.build-cond.outputs.do-build }}
       do-release: ${{ github.repository == env.repo_default }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: RadWolfie/Semantic-Version-Action@main
@@ -65,7 +65,7 @@ jobs:
       # NOTE: Require to reduce workload from CI service from fetch whole git content.
       - name: Upload Changelog
         if: steps.build-cond.outputs.do-build == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: changelog
           path: changelog
@@ -111,7 +111,7 @@ jobs:
             cmake-build-param: -j $(sysctl -n hw.ncpu)
             folder: macos
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Generate CMake Files
         # NOTES:
         # -Werror=dev is used to validate CMakeLists.txt for any faults.
@@ -125,7 +125,7 @@ jobs:
         run: cmake --install build --config ${{ matrix.configuration }} --prefix upload/${{ matrix.folder }}_${{ matrix.arch }}
       - name: Upload Build Artifact
         if: matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: XbSymbolDatabase
           # roughly translate to upload/<platform_arch>/<bin | lib | include>/<anything in here and after>
@@ -133,7 +133,7 @@ jobs:
           if-no-files-found: error
       - name: Upload Misc Artifact
         if: matrix.cmake-generator == '-G "Unix Makefiles"' && matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: XbSymbolDatabase
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
         run: |
           if [ "true" == "${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') || steps.semver-output.outputs.version_previous != steps.semver-output.outputs.version_current }}" ]
           then
-            echo "::set-output name=do-build::true"
+            echo "do-build=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=do-build::false"
+            echo "do-build=false" >> $GITHUB_OUTPUT
           fi
       - name: Generate Changelog
         if: steps.build-cond.outputs.do-build == 'true'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Labeler
-        uses: actions/labeler@v3
+        uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # IMPORTANT: Make sure checkout is pulling pull request's merge commit!
           ref: 'refs/pull/${{ github.event.number }}/merge'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     if: needs.build.outputs.do-release == 'true'
     runs-on: ubuntu-latest
     env:
-      version_current: ${{ needs.build.outputs.ver-cur }}
+      tag_name: ${{ needs.build.outputs.ver-cur }}
     steps:
       - uses: actions/checkout@v3
       - name: Get Artifacts
@@ -31,20 +31,7 @@ jobs:
         run: | # download-artifact doesn't download a zip, so rezip it
           7z a -mx1 "XbSymbolDatabase.zip" "./XbSymbolDatabase/*"
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
         env:
+          GH_REPO: ${{ github.repository }} # https://github.com/cli/cli/issues/3556
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version_current }}
-          release_name: ${{ env.version_current }}
-          body_path: changelog/changelog
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: XbSymbolDatabase.zip
-          asset_name: XbSymbolDatabase.zip
-          asset_content_type: application/zip
+        run: gh release create ${{ env.tag_name }} XbSymbolDatabase.zip --notes-file changelog --target $GITHUB_SHA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
     env:
       version_current: ${{ needs.build.outputs.ver-cur }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         # NOTE: We're downloading ALL artifacts.
       - name: Prepare artifacts for release
         run: | # download-artifact doesn't download a zip, so rezip it


### PR DESCRIPTION
With these changes and a fix in [Semantic Version Action](https://github.com/RadWolfie/Semantic-Version-Action). The only warning left is:
```
Annotations
1 warning
GitHub CI: .github#L1
macOS-latest pipelines will use macOS-12 soon. ...
```
However, we are using macOS-latest, currently is macOS-11, at this time which doesn't need any fix.