### PR TITLE
Bulk misc updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,42 +1,68 @@
 # Add 'OOVPA' and 'needs-verification' labels within OOVPADatabase folder and subfolders
 OOVPA:
-  - src/OOVPADatabase/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/**/*
 needs-verification:
-  - src/OOVPADatabase/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/**/*
 
 # The rest is base on folder and file's naming
 D3D8:
-  - src/OOVPADatabase/D3D8/*
-  - src/OOVPADatabase/D3D8_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/D3D8/*
+    - src/OOVPADatabase/D3D8_*.inl
 D3D8LTCG:
-  - src/OOVPADatabase/D3D8LTCG/*
-  - src/OOVPADatabase/D3D8LTCG_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/D3D8LTCG/*
+    - src/OOVPADatabase/D3D8LTCG_*.inl
 DSOUND:
-  - src/OOVPADatabase/DSound/*
-  - src/OOVPADatabase/DSound_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/DSound/*
+    - src/OOVPADatabase/DSound_*.inl
 JVS:
-  - src/OOVPADatabase/JVS/*
-  - src/OOVPADatabase/JVS_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/JVS/*
+    - src/OOVPADatabase/JVS_*.inl
 XACTENG:
-  - src/OOVPADatabase/XActEng/*
-  - src/OOVPADatabase/XActEng_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/XActEng/*
+    - src/OOVPADatabase/XActEng_*.inl
 XGRAPHIC:
-  - src/OOVPADatabase/XGraphic/*
-  - src/OOVPADatabase/XGraphic_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/XGraphic/*
+    - src/OOVPADatabase/XGraphic_*.inl
 XNET:
-  - src/OOVPADatabase/XNet/*
-  - src/OOVPADatabase/XNet_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/XNet/*
+    - src/OOVPADatabase/XNet_*.inl
 XONLINE:
-  - src/OOVPADatabase/XOnline/*
-  - src/OOVPADatabase/XOnline_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/XOnline/*
+    - src/OOVPADatabase/XOnline_*.inl
 XAPI:
-  - src/OOVPADatabase/Xapi/*
-  - src/OOVPADatabase/Xapi_*.inl
+- changed-files:
+  - any-glob-to-any-file:
+    - src/OOVPADatabase/Xapi/*
+    - src/OOVPADatabase/Xapi_*.inl
 
 # Misc
 CMAKE:
-  - '**/CMakeLists.txt'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/CMakeLists.txt'
 
 # Whenever add another tool, update below as well.
 TOOLS:
