### PR TITLE
HOTFIX: Fix arch typo and use latest macOS with target arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             const platforms = [
                 {"platform": "Windows", "folder": "win", "cmake-build-param": "-j $env:NUMBER_OF_PROCESSORS"},
                 {"platform": "Linux", "folder": "linux", "cmake-build-param": "-j $(nproc --all)", "cmake-generator": "-G \"Unix Makefiles\""},
-                {"platform": "macOS", "folder": "macos", "cmake-build-param": "-j $(sysctl -n hw.ncpu)", "cmake-generator": "-G Xcode"}
+                {"platform": "macOS", "folder": "macos", "cmake-build-param": "-j $(sysctl -n hw.ncpu)"}
             ];
             let builder = [];
             for (let build of platforms.values()) {
@@ -105,13 +105,15 @@ jobs:
                 builder.push(Object.assign({}, build));
               }
               if (build.platform === "macOS") {
-                // create x64 build (only on macos-13 and earlier)
-                build["os"] = "macos-13";
-                build["arch"] = "x64";
-                builder.push(Object.assign({}, build));
-                // create amd64 build (only on macos-14 and later)
+                // always use the latest os
                 build["os"] = "macos-latest";
-                build["arch"] = "amd64";
+                // create x64 build
+                build["arch"] = "x64";
+                build["cmake-generator"] = "-G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64";
+                builder.push(Object.assign({}, build));
+                // create arm64 build
+                build["arch"] = "arm64";
+                build["cmake-generator"] = "-G Xcode -DCMAKE_OSX_ARCHITECTURES=arm64";
                 builder.push(Object.assign({}, build));
               }
             }


### PR DESCRIPTION
I recently noticed my mistake of mixup with arm64 and amd64 wording. This hotfix pull request will compile with given architecture target on latest macOS image from Github CI. After inspection from GitHub CI log output, I can confirm they have been corrected.

references from this pull request's CI builds:
- ![image](https://github.com/Cxbx-Reloaded/XbSymbolDatabase/assets/3938312/f6528eb6-08be-4f1c-acb7-82d02939297d)
- ![image](https://github.com/Cxbx-Reloaded/XbSymbolDatabase/assets/3938312/d1a2bff5-e060-4385-8a75-237c0db5d5d9)


Technically, it could be possible to build universal binary bundled both x64 and arm64. However, Ghidra seems to use separate folder both architectures. For time being, we will have them build separately until there is a request to merge together.