### PR TITLE
HOTFIX: fix endless loop for dependency flag check is completed or not

### DIFF
--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -463,8 +463,8 @@ uint32_t XbSymbolDatabase_GetLibraryDependencies(uint32_t library_flag, XbSDBLib
             ret_dependencies |= library_filters.filters[i].flag;
         }
     }
-    // If flag dependency is/are found, then return those.
-    if (ret_dependencies) {
+    // If library filters were given, then return any dependencies that were found.
+    if (library_filters.count) {
         return ret_dependencies;
     }
     // If not, then return whole dependency filters.


### PR DESCRIPTION
After reviewing codebase, I believe I found the source of endless loop for when dependency flags are returned but never checked if any of them are matched. Instead of fix cli and unittest tools, I recommended to fix it internally to work as intentional design. This fixed certain Chihiro titles containing D3D8I library except absent of D3D8I signatures support.

fixed #197