### PR TITLE
Rename D3D8LTCG symbols

### DIFF
--- a/src/OOVPADatabase/D3D8LTCG/3911.inl
+++ b/src/OOVPADatabase/D3D8LTCG/3911.inl
@@ -1130,7 +1130,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0__LTCG_eax_handle,
                          2060)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/4039.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4039.inl
@@ -729,7 +729,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0__LTCG_eax_handle,
                          2072)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/4531.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4531.inl
@@ -212,7 +212,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_SetPixelShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0__LTCG_eax_handle,
                          2024)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/4627.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4627.inl
@@ -819,7 +819,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_CreateVertexShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0__LTCG_eax_handle,
                          2036)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/4627.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4627.inl
@@ -727,7 +727,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_Reset
 // ******************************************************************
 //803F6A006A036A006A00E8 ...C3
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset_0,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_Reset_0__LTCG_edi_pPresentationParameters,
                          2024)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/4721.inl
+++ b/src/OOVPADatabase/D3D8LTCG/4721.inl
@@ -74,7 +74,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_SetTexture
 // ******************************************************************
 //81C10000F8FF89 ...C20400
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTexture_4,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetTexture_4__LTCG_eax_Stage,
                          2036)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/5788.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5788.inl
@@ -101,7 +101,7 @@ OOVPA_SIG_MATCH(
 // * D3DDevice_CreateVertexShader
 // ******************************************************************
 //C740040000210083C008 ...C3
-OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0,
+OOVPA_SIG_HEADER_NO_XREF(D3DDevice_SetPixelShader_0__LTCG_eax_handle,
                          2048)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG/5788.inl
+++ b/src/OOVPADatabase/D3D8LTCG/5788.inl
@@ -551,7 +551,7 @@ OOVPA_SIG_MATCH(
 // * D3D_MakeRequestedSpace
 // ******************************************************************
 //81C5004000003BE9 ...C20400
-OOVPA_SIG_HEADER_NO_XREF(D3D_MakeRequestedSpace,
+OOVPA_SIG_HEADER_NO_XREF(D3D_MakeRequestedSpace_4__LTCG_eax_RequestedSpace,
                          2048)
 OOVPA_SIG_MATCH(
 

--- a/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -199,7 +199,7 @@ OOVPATable D3D8LTCG_OOVPA[] = {
     REGISTER_OOVPAS_C_BIND_XREF(D3DDevice_SetTextureState_TexCoordIndex_0, D3DDevice_SetTextureState_TexCoordIndex, 2039, 2058),
     REGISTER_OOVPAS_C_BIND_XREF(D3DDevice_SetTextureState_TexCoordIndex_4, D3DDevice_SetTextureState_TexCoordIndex, 2040, 2045, 2052, 2058),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetTexture_4__LTCG_eax_pTexture, D3DDevice_SetTexture, 2024),
-    REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetTexture_4, D3DDevice_SetTexture, 2036),
+    REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetTexture_4__LTCG_eax_Stage, D3DDevice_SetTexture, 2036),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetTile_0, D3DDevice_SetTile, 2024, 2036, 2048, 2060, 2072),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetTransform_0__LTCG_eax1_edx2, D3DDevice_SetTransform, 3911, 4034, 5344, 5455, 5558),
     REGISTER_OOVPAS(D3DDevice_SetVertexData2f, 1024, 1036, 1048),

