### PR TITLE
Fix XbSymbolDatabase_GenerateLibraryFilter for duplicate D3D8(LTCG) libraries

### DIFF
--- a/src/lib/internal_functions.h
+++ b/src/lib/internal_functions.h
@@ -652,3 +652,37 @@ static bool internal_LibraryFilterPermitScan(iXbSymbolContext* pContext, uint32_
     }
     return false;
 }
+
+// Check & update if build version is higher than existing library flag.
+static void internal_LibraryFilterUpdateVersionIfGreater(XbSDBLibrary* filters,
+                                                         unsigned int count,
+                                                         uint32_t library_flags,
+                                                         uint16_t wBuildVersion,
+                                                         uint16_t QFEVersion)
+{
+    for (unsigned filter_i = 0; filter_i < count; filter_i++) {
+        if (filters[filter_i].flag & library_flags) {
+            if (filters[filter_i].build_version < wBuildVersion) {
+                filters[filter_i].build_version = wBuildVersion;
+                filters[filter_i].qfe_version = QFEVersion;
+            }
+            else if (filters[filter_i].qfe_version < QFEVersion) {
+                filters[filter_i].qfe_version = QFEVersion;
+            }
+        }
+    }
+}
+
+// Check & update existing library flag to new library flag.
+static void internal_LibraryFilterUpdateFlagIfExist(XbSDBLibrary* filters,
+                                                    unsigned int count,
+                                                    uint32_t library_flag_find,
+                                                    uint32_t library_flag_set)
+{
+    for (unsigned filter_i = 0; filter_i < count; filter_i++) {
+        if ((filters[filter_i].flag & library_flag_find) == library_flag_find) {
+            filters[filter_i].flag = library_flag_set;
+            memcpy(filters[filter_i].name, XbSymbolDatabase_LibraryToString(library_flag_set), 8);
+        }
+    }
+}

--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -503,6 +503,7 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
     unsigned int count = 0;
     uint16_t build_version = 0;
     bool has_dsound_library = false;
+    bool has_d3d8__ltcg_library = false;
     xb_xbe_type XbeType = GetXbeType(xb_header_addr);
     OutputHandler output = {
         .func = g_output_func,
@@ -529,6 +530,31 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
             // If found DSOUND library, then skip the manual check.
             if (library_flag == XbSymbolLib_DSOUND && !has_dsound_library) {
                 has_dsound_library = true;
+            }
+
+            // If D3D8 and D3D8LTCG library details may had bundled by accident, then do manual fix below.
+            // See details from https://github.com/Cxbx-Reloaded/XbSymbolDatabase/issues/178
+            if (has_d3d8__ltcg_library) {
+                if (library_header != NULL) {
+                    if (library_flag == XbSymbolLib_D3D8LTCG) {
+                        // Force set to D3D8LTCG if D3D8 flag was found first.
+                        internal_LibraryFilterUpdateFlagIfExist(library_header->filters,
+                                                                count,
+                                                                XbSymbolLib_D3D8,
+                                                                XbSymbolLib_D3D8LTCG);
+                    }
+                    // Update duplicated library detail
+                    internal_LibraryFilterUpdateVersionIfGreater(library_header->filters,
+                                                                 count,
+                                                                 XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG,
+                                                                 xb_library_versions[library_index].wBuildVersion,
+                                                                 xb_library_versions[library_index].wFlags.QFEVersion);
+                }
+                // Skip duplicate library finding.
+                continue;
+            }
+            else if (!has_d3d8__ltcg_library && (library_flag & (XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG))) {
+                has_d3d8__ltcg_library = true;
             }
 
             // Append the information to the array.


### PR DESCRIPTION
fixed #178

It was brought up while doing the unit test process with Xbox Dashboard (b5659) which end up showing:
```
Library[4]
    name    = D3D8;
    build   = 5659;
    qre ver = 0x1;
    flag    = 0x1;
Library[5]
    name    = D3D8LTCG;
    build   = 5659;
    qre ver = 0x1;
    flag    = 0x2;
```


With this pull request, now it is showing correctly for specific D3D8(LTCG) library to scan.
```
[00005a28] INFO   : Getting library and section filters...
[00005a28] INFO   : Outputting library filters...
[00005a28] INFO   : Library[0]
[00005a28] INFO   :     name    = XAPILIB
[00005a28] INFO   :     build   = 5659
[00005a28] INFO   :     qre ver = 0x1
[00005a28] INFO   :     flag    = 0x40
[00005a28] INFO   : Library[1]
[00005a28] INFO   :     name    = D3DX8
[00005a28] INFO   :     build   = 5659
[00005a28] INFO   :     qre ver = 0x1
[00005a28] INFO   :     flag    = 0x4
[00005a28] INFO   : Library[2]
[00005a28] INFO   :     name    = DSOUND
[00005a28] INFO   :     build   = 5659
[00005a28] INFO   :     qre ver = 0x1
[00005a28] INFO   :     flag    = 0x8
[00005a28] INFO   : Library[3]
[00005a28] INFO   :     name    = XONLINES
[00005a28] INFO   :     build   = 5659
[00005a28] INFO   :     qre ver = 0x1
[00005a28] INFO   :     flag    = 0x1000
[00005a28] INFO   : Library[4]
[00005a28] INFO   :     name    = D3D8LTCG
[00005a28] INFO   :     build   = 5659
[00005a28] INFO   :     qre ver = 0x1
[00005a28] INFO   :     flag    = 0x2
```

----

Here's the xbe's library header details from Xbox Dashboard (b5659) as example of conflict.
```
Name                  : Xbox Dashboard
TitleID               : FFFE0000
TitleIDHex            : 0xfffe0000
Region                : 0x7fffffff
Xbe header hash       : 387b0a91349ec64f
Library Name[ 0]      : XAPILIB  (b5659.1)
Library Name[ 1]      : XAPILBP  (b5659.1)
Library Name[ 2]      : XBOXDASH (b5659.4099)
Library Name[ 3]      : LIBCMT   (b5659.1)
Library Name[ 4]      : XBOXKRNL (b5659.1)
Library Name[ 5]      : D3DX8    (b5659.1)
Library Name[ 6]      : DSOUND   (b5659.1)
Library Name[ 7]      : XONLINES (b5659.1)
Library Name[ 8]      : XVOICE   (b5659.1)
Library Name[ 9]      : XKEY     (b5659.1)
Library Name[10]      : LIBCPMT  (b5659.1)
Library Name[11]      : D3D8     (b5659.1)
Library Name[12]      : D3D8LTCG (b5659.1)
Library Name[13]      : XGRAPHCL (b5659.1)
BuildVersion          : 5659
```