-  - src/cli/**
+- changed-files:
+  - any-glob-to-any-file:
+    - src/cli/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       do-build: ${{ steps.build-cond.outputs.do-build }}
       do-release: ${{ github.repository == env.repo_default }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: RadWolfie/Semantic-Version-Action@main
@@ -65,78 +65,106 @@ jobs:
       # NOTE: Require to reduce workload from CI service from fetch whole git content.
       - name: Upload Changelog
         if: steps.build-cond.outputs.do-build == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: changelog
+  matrix_setup:
+    name: Setup Builders
+    runs-on: ubuntu-latest
+    outputs:
+      builder: ${{steps.set-builder.outputs.result}}
+    steps:
+      - uses: actions/github-script@v7
+        id: set-builder
+        with:
+          script: |
+            const platforms = [
+                {"platform": "Windows", "folder": "win", "cmake-build-param": "-j $env:NUMBER_OF_PROCESSORS"},
+                {"platform": "Linux", "folder": "linux", "cmake-build-param": "-j $(nproc --all)", "cmake-generator": "-G \"Unix Makefiles\""},
+                {"platform": "macOS", "folder": "macos", "cmake-build-param": "-j $(sysctl -n hw.ncpu)", "cmake-generator": "-G Xcode"}
+            ];
+            let builder = [];
+            for (let build of platforms.values()) {
+              if (build.platform === "Windows") {
+                // always use the latest os
+                build["os"] = "windows-latest";
+                // create x86 build
+                build["arch"] = "x86";
+                build["cmake-generator"] = "-A Win32";
+                builder.push(Object.assign({}, build));
+                // create x64 build
+                build["arch"] = "x64";
+                build["cmake-generator"] = "-A x64";
+                builder.push(Object.assign({}, build));
+              }
+              if (build.platform === "Linux") {
+                // no other variant needed at this time
+                build["os"] = "ubuntu-latest";
+                build["arch"] = "x64";
+                builder.push(Object.assign({}, build));
+              }
+              if (build.platform === "macOS") {
+                // create x64 build (only on macos-13 and earlier)
+                build["os"] = "macos-13";
+                build["arch"] = "x64";
+                builder.push(Object.assign({}, build));
+                // create amd64 build (only on macos-14 and later)
+                build["os"] = "macos-latest";
+                build["arch"] = "amd64";
+                builder.push(Object.assign({}, build));
+              }
+            }
+            console.log(builder);
+            return builder;
   build:
-    name: ${{ matrix.platform }} (${{ matrix.arch }}, ${{ matrix.configuration }})
-    runs-on: ${{ matrix.os }}
-    needs: semver
+    name: ${{ matrix.builder.platform }} (${{ matrix.builder.arch }}, ${{ matrix.configuration }})
+    runs-on: ${{ matrix.builder.os }}
+    needs: [semver, matrix_setup]
     if: needs.semver.outputs.do-build == 'true'
     strategy:
       fail-fast: false
       matrix:
-        cmake-generator:
-          # x86 arch
-          - -A Win32 # Visual Studio (latest IDE)
-          # x64 arch
-          - -A x64 # Visual Studio (latest IDE)
-          - -G "Unix Makefiles"
-          - -G Xcode
         configuration: [Debug, Release]
-        include:
-          - cmake-generator: -A Win32
-            platform: Windows
-            os: windows-latest
-            arch: x86
-            cmake-build-param: -j $env:NUMBER_OF_PROCESSORS
-            folder: win
-          - cmake-generator: -A x64
-            platform: Windows
-            os: windows-latest
-            arch: x64
-            cmake-build-param: -j $env:NUMBER_OF_PROCESSORS
-            folder: win
-          - cmake-generator: -G "Unix Makefiles"
-            platform: Linux
-            os: ubuntu-latest
-            arch: x64
-            cmake-build-param: -j $(nproc --all)
-            folder: linux
-          - cmake-generator: -G Xcode
-            platform: macOS
-            os: macos-latest
-            arch: x64
-            cmake-build-param: -j $(sysctl -n hw.ncpu)
-            folder: macos
+        builder: ${{fromJSON(needs.matrix_setup.outputs.builder)}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Generate CMake Files
         # NOTES:
         # -Werror=dev is used to validate CMakeLists.txt for any faults.
-        run: cmake -B build -Werror=dev ${{ matrix.cmake-generator }}
+        run: cmake -B build -Werror=dev ${{ matrix.builder.cmake-generator }}
       - name: Build
-        run: cmake --build build --config ${{ matrix.configuration }} ${{ matrix.cmake-build-param }}
+        run: cmake --build build --config ${{ matrix.configuration }} ${{ matrix.builder.cmake-build-param }}
       - name: CTests
         run: ctest --test-dir build --build-config ${{ matrix.configuration }} --verbose
       - name: Copy Files
         if: matrix.configuration == 'Release'
-        run: cmake --install build --config ${{ matrix.configuration }} --prefix upload/${{ matrix.folder }}_${{ matrix.arch }}
+        run: cmake --install build --config ${{ matrix.configuration }} --prefix upload/${{ matrix.builder.folder }}_${{ matrix.builder.arch }}
       - name: Upload Build Artifact
         if: matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: XbSymbolDatabase
+          name: XbSymbolDatabase-${{ matrix.builder.folder }}_${{ matrix.builder.arch }}
           # roughly translate to upload/<platform_arch>/<bin | lib | include>/<anything in here and after>
           path: upload/*/*/*
           if-no-files-found: error
       - name: Upload Misc Artifact
-        if: matrix.cmake-generator == '-G "Unix Makefiles"' && matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v3
+        if: matrix.builder.cmake-generator == '-G "Unix Makefiles"' && matrix.configuration == 'Release'
+        uses: actions/upload-artifact@v4
         with:
-          name: XbSymbolDatabase
+          name: XbSymbolDatabase-misc
           path: |
             README.md
             LICENSE
           if-no-files-found: error
+  merge:
+    name: Merge Artifacts
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ !cancelled() }}
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: XbSymbolDatabase
+          pattern: XbSymbolDatabase-*
+          delete-merged: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Labeler
-        uses: actions/labeler@v4
+        uses: actions/labeler@v5
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
+          dot: false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # IMPORTANT: Make sure checkout is pulling pull request's merge commit!
           ref: 'refs/pull/${{ github.event.number }}/merge'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
     env:
       tag_name: ${{ needs.build.outputs.ver-cur }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         # NOTE: We're downloading ALL artifacts.
       - name: Prepare artifacts for release
         run: | # download-artifact doesn't download a zip, so rezip it

--- a/projects/UnitTest/CMakeLists.txt
+++ b/projects/UnitTest/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT TARGET simpleini)
  FetchContent_Populate(
   simpleini
   GIT_REPOSITORY https://github.com/brofield/simpleini.git
-  GIT_TAG        56499b5af5d2195c6acfc58c4630b70e0c9c4c21
+  GIT_TAG        f7862c3dd7ad35becc2741f268e3402e89a37666
  )
 endif()
 

--- a/src/OOVPADatabase/OOVPA.h
+++ b/src/OOVPADatabase/OOVPA.h
@@ -178,10 +178,12 @@ typedef struct _LOOVPA {
 #define OOVPA_END }
 // clang-format on
 
+#pragma pack() // require restore pack for AppleClang to build
 typedef struct _OOVPARevision {
     OOVPA* Oovpa;
     unsigned short Version; // : 13; // 2^13 = 8192, enough to store lowest and highest possible Library Version number in
 } OOVPARevision;
+#pragma pack(1)
 
 #define COUNTARGS_USHORT(...) (sizeof((unsigned short[]){ __VA_ARGS__ }) / sizeof(unsigned short))
 
@@ -196,6 +198,7 @@ typedef enum _eDBScanType {
 // ******************************************************************
 // * OOVPATable
 // ******************************************************************
+#pragma pack() // require restore pack for AppleClang to build
 typedef struct _OOVPATable {
     uint16_t xref;
     char* szFuncName;
@@ -203,6 +206,7 @@ typedef struct _OOVPATable {
     unsigned count;
     OOVPARevision* revisions;
 } OOVPATable;
+#pragma pack(1)
 
 // http://en.cppreference.com/w/cpp/iterator/size
 //#include <iterator>

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -898,7 +898,7 @@ int main(int argc, char** argv)
         return UNITTEST_OK;
     }
 
-    if (test_ret = cliInputInteractive(argc, argv)) {
+    if ((test_ret = cliInputInteractive(argc, argv))) {
         return test_ret;
     }
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -22,6 +22,7 @@
 #include <string>
 //#define DISABLE_MULTI_THREAD // NOTE: Uncomment define if need to use or test on single thread.
 #ifndef DISABLE_MULTI_THREAD
+#include <vector> // for using with thread library
 #include <thread>
 #include <mutex>
 static std::mutex mtx_context;


### PR DESCRIPTION
Due to GitHub Actions made some regression along with latest macOS's architecture change. I have determined to have all the fixes in one pull request to ensure the GitHub Actions upgrade directly are working with new requirement changes.

GitHub Actions upgrade:
- actions/checkout@v4
- actions/upload-artifact@v4
- actions/download-artifact@v4
- actions/labeler@v5

The github-script action is added due to workflow's matrix doesn't really accept dynamic selection for specific builder. Although, it does seem a little bloated but does the job simpler.

The previous upload method no longer works with upload-artifact v4. Which require additional job to merge all the upload artifacts into one after the matrix builders are done.

macOS latest (macos-14) made a change from x64 to amd64 architecture. Which require to force fix folder name and add support for amd64.

Finally, labeler action has major rehaul on configuration file layout which require correction before upstream.