--- a/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -67,7 +67,7 @@
 OOVPATable D3D8LTCG_OOVPA[] = {
 
     REGISTER_OOVPAS_BIND_XREF(D3D_MakeRequestedSpace_8, D3D_MakeRequestedSpace, 1036), // NOTE: OOVPA is in 5849. In used by (5849) Manhunt title
-    REGISTER_OOVPAS(D3D_MakeRequestedSpace, 2048),
+    REGISTER_OOVPAS_BIND_XREF(D3D_MakeRequestedSpace_4__LTCG_eax_RequestedSpace, D3D_MakeRequestedSpace, 2048),
     REGISTER_OOVPAS(D3D_SetFence, 1024, 1036, 1048, 1060),
     REGISTER_OOVPAS(D3D_BlockOnTime, 1024, 1036, 1048),
     REGISTER_OOVPAS_BIND_XREF(D3D_BlockOnTime_4, D3D_BlockOnTime, 2048, 2060),

--- a/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -144,7 +144,7 @@ OOVPATable D3D8LTCG_OOVPA[] = {
     REGISTER_OOVPAS(D3DDevice_SetPixelShaderConstant, 1024, 1036),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetPixelShaderConstant_4, D3DDevice_SetPixelShaderConstant, 2024),
     REGISTER_OOVPAS(D3DDevice_SetPixelShaderProgram, 1024),
-    REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetPixelShader_0, D3DDevice_SetPixelShader, 2024, 2036, 2048, 2060, 2072),
+    REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetPixelShader_0__LTCG_eax_handle, D3DDevice_SetPixelShader, 2024, 2036, 2048, 2060, 2072),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_SetRenderStateNotInline_0, D3DDevice_SetRenderStateNotInline, 2048),
     REGISTER_OOVPAS(D3DDevice_SetRenderState_BackFillMode, 1024, 1036),
     REGISTER_OOVPAS_C(D3DDevice_SetRenderState_CullMode, 1045, 1049, 1052, 1053),

--- a/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
+++ b/src/OOVPADatabase/D3D8LTCG_OOVPA.inl
@@ -124,7 +124,7 @@ OOVPATable D3D8LTCG_OOVPA[] = {
     REGISTER_OOVPAS(D3DDevice_Present, 1024),
     REGISTER_OOVPAS(D3DDevice_Release, 1024),
     REGISTER_OOVPAS(D3DDevice_Reset, 1024, 1036),
-    REGISTER_OOVPAS_BIND_XREF(D3DDevice_Reset_0, D3DDevice_Reset, 2024),
+    REGISTER_OOVPAS_BIND_XREF(D3DDevice_Reset_0__LTCG_edi_pPresentationParameters, D3DDevice_Reset, 2024),
     REGISTER_OOVPAS(D3DDevice_RunPushBuffer, 1024, 1048),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_RunPushBuffer_4, D3DDevice_RunPushBuffer, 2048),
     REGISTER_OOVPAS_BIND_XREF(D3DDevice_RunVertexStateShader_4, D3DDevice_RunVertexStateShader, 2048),

