### PR TITLE
Update action to resolve missing distutils module error

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
           # IMPORTANT: Make sure checkout is pulling pull request's merge commit!
           ref: 'refs/pull/${{ github.event.number }}/merge'
       - name: Clang-Format Lint Verify
-        uses: DoozyX/clang-format-lint-action@v0.11
+        uses: DoozyX/clang-format-lint-action@v0.18
         with:
           source: '.'
           extensions: 'h,c,inl'


### PR DESCRIPTION
`DoozyX/clang-format-lint-action@v0.11` report an error, most likely GitHub's runner image may have changed over time.

```
Traceback (most recent call last):
  File "/run-clang-format.py", line 25, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils'
```