### PR TITLE
Update xxhash submodule to v0.8.2 and one commit ahead for necessary cmake error fix

### DIFF
--- a/projects/UnitTest/CMakeLists.txt
+++ b/projects/UnitTest/CMakeLists.txt
@@ -39,7 +39,7 @@ if(NOT TARGET xxhash)
  FetchContent_Populate(
   xxhash
   GIT_REPOSITORY https://github.com/Cyan4973/xxhash.git
-  GIT_TAG        35b0373c697b5f160d3db26b1cbb45a0d5ba788c
+  GIT_TAG        ea3bd57f8eca408d9e17fc003876b805be3af54e
   SOURCE_SUBDIR ./cmake_unofficial
  )
  add_subdirectory(${xxhash_SOURCE_DIR}/cmake_unofficial ${xxhash_BINARY_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
According to recent active pull request's log. CMake expected minimal required to be 3.5 or above from external library used for unit test tool.
> CMake Deprecation Error at build/projects/UnitTest/xxhash-src/cmake_unofficial/CMakeLists.txt:8 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.

Since upstream already include a fix for this. I proceed with update xxhash submodule to v0.8.2 plus one merged pull request commit relative to cmake fix warning deprecation (which is being treated as error by `-Werror=dev` flag).