--- a/src/test/libverify/D3D8.cpp
+++ b/src/test/libverify/D3D8.cpp
@@ -179,7 +179,9 @@ static const library_list database_full = {
     REGISTER_SYMBOLS(D3DDevice_SetPalette,
                      REGISTER_SYMBOL(D3DDevice_SetPalette, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
                      REGISTER_SYMBOL(D3DDevice_SetPalette_4, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE))), // NOTE: LTCG usage
-    REGISTER_SYMBOL_INLINE(D3DDevice_SetPixelShader, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+    REGISTER_SYMBOLS(D3DDevice_SetPixelShader,
+                     REGISTER_SYMBOL(D3DDevice_SetPixelShader, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+                     REGISTER_SYMBOL(D3DDevice_SetPixelShader_0__LTCG_eax_handle, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE))),
     REGISTER_SYMBOLS(D3DDevice_SetPixelShaderConstant,
                      REGISTER_SYMBOL(D3DDevice_SetPixelShaderConstant, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
                      REGISTER_SYMBOL(D3DDevice_SetPixelShaderConstant_4, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE))), // NOTE: LTCG usage

--- a/src/test/libverify/D3D8.cpp
+++ b/src/test/libverify/D3D8.cpp
@@ -149,7 +149,9 @@ static const library_list database_full = {
     REGISTER_SYMBOL_INLINE(D3DDevice_Present, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
     REGISTER_SYMBOL_INLINE(D3DDevice_PrimeVertexCache, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
     REGISTER_SYMBOL_INLINE(D3DDevice_Release, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
-    REGISTER_SYMBOL_INLINE(D3DDevice_Reset, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+    REGISTER_SYMBOLS(D3DDevice_Reset,
+                     REGISTER_SYMBOL(D3DDevice_Reset, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+                     REGISTER_SYMBOL(D3DDevice_Reset_0__LTCG_edi_pPresentationParameters, VER_RANGE(4627, VER_MAX, VER_NONE, VER_NONE))),
     REGISTER_SYMBOLS(D3DDevice_RunPushBuffer,
                      REGISTER_SYMBOL(D3DDevice_RunPushBuffer, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
                      REGISTER_SYMBOL(D3DDevice_RunPushBuffer_4, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE))), // NOTE: LTCG usage

--- a/src/test/libverify/D3D8.cpp
+++ b/src/test/libverify/D3D8.cpp
@@ -248,7 +248,10 @@ static const library_list database_full = {
                      REGISTER_SYMBOL(D3DDevice_SetStreamSource_4, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),  // NOTE: LTCG usage
                      REGISTER_SYMBOL(D3DDevice_SetStreamSource_8, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE))), // NOTE: LTCG usage
     REGISTER_SYMBOL_INLINE(D3DDevice_SetSwapCallback, VER_RANGE(4039, VER_MAX, VER_NONE, VER_NONE)),
-    REGISTER_SYMBOL_INLINE(D3DDevice_SetTexture, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+    REGISTER_SYMBOLS(D3DDevice_SetTexture,
+                     REGISTER_SYMBOL(D3DDevice_SetTexture, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+                     REGISTER_SYMBOL(D3DDevice_SetTexture_4__LTCG_eax_pTexture, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
+                     REGISTER_SYMBOL(D3DDevice_SetTexture_4__LTCG_eax_Stage, VER_RANGE(4721, VER_MAX, VER_NONE, VER_NONE))),
     REGISTER_SYMBOLS(D3DDevice_SetTextureState_BorderColor,
                      REGISTER_SYMBOL(D3DDevice_SetTextureState_BorderColor, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
                      REGISTER_SYMBOL(D3DDevice_SetTextureState_BorderColor_0, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),  // NOTE: LTCG usage

--- a/src/test/libverify/D3D8.cpp
+++ b/src/test/libverify/D3D8.cpp
@@ -369,9 +369,9 @@ static const library_list database_full = {
         REGISTER_SYMBOL(Lock3DSurface, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE)),
         REGISTER_SYMBOL(Lock3DSurface_16, VER_RANGE(3911, VER_MAX, VER_NONE, VER_NONE))), // NOTE: LTCG usage
     REGISTER_SYMBOLS(D3D_MakeRequestedSpace,
-                     // TODO: Need fix D3D_MakeRequestedSpace in LTCG database to amend _4 or _8. Current status is unknown and may be _4 suffix.
                      REGISTER_SYMBOL(D3D_MakeRequestedSpace_4, VER_RANGE(4034, 4134, VER_NONE, VER_NONE)),
-                     REGISTER_SYMBOL(D3D_MakeRequestedSpace_8, VER_RANGE(4134, VER_MAX, VER_NONE, VER_NONE))),
+                     REGISTER_SYMBOL(D3D_MakeRequestedSpace_8, VER_RANGE(4134, VER_MAX, VER_NONE, VER_NONE)),
+                     REGISTER_SYMBOL(D3D_MakeRequestedSpace_4__LTCG_eax_RequestedSpace, VER_RANGE(5788, VER_MAX, VER_NONE, VER_NONE))),
     REGISTER_SYMBOL_INLINE(XMETAL_StartPush, VER_RANGE(3911, 4034, VER_NONE, VER_NONE)),
     REGISTER_SYMBOL_INLINE(IDirect3DVertexBuffer8_Lock, VER_RANGE(4627, VER_MAX, VER_NONE, VER_NONE)),
 


### PR DESCRIPTION
Unit test were crowded by these missing renamed symbols. They should be at least cover most of the LTCG titles. I am able to translate these renamed symbols according to Cxbx-Reloaded's documentations.