### PR TITLE
Rename APIs Prefix

### DIFF
--- a/include/libXbSymbolDatabase.h
+++ b/include/libXbSymbolDatabase.h
@@ -18,63 +18,63 @@ extern "C" {
 // * Library strings
 // ******************************************************************
 // clang-format off
-#define Lib_UNKNOWN  "UNKNOWN"
+#define LIB_UNKNOWN  "UNKNOWN"
 // clang-format on
 // Group of sections since most libraries are compiled inside the
 // section(s) below.
-#define Sec_text     ".text"
-#define Sec_FLASHROM "FLASHROM"
+#define SEC_TEXT     ".text"
+#define SEC_FLASHROM "FLASHROM"
 // DSOUND has a vtable store in .rdata section.
 // clang-format off
-#define Sec_rdata    ".rdata"
+#define SEC_RDATA    ".rdata"
 // clang-format on
 // Individual library (yet do include group sections above)
-#define Lib_D3D8     "D3D8"
-#define Sec_D3D      "D3D"
-#define Lib_D3D8LTCG "D3D8LTCG"
-#define Lib_D3DX8    "D3DX8"
-#define Sec_D3DX     "D3DX"
-#define Lib_DSOUND   "DSOUND"
-#define Sec_DSOUND   Lib_DSOUND
-#define Lib_JVS      "JVS"
-#define Lib_XACTENG  "XACTENG"
-#define Sec_XACTENG  Lib_XACTENG
-#define Lib_XAPILIB  "XAPILIB"
-#define Sec_XID      ".XID"
-#define Sec_XPP      "XPP"
-#define Sec_XPPDat   ".XPP&Dat"
-#define Lib_XGRAPHC  "XGRAPHC"
-#define Sec_XGRPH    "XGRPH"
-#define Lib_XNET     "XNET"
-#define Lib_XNETN    "XNETN"
-#define Lib_XNETS    "XNETS"
-#define Lib_XONLINE  "XONLINE"
-#define Sec_XONLINE  Lib_XONLINE
-#define Lib_XONLINES "XONLINES"
-#define Lib_XONLINLS "XONLINLS"
-#define Sec_XNET     "XNET"
+#define LIB_D3D8     "D3D8"
+#define SEC_D3D      "D3D"
+#define LIB_D3D8LTCG "D3D8LTCG"
+#define LIB_D3DX8    "D3DX8"
+#define SEC_D3DX     "D3DX"
+#define LIB_DSOUND   "DSOUND"
+#define SEC_DSOUND   LIB_DSOUND
+#define LIB_JVS      "JVS"
+#define LIB_XACTENG  "XACTENG"
+#define SEC_XACTENG  LIB_XACTENG
+#define LIB_XAPILIB  "XAPILIB"
+#define SEC_XID      ".XID"
+#define SEC_XPP      "XPP"
+#define SEC_XPPDAT   ".XPP&Dat"
+#define LIB_XGRAPHC  "XGRAPHC"
+#define SEC_XGRPH    "XGRPH"
+#define LIB_XNET     "XNET"
+#define LIB_XNETN    "XNETN"
+#define LIB_XNETS    "XNETS"
+#define LIB_XONLINE  "XONLINE"
+#define SEC_XONLINE  LIB_XONLINE
+#define LIB_XONLINES "XONLINES"
+#define LIB_XONLINLS "XONLINLS"
+#define SEC_XNET     "XNET"
 
-#define XbSymbolLib_D3D8     (1 << 0)
-#define XbSymbolLib_D3D8LTCG (1 << 1)
-#define XbSymbolLib_D3DX8    (1 << 2)
-#define XbSymbolLib_DSOUND   (1 << 3)
-#define XbSymbolLib_JVS      (1 << 4)
-#define XbSymbolLib_XACTENG  (1 << 5)
-#define XbSymbolLib_XAPILIB  (1 << 6)
-#define XbSymbolLib_XGRAPHC  (1 << 7)
-#define XbSymbolLib_XNET     (1 << 8)
-#define XbSymbolLib_XNETN    (1 << 9)
-#define XbSymbolLib_XNETS    (1 << 10)
-#define XbSymbolLib_XONLINE  (1 << 11)
-#define XbSymbolLib_XONLINES (1 << 12)
-#define XbSymbolLib_XONLINLS (1 << 13)
+#define XBSDBLIB_D3D8     (1 << 0)
+#define XBSDBLIB_D3D8LTCG (1 << 1)
+#define XBSDBLIB_D3DX8    (1 << 2)
+#define XBSDBLIB_DSOUND   (1 << 3)
+#define XBSDBLIB_JVS      (1 << 4)
+#define XBSDBLIB_XACTENG  (1 << 5)
+#define XBSDBLIB_XAPILIB  (1 << 6)
+#define XBSDBLIB_XGRAPHC  (1 << 7)
+#define XBSDBLIB_XNET     (1 << 8)
+#define XBSDBLIB_XNETN    (1 << 9)
+#define XBSDBLIB_XNETS    (1 << 10)
+#define XBSDBLIB_XONLINE  (1 << 11)
+#define XBSDBLIB_XONLINES (1 << 12)
+#define XBSDBLIB_XONLINLS (1 << 13)
 
 // clang-format off
 // TODO: Need to find a way keep below intact.
-#define XbSymbolLib_ALL ( XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG | XbSymbolLib_D3DX8 | XbSymbolLib_DSOUND \
-                        | XbSymbolLib_JVS | XbSymbolLib_XACTENG | XbSymbolLib_XAPILIB | XbSymbolLib_XGRAPHC \
-                        | XbSymbolLib_XNET | XbSymbolLib_XNETN | XbSymbolLib_XNETS | XbSymbolLib_XONLINE \
-                        | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS)
+#define XBSDBLIB_ALL ( XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG | XBSDBLIB_D3DX8 | XBSDBLIB_DSOUND \
+                     | XBSDBLIB_JVS | XBSDBLIB_XACTENG | XBSDBLIB_XAPILIB | XBSDBLIB_XGRAPHC \
+                     | XBSDBLIB_XNET | XBSDBLIB_XNETN | XBSDBLIB_XNETS | XBSDBLIB_XONLINE \
+                     | XBSDBLIB_XONLINES | XBSDBLIB_XONLINLS)
 // clang-format on
 
 typedef enum _xb_output_message {
@@ -168,7 +168,7 @@ typedef struct _XbSDBSectionHeader {
     XbSDBSection* filters;
 } XbSDBSectionHeader;
 
-typedef void* XbSymbolContextHandle;
+typedef void* XbSDBContextHandle;
 
 // ******************************************************************
 // * API functions to use with other projects.
@@ -178,21 +178,21 @@ typedef void* XbSymbolContextHandle;
 /// Return value is only useful to prevent re-cache the file every time. It does not taken existing functions into account.
 /// </summary>
 /// <returns>Return a version of current library database.</returns>
-unsigned int XbSymbolDatabase_LibraryVersion();
+unsigned int XbSDB_LibraryVersion();
 
 /// <summary>
 /// Total symbols return give ability to support for progress bar from third-party software. Not all symbols will be detected in every titles.
 /// </summary>
-/// <param name="library_filter">See defined prefix of XbSymbolLib_ above to choose one or more library you wish to obtain total symbols.</param>
+/// <param name="library_filter">See defined prefix of XBSDBLIB_ above to choose one or more library you wish to obtain total symbols.</param>
 /// <returns>Return total symbols in current database system.</returns>
-unsigned XbSymbolDatabase_GetTotalSymbols(uint32_t library_filter);
+unsigned XbSDB_GetTotalSymbols(uint32_t library_filter);
 
 /// <summary>
 /// Register one or more library to be scan instead of whole database for optimize performance.
 /// </summary>
-/// <param name="library_filter">See defined prefix of XbSymbolLib_ above to choose one or more library you wish to scan.</param>
+/// <param name="library_filter">See defined prefix of XBSDBLIB_ above to choose one or more library you wish to scan.</param>
 /// <returns>Return true if success, or else will return false for invalid parameter.</returns>
-bool XbSymbolContext_RegisterLibrary(XbSymbolContextHandle pHandle, uint32_t library_filter);
+bool XbSDBContext_RegisterLibrary(XbSDBContextHandle pHandle, uint32_t library_filter);
 
 /// <summary>
 /// Callback function type for output message to software when have information to be output.
@@ -205,7 +205,7 @@ typedef void (*xb_output_message_t)(xb_output_message message_flag, const char* 
 /// Register output message callback function to receive output message.
 /// </summary>
 /// <param name="message_func">Set output message to a callback function.</param>
-void XbSymbolDatabase_SetOutputMessage(xb_output_message_t message_func);
+void XbSDB_SetOutputMessage(xb_output_message_t message_func);
 
 /// <summary>
 /// To register any detected symbol name with address and build version back to third-party program.
@@ -229,55 +229,55 @@ typedef void (*xb_symbol_register_t)(const char* library_str, uint32_t library_f
 /// <param name="register_func">Callback register function to be call for any detected symbols.</param>
 /// <param name="is_raw">True: Full scan of raw xbe; False: Scan only loaded sections.</param>
 /// <returns>Only return false if something is not valid.</returns>
-bool XbSymbolScan(const void* xb_header_addr, xb_symbol_register_t register_func, bool is_raw);
+bool XbSDB_Scan(const void* xb_header_addr, xb_symbol_register_t register_func, bool is_raw);
 
 /// <summary>
 /// To convert library flag into string format.
 /// </summary>
 /// <param name="library_flag">Input specific library flag.</param>
 /// <returns>Return "UNKNOWN" string if does not exist in the database. Otherwise will return library name string.</returns>
-const char* XbSymbolDatabase_LibraryToString(uint32_t library_flag);
+const char* XbSDB_LibraryToString(uint32_t library_flag);
 
 /// <summary>
 /// To convert parameter type into string format.
 /// </summary>
 /// <param name="param_type">Input provided param_type from symbol register callback.</param>
 /// <returns>Return "unk" string if does not exist in the database. Otherwise it will return the string representation of the parameter type.</returns>
-const char* XbSymbolDatabase_ParamToString(uint32_t param_type);
+const char* XbSDB_ParamToString(uint32_t param_type);
 
 /// <summary>
 /// To convert calling convention type into string format.
 /// </summary>
 /// <param name="call_type">Input provided call_type from symbol register callback.</param>
 /// <returns>Return "unknown" string if does not exist in the database. Otherwise it will return the string representation of the calling convention type.</returns>
-const char* XbSymbolDatabase_CallingConventionToString(uint32_t call_type);
+const char* XbSDB_CallingConventionToString(uint32_t call_type);
 
 /// <summary>
 /// To convert a symbol reference index into string format.
 /// </summary>
 /// <param name="xref_index">Input provided xref_index from symbol register callback.</param>
 /// <returns>Returns a demangled symbol name string.</returns>
-const char* XbSymbolDatabase_SymbolReferenceToString(uint32_t xref_index);
+const char* XbSDB_SymbolReferenceToString(uint32_t xref_index);
 
 /// <summary>
 /// To convert library name string into flag format.
 /// </summary>
 /// <param name="library_name">Input library name string.</param>
 /// <returns>Return 0 if does not exist in the database. Otherwise will return flag value.</returns>
-uint32_t XbSymbolDatabase_LibraryToFlag(const char* library_name);
+uint32_t XbSDB_LibraryToFlag(const char* library_name);
 
 /// <summary>
 /// (Debug feature) By calling it will perform a self test for duplicate OOVPAs. (May will change at any time.)
 /// </summary>
 /// <returns>Return total count of errors.</returns>
-unsigned int XbSymbolDatabase_TestOOVPAs();
+unsigned int XbSDB_TestOOVPAs();
 
 /// <summary>
 /// (Debug feature) Set to true will perform full range of OOVPAs registered in current database.
 /// Or stop at xbe's build version detected.
 /// </summary>
 /// <param name="bypass_limit">Input boolean to either bypass or enable the build version limit.</param>
-void XbSymbolContext_SetBypassBuildVersionLimit(XbSymbolContextHandle pHandle, bool bypass_limit);
+void XbSDBContext_SetBypassBuildVersionLimit(XbSDBContextHandle pHandle, bool bypass_limit);
 
 /// <summary>
 /// To set verbose level can be output message.
@@ -285,29 +285,29 @@ void XbSymbolContext_SetBypassBuildVersionLimit(XbSymbolContextHandle pHandle, b
 /// </summary>
 /// <param name="verbose_level">See xb_output_message enum for list of options.</param>
 /// <returns>True: Successful set. False: Invalid input value.</returns>
-bool XbSymbolDatabase_SetOutputVerbosity(xb_output_message verbose_level);
+bool XbSDB_SetOutputVerbosity(xb_output_message verbose_level);
 
 /// <summary>
 /// (Debug feature) Set to true will continue the same signature scan after first detected.
 /// </summary>
 /// <param name="enable">Input boolean to either continue with the signature scan after first symbol found or not.</param>
-void XbSymbolContext_SetContinuousSigScan(XbSymbolContextHandle pHandle, bool enable);
+void XbSDBContext_SetContinuousSigScan(XbSDBContextHandle pHandle, bool enable);
 
 /// <summary>
 /// (Debug feature) Set to true will register first detected address only.
-/// This function can be used if XbSymbolContext_SetContinuousSigScan is set to true.
+/// This function can be used if XbSDBContext_SetContinuousSigScan is set to true.
 /// </summary>
 /// <param name="enable">Input boolean to use first symbol address only or not.</param>
-void XbSymbolContext_SetFirstDetectAddressOnly(XbSymbolContextHandle pHandle, bool enable);
+void XbSDBContext_SetFirstDetectAddressOnly(XbSDBContextHandle pHandle, bool enable);
 
 /// <summary>
 /// Get library flag's dependencies.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
 /// <param name="library_flag">Input specific library flag.</param>
 /// <param name="library_filters">Input generated library filters.</param>
 /// <returns>Return either none, one, or more library flag dependencies.</returns>
-uint32_t XbSymbolDatabase_GetLibraryDependencies(uint32_t library_flag, XbSDBLibraryHeader library_filters);
+uint32_t XbSDB_GetLibraryDependencies(uint32_t library_flag, XbSDBLibraryHeader library_filters);
 
 /// <summary>
 /// Step 1: Generate library array for LibraryHeader input.
@@ -316,7 +316,7 @@ uint32_t XbSymbolDatabase_GetLibraryDependencies(uint32_t library_flag, XbSDBLib
 /// <param name="xb_header_addr">Input pointer to xbox pe header.</param>
 /// <param name="library_out">Input null pointer will provide the count to allocate memory for library_out.filters field. Otherwise, information will be input to library_out.filters field.</param>
 /// <returns>Return total library found can be use in scan process.</returns>
-unsigned int XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSDBLibraryHeader* library_out);
+unsigned int XbSDB_GenerateLibraryFilter(const void* xb_header_addr, XbSDBLibraryHeader* library_out);
 
 /// <summary>
 /// Step 2: Generate section array for SectionHeader input.
@@ -326,73 +326,73 @@ unsigned int XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, 
 /// <param name="section_out">Input null pointer will provide the count to allocate memory, then allocate memory to section_out.filters field.</param>
 /// <param name="is_raw">True: Convert array to use raw xbe's relative address; False: Convert array to use xbox virtual memory relative address.</param>
 /// <returns>Return total sections found can be use in scan process.</returns>
-unsigned int XbSymbolDatabase_GenerateSectionFilter(const void* xb_header_addr, XbSDBSectionHeader* section_out, bool is_raw);
+unsigned int XbSDB_GenerateSectionFilter(const void* xb_header_addr, XbSDBSectionHeader* section_out, bool is_raw);
 
 /// <summary>
 /// Step 3: Get Xbox kernel thunk address.
 /// </summary>
 /// <param name="xb_header_addr">Input pointer to xbox pe header.</param>
 /// <returns>Return kernel thunk address. NOTE: This function may not return valid address.</returns>
-xbaddr XbSymbolDatabase_GetKernelThunkAddress(const void* xb_header_addr);
+xbaddr XbSDB_GetKernelThunkAddress(const void* xb_header_addr);
 
 /// <summary>
-/// Step 4: Create XbSymbolContextHandle context for the scan process.
+/// Step 4: Create XbSDBContextHandle context for the scan process.
 /// </summary>
-/// <param name="ppHandle">Output XbSymbolContextHandle handler.</param>
+/// <param name="ppHandle">Output XbSDBContextHandle handler.</param>
 /// <param name="register_func">Register callback function for any detected symbols during scan process.</param>
-/// <param name="library_input">See XbSymbolDatabase_GenerateLibraryFilter for details.</param>
-/// <param name="section_input">See XbSymbolDatabase_GenerateSectionFilter for details.</param>
+/// <param name="library_input">See XbSDB_GenerateLibraryFilter for details.</param>
+/// <param name="section_input">See XbSDB_GenerateSectionFilter for details.</param>
 /// <param name="kernel_thunk">Input decoded virtual kernel thunk.</param>
 /// <returns>Return true if context handle's creation is a success.</returns>
-bool XbSymbolDatabase_CreateXbSymbolContext(XbSymbolContextHandle* ppHandle, xb_symbol_register_t register_func, XbSDBLibraryHeader library_input, XbSDBSectionHeader section_input, xbaddr kernel_thunk);
+bool XbSDB_CreateContext(XbSDBContextHandle* ppHandle, xb_symbol_register_t register_func, XbSDBLibraryHeader library_input, XbSDBSectionHeader section_input, xbaddr kernel_thunk);
 
 /// <summary>
 /// Step 5: Perform a manual scan to set references, XRefDatabase, manually by requirement.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
-void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle);
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
+void XbSDBContext_ScanManual(XbSDBContextHandle pHandle);
 
 /// <summary>
 /// Step 6: Get library flag's dependencies.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
 /// <param name="library_flag">Input specific library flag.</param>
 /// <param name="library_filters">Input generated library filters.</param>
 /// <returns>Return either none, one, or more library flag dependencies.</returns>
-uint32_t XbSymbolContext_GetLibraryDependencies(XbSymbolContextHandle pHandle, uint32_t library_flag);
+uint32_t XbSDBContext_GetLibraryDependencies(XbSDBContextHandle pHandle, uint32_t library_flag);
 
-#define XbSymbolDatabase_CheckDependencyCompletion(completion_flag, dependencies) ((completion_flag & dependencies) == dependencies)
+#define XbSDB_CheckDependencyCompletion(completion_flag, dependencies) ((completion_flag & dependencies) == dependencies)
 
 /// <summary>
 /// Step 7a: (multi-thread safe, optional) Process individual library input by third-party.
 /// NOTE: If planned to use multi-thread purpose, please use thread-safe method for library dependency checkup.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
 /// <param name="pLibrary">Input pointer of a library to start a scan process.</param>
 /// <param name="xref_first_pass">True: Optimized first search scan process; False: 2nd call and later will continue to return non-zero; see return for detail.</param>
 /// <returns>Return total xref count found. Unless it return zero, then there's nothing left to find.</returns>
-unsigned int XbSymbolContext_ScanLibrary(XbSymbolContextHandle pHandle, const XbSDBLibrary* pLibrary, bool xref_first_pass);
+unsigned int XbSDBContext_ScanLibrary(XbSDBContextHandle pHandle, const XbSDBLibrary* pLibrary, bool xref_first_pass);
 
-#define XbSymbolDatabase_SetLibraryCompletion(completion_flag, library_flag) (completion_flag |= library_flag)
+#define XbSDB_SetLibraryCompletion(completion_flag, library_flag) (completion_flag |= library_flag)
 
 /// <summary>
 /// Step 7b: (single-thread usage) Process all of filter libraries internally.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
-void XbSymbolContext_ScanAllLibraryFilter(XbSymbolContextHandle pHandle);
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
+void XbSDBContext_ScanAllLibraryFilter(XbSDBContextHandle pHandle);
 
 /// <summary>
 /// Step 8: Register any references, XRefDatabase, may not had been output during the scan process.
 /// NOTE: Currently a stub at the moment.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
-void XbSymbolContext_RegisterXRefs(XbSymbolContextHandle pHandle);
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
+void XbSDBContext_RegisterXRefs(XbSDBContextHandle pHandle);
 
 /// <summary>
 /// Final Step: Release context.
 /// </summary>
-/// <param name="pHandle">Input XbSymbolContextHandle handler.</param>
-void XbSymbolContext_Release(XbSymbolContextHandle pHandle);
+/// <param name="pHandle">Input XbSDBContextHandle handler.</param>
+void XbSDBContext_Release(XbSDBContextHandle pHandle);
 
 #ifdef __cplusplus
 }

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -24,7 +24,7 @@ static void reg_cb(const char* library_str,
                    uint32_t param_count,
                    const XbSDBSymbolParam* param_list)
 {
-    const char* symbol_name = bReverseMangle ? symbol_str : XbSymbolDatabase_SymbolReferenceToString(xref_index);
+    const char* symbol_name = bReverseMangle ? symbol_str : XbSDB_SymbolReferenceToString(xref_index);
     char buffer[64] = { 0 };
     char param_output[256] = { 0 };
     size_t param_size = 0;
@@ -39,7 +39,7 @@ static void reg_cb(const char* library_str,
                     if (param_list[i].type == param_void) {
                         break;
                     }
-                    snprintf(buffer, ARRAY_SIZE(buffer), (i == 0 ? "%s %s" : ", %s %s"), XbSymbolDatabase_ParamToString(param_list[i].type), param_list[i].name);
+                    snprintf(buffer, ARRAY_SIZE(buffer), (i == 0 ? "%s %s" : ", %s %s"), XbSDB_ParamToString(param_list[i].type), param_list[i].name);
                     size_t buffer_count = strnlen(buffer, ARRAY_SIZE(buffer));
                     if (param_size + buffer_count >= ARRAY_SIZE(param_output)) {
                         printf("ERROR: param_size(%zu) + buffer_count(%zu) is too long to be stored in param_output(%zu)\n", param_size, buffer_count, ARRAY_SIZE(param_output));
@@ -48,7 +48,7 @@ static void reg_cb(const char* library_str,
                     strncat(param_output, buffer, buffer_count);
                     param_size += buffer_count;
                 }
-                printf("%.8s__FUN__%s__%s(%s) = 0x%08x\n", library_str, XbSymbolDatabase_CallingConventionToString(call_type), symbol_name, param_output, address);
+                printf("%.8s__FUN__%s__%s(%s) = 0x%08x\n", library_str, XbSDB_CallingConventionToString(call_type), symbol_name, param_output, address);
                 return;
             }
             default: {
@@ -95,7 +95,7 @@ int main(int argc, char const* argv[])
         return 1;
     }
 
-    unsigned int version = XbSymbolDatabase_LibraryVersion();
+    unsigned int version = XbSDB_LibraryVersion();
     if (bVerbose) {
         fprintf(stderr, "Database Version = %x\n", version);
     }
@@ -123,14 +123,14 @@ int main(int argc, char const* argv[])
         return 1;
     }
 
-    XbSymbolDatabase_SetOutputMessage(&msg_cb);
+    XbSDB_SetOutputMessage(&msg_cb);
 
     if (bVerbose) {
-        XbSymbolDatabase_SetOutputVerbosity(XB_OUTPUT_MESSAGE_DEBUG);
+        XbSDB_SetOutputVerbosity(XB_OUTPUT_MESSAGE_DEBUG);
     }
 
     XbSDBLibraryHeader lib_header = {
-        .count = XbSymbolDatabase_GenerateLibraryFilter(xbe_buffer, NULL),
+        .count = XbSDB_GenerateLibraryFilter(xbe_buffer, NULL),
         .filters = malloc(lib_header.count * sizeof(XbSDBLibrary))
     };
     if (!lib_header.filters) {
@@ -138,7 +138,7 @@ int main(int argc, char const* argv[])
         free(xbe_buffer);
         return 1;
     }
-    XbSymbolDatabase_GenerateLibraryFilter(xbe_buffer, &lib_header);
+    XbSDB_GenerateLibraryFilter(xbe_buffer, &lib_header);
 
     if (bVerbose) {
         fprintf(stderr, "%u libraries\n", lib_header.count);
@@ -148,7 +148,7 @@ int main(int argc, char const* argv[])
     }
 
     XbSDBSectionHeader sect_header = {
-        .count = XbSymbolDatabase_GenerateSectionFilter(xbe_buffer, NULL, 1),
+        .count = XbSDB_GenerateSectionFilter(xbe_buffer, NULL, 1),
         .filters = malloc(sect_header.count * sizeof(XbSDBSection))
     };
     if (!sect_header.filters) {
@@ -157,7 +157,7 @@ int main(int argc, char const* argv[])
         free(xbe_buffer);
         return 1;
     }
-    XbSymbolDatabase_GenerateSectionFilter(xbe_buffer, &sect_header, 1);
+    XbSDB_GenerateSectionFilter(xbe_buffer, &sect_header, 1);
 
     if (bVerbose) {
         fprintf(stderr, "%u sections\n", sect_header.count);
@@ -166,17 +166,17 @@ int main(int argc, char const* argv[])
         }
     }
 
-    XbSymbolContextHandle ctx;
-    bool status = XbSymbolDatabase_CreateXbSymbolContext(&ctx,
-                                                         reg_cb,
-                                                         lib_header,
-                                                         sect_header,
-                                                         XbSymbolDatabase_GetKernelThunkAddress(xbe_buffer));
+    XbSDBContextHandle ctx;
+    bool status = XbSDB_CreateContext(&ctx,
+                                      reg_cb,
+                                      lib_header,
+                                      sect_header,
+                                      XbSDB_GetKernelThunkAddress(xbe_buffer));
     assert(status == 1);
-    XbSymbolContext_ScanManual(ctx);
-    XbSymbolContext_ScanAllLibraryFilter(ctx);
-    XbSymbolContext_RegisterXRefs(ctx);
-    XbSymbolContext_Release(ctx);
+    XbSDBContext_ScanManual(ctx);
+    XbSDBContext_ScanAllLibraryFilter(ctx);
+    XbSDBContext_RegisterXRefs(ctx);
+    XbSDBContext_Release(ctx);
 
     free(lib_header.filters);
     free(sect_header.filters);

--- a/src/lib/internal_db_version.h
+++ b/src/lib/internal_db_version.h
@@ -6,7 +6,7 @@
 #pragma once
 
 // ******************************************************************
-// * Used for XbSymbolDatabase_LibraryVersion
+// * Used for XbSDB_LibraryVersion
 // ******************************************************************
 
 // Adapted from https://gist.github.com/underscorediscovery/81308642d0325fd386237cfa3b44785c

--- a/src/lib/internal_functions.h
+++ b/src/lib/internal_functions.h
@@ -299,9 +299,6 @@ static void* internal_LocateSymbol(iXbSymbolContext* pContext,
     return symbol_address;
 }
 
-#define LocateSymbolCast(pContext, iLibraryType, szSymbolName, version, Oovpa, pSection) \
-    internal_LocateSymbol(pContext, iLibraryType, szSymbolName, version, (OOVPA*)Oovpa, pSection, false)
-
 // Old Method - However, the library's scan method doesn't have self-register support implemented yet.
 // NOTE: Do not use direct call to this function. Use internal_RegisterValidXRefAddr_M macro instead.
 static void internal_RegisterValidXRefAddr(iXbSymbolContext* pContext,

--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -96,17 +96,17 @@ typedef enum _eFirstPass {
     FIRSTPASS_YES,
 } eFirstPass;
 
-typedef struct _iXbSymbolLibraryContext {
+typedef struct _XbSDBiLibraryContext {
     uint32_t xref_registered;
     bool is_active;
-} iXbSymbolLibraryContext;
+} XbSDBiLibraryContext;
 
-typedef struct _iXbSymbolLibrarySession {
+typedef struct _XbSDBiLibrarySession {
     const XbSDBLibrary* pLibrary;
     eLibraryType iLibraryType;
-} iXbSymbolLibrarySession;
+} XbSDBiLibrarySession;
 
-typedef struct _iXbSymbolContext {
+typedef struct _XbSDBiContext {
     bool strict_build_version_limit;
     bool one_time_scan;
     bool scan_first_detect;
@@ -117,8 +117,8 @@ typedef struct _iXbSymbolContext {
     XbSDBLibraryHeader library_input;
     XbSDBSectionHeader section_input;
     eScanStage scan_stage;
-    iXbSymbolLibraryContext library_contexts[LT_COUNT];
-} iXbSymbolContext;
+    XbSDBiLibraryContext library_contexts[LT_COUNT];
+} XbSDBiContext;
 
 typedef const struct _PairScanLibSec {
     uint32_t library;
@@ -131,63 +131,63 @@ typedef const struct _SymbolDatabaseList {
     OOVPATableList* Symbols;
 } SymbolDatabaseList;
 
-typedef bool (*custom_scan_func_t)(iXbSymbolContext* pContext,
-                                   const iXbSymbolLibrarySession* pLibrarySession,
+typedef bool (*custom_scan_func_t)(XbSDBiContext* pContext,
+                                   const XbSDBiLibrarySession* pLibrarySession,
                                    SymbolDatabaseList* pLibraryDB,
                                    const XbSDBSection* pSection);
 
 SymbolDatabaseList SymbolDBList[] = {
     // Support inline functions in .text section
-    { XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG, { Sec_text, Sec_D3D, Sec_FLASHROM }, &D3D8_OOVPA },
+    { XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG, { SEC_TEXT, SEC_D3D, SEC_FLASHROM }, &D3D8_OOVPA },
 
     // LTCG database have to be after standard library or otherwise the scan process will not work correctly.
-    { XbSymbolLib_D3D8LTCG, { Sec_text, Sec_D3D }, &D3D8LTCG_OOVPA },
+    { XBSDBLIB_D3D8LTCG, { SEC_TEXT, SEC_D3D }, &D3D8LTCG_OOVPA },
 
     // NOTE: Likely is a D3D Helper library.
     // Jarupxx mention this is not a requirement?
-    //{ Lib_D3DX8, { Sec_D3DX }, &_OOVPA },
+    //{ LIB_D3DX8, { SEC_D3DX }, &_OOVPA },
 
     // Only used for manual scan purpose as a workaround since both FLASHROM
     // and text section will lead to false detection for non-manual signatures, see comment below.
-    { XbSymbolLib_DSOUND, { Sec_DSOUND, Sec_rdata, Sec_FLASHROM, Sec_text }, &DSound_OOVPA_manual },
+    { XBSDBLIB_DSOUND, { SEC_DSOUND, SEC_RDATA, SEC_FLASHROM, SEC_TEXT }, &DSound_OOVPA_manual },
 
     // NOTE: By adding FLASHROM to scan section may will lead false detection.
     // Since some symbols has very short asm codes.
-    { XbSymbolLib_DSOUND, { Sec_DSOUND, Sec_rdata, Sec_FLASHROM }, &DSound_OOVPA },
+    { XBSDBLIB_DSOUND, { SEC_DSOUND, SEC_RDATA, SEC_FLASHROM }, &DSound_OOVPA },
 
     // DSOUNDH is just meant to define hot fix, there is no separate section
-    //{ XbSymbolLib_DSOUNDH, { Sec_DSOUND }, &DSound_OOVPA },
+    //{ XBSDBLIB_DSOUNDH, { SEC_DSOUND }, &DSound_OOVPA },
 
     // Only used in Chihiro applications
-    { XbSymbolLib_JVS, { Sec_text, Sec_XPP, Sec_FLASHROM }, &JVSLIB_OOVPA },
+    { XBSDBLIB_JVS, { SEC_TEXT, SEC_XPP, SEC_FLASHROM }, &JVSLIB_OOVPA },
 
     //
-    { XbSymbolLib_XACTENG, { Sec_XACTENG, Sec_FLASHROM }, &XACTENG_OOVPA },
+    { XBSDBLIB_XACTENG, { SEC_XACTENG, SEC_FLASHROM }, &XACTENG_OOVPA },
 
     // test case: Power Drome (Unluckily, it use LTCG version of the library.)
     // LTCG database have to be after standard library or otherwise the scan process will not work correctly.
-    //{ XbSymbolLib_XACTENLT, { Sec_XACTENG }, &XACTENGLT_OOVPA },
+    //{ XBSDBLIB_XACTENLT, { SEC_XACTENG }, &XACTENGLT_OOVPA },
 
     //
-    { XbSymbolLib_XAPILIB, { Sec_text, Sec_XPP, Sec_FLASHROM }, &XAPILIB_OOVPA },
+    { XBSDBLIB_XAPILIB, { SEC_TEXT, SEC_XPP, SEC_FLASHROM }, &XAPILIB_OOVPA },
 
     // Support inline functions in .text section
-    { XbSymbolLib_XGRAPHC, { Sec_text, Sec_XGRPH, Sec_FLASHROM }, &XGRAPHC_OOVPA },
+    { XBSDBLIB_XGRAPHC, { SEC_TEXT, SEC_XGRPH, SEC_FLASHROM }, &XGRAPHC_OOVPA },
 
     // LTCG database have to be after standard library or otherwise the scan process will not work correctly.
-    //{ XbSymbolLib_XGRAPHCL, { Sec_XGRPH }, &XGRAPHCL_OOVPA },
+    //{ XBSDBLIB_XGRAPHCL, { SEC_XGRPH }, &XGRAPHCL_OOVPA },
 
-    // Added Sec_text and Sec_XNET just in case.
-    // TODO: Do we need to keep Sec_XNET in here?
+    // Added SEC_TEXT and SEC_XNET just in case.
+    // TODO: Do we need to keep SEC_XNET in here?
     // TODO: Need to find out which function is only part of XOnlines.
     // Fun fact, XONLINES are split into 2 header sections.
-    { XbSymbolLib_XONLINE | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS, { Sec_text, Sec_XONLINE, Sec_XNET, Sec_FLASHROM }, &XONLINE_OOVPA },
+    { XBSDBLIB_XONLINE | XBSDBLIB_XONLINES | XBSDBLIB_XONLINLS, { SEC_TEXT, SEC_XONLINE, SEC_XNET, SEC_FLASHROM }, &XONLINE_OOVPA },
 
-    // Added Sec_text just in case.
+    // Added SEC_TEXT just in case.
     // TODO: Need to find out which function is only part of XNets.
     // XNETS only has XNET, might be true.
     // XNETN's test case: Stake
-    { XbSymbolLib_XNET | XbSymbolLib_XNETS | XbSymbolLib_XNETN | XbSymbolLib_XONLINE | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS, { Sec_text, Sec_XNET, Sec_FLASHROM }, &XNET_OOVPA },
+    { XBSDBLIB_XNET | XBSDBLIB_XNETS | XBSDBLIB_XNETN | XBSDBLIB_XONLINE | XBSDBLIB_XONLINES | XBSDBLIB_XONLINLS, { SEC_TEXT, SEC_XNET, SEC_FLASHROM }, &XNET_OOVPA },
 };
 
 // ******************************************************************
@@ -196,19 +196,19 @@ SymbolDatabaseList SymbolDBList[] = {
 const unsigned int SymbolDBListCount = XBSDB_ARRAY_SIZE(SymbolDBList);
 
 const char SectionList[][8] = {
-    Sec_text,
-    Sec_FLASHROM,
-    Sec_rdata,
-    Sec_D3D,
-    Sec_D3DX,
-    Sec_DSOUND,
-    Sec_XACTENG,
-    Sec_XID,
-    Sec_XPP,
-    Sec_XPPDat,
-    Sec_XGRPH,
-    Sec_XONLINE,
-    Sec_XNET
+    SEC_TEXT,
+    SEC_FLASHROM,
+    SEC_RDATA,
+    SEC_D3D,
+    SEC_D3DX,
+    SEC_DSOUND,
+    SEC_XACTENG,
+    SEC_XID,
+    SEC_XPP,
+    SEC_XPPDAT,
+    SEC_XGRPH,
+    SEC_XONLINE,
+    SEC_XNET
 };
 
 const unsigned int SectionListTotal = XBSDB_ARRAY_SIZE(SectionList);
@@ -267,7 +267,7 @@ static xb_xbe_type GetXbeType(const xbe_header* pXbeHeader)
     return XB_XBE_TYPE_RETAIL;
 }
 
-static bool iXbSymbolContext_AllowSetParameter(iXbSymbolContext* pContext)
+static bool XbSDBiContext_AllowSetParameter(XbSDBiContext* pContext)
 {
     bool bRet = (pContext->scan_stage == SS_NONE);
 
@@ -278,12 +278,12 @@ static bool iXbSymbolContext_AllowSetParameter(iXbSymbolContext* pContext)
     return bRet;
 }
 
-static bool iXbSymbolContext_AllowScanLibrary(iXbSymbolContext* pContext)
+static bool XbSDBiContext_AllowScanLibrary(XbSDBiContext* pContext)
 {
     bool bRet = (pContext->scan_stage == SS_2_SCAN_LIBS);
 
     if (!bRet) {
-        output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "XbSymbolContext_ScanManual must be call first before scan for library's symbols.");
+        output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "XbSDBContext_ScanManual must be call first before scan for library's symbols.");
     }
 
     return bRet;
@@ -301,12 +301,12 @@ static bool iXbSymbolContext_AllowScanLibrary(iXbSymbolContext* pContext)
 // ******************************************************************
 
 xb_output_message_t g_output_func = NULL;
-void XbSymbolDatabase_SetOutputMessage(xb_output_message_t message_func)
+void XbSDB_SetOutputMessage(xb_output_message_t message_func)
 {
     g_output_func = message_func;
 }
 
-bool XbSymbolDatabase_SetOutputVerbosity(xb_output_message verbose_level)
+bool XbSDB_SetOutputVerbosity(xb_output_message verbose_level)
 {
     if (verbose_level < XB_OUTPUT_MESSAGE_MAX) {
         g_output_verbose_level = verbose_level;
@@ -316,53 +316,53 @@ bool XbSymbolDatabase_SetOutputVerbosity(xb_output_message verbose_level)
     return false;
 }
 
-const char* XbSymbolDatabase_LibraryToString(uint32_t library_flag)
+const char* XbSDB_LibraryToString(uint32_t library_flag)
 {
     switch (library_flag) {
-        case XbSymbolLib_D3D8: {
-            return Lib_D3D8;
+        case XBSDBLIB_D3D8: {
+            return LIB_D3D8;
         }
-        case XbSymbolLib_D3D8LTCG: {
-            return Lib_D3D8LTCG;
+        case XBSDBLIB_D3D8LTCG: {
+            return LIB_D3D8LTCG;
         }
-        case XbSymbolLib_D3DX8: {
-            return Lib_D3DX8;
+        case XBSDBLIB_D3DX8: {
+            return LIB_D3DX8;
         }
-        case XbSymbolLib_DSOUND: {
-            return Lib_DSOUND;
+        case XBSDBLIB_DSOUND: {
+            return LIB_DSOUND;
         }
-        case XbSymbolLib_JVS: {
-            return Lib_JVS;
+        case XBSDBLIB_JVS: {
+            return LIB_JVS;
         }
-        case XbSymbolLib_XACTENG: {
-            return Lib_XACTENG;
+        case XBSDBLIB_XACTENG: {
+            return LIB_XACTENG;
         }
-        case XbSymbolLib_XAPILIB: {
-            return Lib_XAPILIB;
+        case XBSDBLIB_XAPILIB: {
+            return LIB_XAPILIB;
         }
-        case XbSymbolLib_XGRAPHC: {
-            return Lib_XGRAPHC;
+        case XBSDBLIB_XGRAPHC: {
+            return LIB_XGRAPHC;
         }
-        case XbSymbolLib_XNET: {
-            return Lib_XNET;
+        case XBSDBLIB_XNET: {
+            return LIB_XNET;
         }
-        case XbSymbolLib_XNETN: {
-            return Lib_XNETN;
+        case XBSDBLIB_XNETN: {
+            return LIB_XNETN;
         }
-        case XbSymbolLib_XNETS: {
-            return Lib_XNETS;
+        case XBSDBLIB_XNETS: {
+            return LIB_XNETS;
         }
-        case XbSymbolLib_XONLINE: {
-            return Lib_XONLINE;
+        case XBSDBLIB_XONLINE: {
+            return LIB_XONLINE;
         }
-        case XbSymbolLib_XONLINES: {
-            return Lib_XONLINES;
+        case XBSDBLIB_XONLINES: {
+            return LIB_XONLINES;
         }
-        case XbSymbolLib_XONLINLS: {
-            return Lib_XONLINLS;
+        case XBSDBLIB_XONLINLS: {
+            return LIB_XONLINLS;
         }
         default: {
-            return Lib_UNKNOWN;
+            return LIB_UNKNOWN;
         }
     }
 }
@@ -381,7 +381,7 @@ static const char* const param_type_str[] = {
 #undef PARAM_TYPE__8_
 };
 
-const char* XbSymbolDatabase_ParamToString(uint32_t param_type)
+const char* XbSDB_ParamToString(uint32_t param_type)
 {
     if (param_type >= param_max) {
         return param_type_str[param_unk];
@@ -396,7 +396,7 @@ static const char* const call_type_str[] = {
 #undef CALL_
 };
 
-const char* XbSymbolDatabase_CallingConventionToString(uint32_t call_type)
+const char* XbSDB_CallingConventionToString(uint32_t call_type)
 {
     if (call_type >= call_max) {
         return call_type_str[call_unknown];
@@ -419,7 +419,7 @@ const char* xref_str[] = {
 #undef XREF_SYMBOL
 };
 
-const char* XbSymbolDatabase_SymbolReferenceToString(uint32_t xref_index)
+const char* XbSDB_SymbolReferenceToString(uint32_t xref_index)
 {
     if (xref_index <= XREF_KT_COUNT || XREF_COUNT <= xref_index) {
         return NULL;
@@ -428,70 +428,70 @@ const char* XbSymbolDatabase_SymbolReferenceToString(uint32_t xref_index)
 }
 
 // NOTE: Library string must return only one specific flag, cannot make a mix combo flags.
-//       Otherwise, internal scan and XbSymbolDatabase_LibraryToString will not function correctly.
-uint32_t XbSymbolDatabase_LibraryToFlag(const char* library_name)
+//       Otherwise, internal scan and XbSDB_LibraryToString will not function correctly.
+uint32_t XbSDB_LibraryToFlag(const char* library_name)
 {
-    if (strncmp(library_name, Lib_D3D8, 8) == 0) {
-        return XbSymbolLib_D3D8;
+    if (strncmp(library_name, LIB_D3D8, 8) == 0) {
+        return XBSDBLIB_D3D8;
     }
-    if (strncmp(library_name, Lib_D3D8LTCG, 8) == 0) {
-        return XbSymbolLib_D3D8LTCG;
+    if (strncmp(library_name, LIB_D3D8LTCG, 8) == 0) {
+        return XBSDBLIB_D3D8LTCG;
     }
-    if (strncmp(library_name, Lib_D3DX8, 8) == 0) {
-        return XbSymbolLib_D3DX8;
+    if (strncmp(library_name, LIB_D3DX8, 8) == 0) {
+        return XBSDBLIB_D3DX8;
     }
-    if (strncmp(library_name, Lib_DSOUND, 8) == 0) {
-        return XbSymbolLib_DSOUND;
+    if (strncmp(library_name, LIB_DSOUND, 8) == 0) {
+        return XBSDBLIB_DSOUND;
     }
-    if (strncmp(library_name, Lib_JVS, 8) == 0) {
-        return XbSymbolLib_JVS;
+    if (strncmp(library_name, LIB_JVS, 8) == 0) {
+        return XBSDBLIB_JVS;
     }
-    if (strncmp(library_name, Lib_XACTENG, 8) == 0) {
-        return XbSymbolLib_XACTENG;
+    if (strncmp(library_name, LIB_XACTENG, 8) == 0) {
+        return XBSDBLIB_XACTENG;
     }
-    if (strncmp(library_name, Lib_XAPILIB, 8) == 0) {
-        return XbSymbolLib_XAPILIB;
+    if (strncmp(library_name, LIB_XAPILIB, 8) == 0) {
+        return XBSDBLIB_XAPILIB;
     }
-    if (strncmp(library_name, Lib_XGRAPHC, 8) == 0) {
-        return XbSymbolLib_XGRAPHC;
+    if (strncmp(library_name, LIB_XGRAPHC, 8) == 0) {
+        return XBSDBLIB_XGRAPHC;
     }
-    if (strncmp(library_name, Lib_XNET, 8) == 0) {
-        return XbSymbolLib_XNET;
+    if (strncmp(library_name, LIB_XNET, 8) == 0) {
+        return XBSDBLIB_XNET;
     }
-    if (strncmp(library_name, Lib_XNETN, 8) == 0) {
-        return XbSymbolLib_XNETN;
+    if (strncmp(library_name, LIB_XNETN, 8) == 0) {
+        return XBSDBLIB_XNETN;
     }
-    if (strncmp(library_name, Lib_XNETS, 8) == 0) {
-        return XbSymbolLib_XNETS;
+    if (strncmp(library_name, LIB_XNETS, 8) == 0) {
+        return XBSDBLIB_XNETS;
     }
-    if (strncmp(library_name, Lib_XONLINE, 8) == 0) {
-        return XbSymbolLib_XONLINE;
+    if (strncmp(library_name, LIB_XONLINE, 8) == 0) {
+        return XBSDBLIB_XONLINE;
     }
-    if (strncmp(library_name, Lib_XONLINES, 8) == 0) {
-        return XbSymbolLib_XONLINES;
+    if (strncmp(library_name, LIB_XONLINES, 8) == 0) {
+        return XBSDBLIB_XONLINES;
     }
-    if (strncmp(library_name, Lib_XONLINLS, 8) == 0) {
-        return XbSymbolLib_XONLINLS;
+    if (strncmp(library_name, LIB_XONLINLS, 8) == 0) {
+        return XBSDBLIB_XONLINLS;
     }
     return 0;
 }
 
-uint32_t XbSymbolDatabase_GetLibraryDependencies(uint32_t library_flag, XbSDBLibraryHeader library_filters)
+uint32_t XbSDB_GetLibraryDependencies(uint32_t library_flag, XbSDBLibraryHeader library_filters)
 {
     uint32_t flag_dependencies;
     switch (library_flag) {
         default:
             return 0;
-        case XbSymbolLib_D3DX8:
-            flag_dependencies = XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG;
+        case XBSDBLIB_D3DX8:
+            flag_dependencies = XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG;
             break;
-        case XbSymbolLib_XACTENG:
-            return XbSymbolLib_DSOUND;
+        case XBSDBLIB_XACTENG:
+            return XBSDBLIB_DSOUND;
 #if 0 // Disabled since internal scan will scan XNET(N|S) library anyway.
-        case XbSymbolLib_XONLINE:
-        case XbSymbolLib_XONLINES:
-        case XbSymbolLib_XONLINLS:
-            flag_dependencies = XbSymbolLib_XNET | XbSymbolLib_XNETN | XbSymbolLib_XNETS;
+        case XBSDBLIB_XONLINE:
+        case XBSDBLIB_XONLINES:
+        case XBSDBLIB_XONLINLS:
+            flag_dependencies = XBSDBLIB_XNET | XBSDBLIB_XNETN | XBSDBLIB_XNETS;
             break;
 #endif
     }
@@ -511,15 +511,15 @@ uint32_t XbSymbolDatabase_GetLibraryDependencies(uint32_t library_flag, XbSDBLib
     return flag_dependencies;
 }
 
-uint32_t XbSymbolContext_GetLibraryDependencies(XbSymbolContextHandle pHandle, uint32_t library_flag)
+uint32_t XbSDBContext_GetLibraryDependencies(XbSDBContextHandle pHandle, uint32_t library_flag)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
-    // Forward call to XbSymbolDatabase_GetLibraryDependencies.
-    return XbSymbolDatabase_GetLibraryDependencies(library_flag, pContext->library_input);
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
+    // Forward call to XbSDB_GetLibraryDependencies.
+    return XbSDB_GetLibraryDependencies(library_flag, pContext->library_input);
 }
 
 // TODO: Expose to third-party?
-bool XbSymbolHasDSoundSection(const void* xb_header_addr)
+bool XbSDBi_HasDSoundSection(const void* xb_header_addr)
 {
     const xbe_header* pXbeHeader = xb_header_addr;
     memptr_t xb_start_addr = (memptr_t)xb_header_addr - pXbeHeader->dwBaseAddr;
@@ -531,7 +531,7 @@ bool XbSymbolHasDSoundSection(const void* xb_header_addr)
     for (unsigned int v = 0; v < pXbeHeader->dwSections; v++) {
         SectionName = (const char*)(xb_start_addr + pSectionHeaders[v].SectionNameAddr);
 
-        if (strncmp(SectionName, Lib_DSOUND, 8) == 0) {
+        if (strncmp(SectionName, LIB_DSOUND, 8) == 0) {
             has_dsound = true;
             break;
         }
@@ -540,7 +540,7 @@ bool XbSymbolHasDSoundSection(const void* xb_header_addr)
     return has_dsound;
 }
 
-uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSDBLibraryHeader* library_header)
+uint32_t XbSDB_GenerateLibraryFilter(const void* xb_header_addr, XbSDBLibraryHeader* library_header)
 {
     uint32_t library_flag;
     const xbe_header* pXbeHeader = xb_header_addr;
@@ -562,7 +562,7 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
 
         for (unsigned library_index = 0; library_index < library_total; library_index++) {
 
-            library_flag = XbSymbolDatabase_LibraryToFlag(xb_library_versions[library_index].szName);
+            library_flag = XbSDB_LibraryToFlag(xb_library_versions[library_index].szName);
 
             // Keep the highest build version for manual checklist.
             if (build_version < xb_library_versions[library_index].wBuildVersion) {
@@ -575,7 +575,7 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
             }
 
             // If found DSOUND library, then skip the manual check.
-            if (library_flag == XbSymbolLib_DSOUND) {
+            if (library_flag == XBSDBLIB_DSOUND) {
                 if (!has_dsound_library) {
                     has_dsound_library = true;
                 }
@@ -583,22 +583,22 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
 
             // If D3D8 and D3D8LTCG library details may had bundled by accident, then do manual fix below.
             // See details from https://github.com/Cxbx-Reloaded/XbSymbolDatabase/issues/178
-            if (library_flag & (XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG)) {
+            if (library_flag & (XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG)) {
                 if (has_d3d8__ltcg_library) {
                     if (library_header != NULL) {
-                        if (library_flag == XbSymbolLib_D3D8LTCG) {
+                        if (library_flag == XBSDBLIB_D3D8LTCG) {
                             // Force set to D3D8LTCG if D3D8 flag was found first.
-                            internal_LibraryFilterUpdateFlagIfExist(library_header->filters,
-                                                                    count,
-                                                                    XbSymbolLib_D3D8,
-                                                                    XbSymbolLib_D3D8LTCG);
+                            XbSDBi_LibraryFilterUpdateFlagIfExist(library_header->filters,
+                                                                  count,
+                                                                  XBSDBLIB_D3D8,
+                                                                  XBSDBLIB_D3D8LTCG);
                         }
                         // Update duplicated library detail
-                        internal_LibraryFilterUpdateVersionIfGreater(library_header->filters,
-                                                                     count,
-                                                                     XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG,
-                                                                     xb_library_versions[library_index].wBuildVersion,
-                                                                     xb_library_versions[library_index].wFlags.QFEVersion);
+                        XbSDBi_LibraryFilterUpdateVersionIfGreater(library_header->filters,
+                                                                   count,
+                                                                   XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG,
+                                                                   xb_library_versions[library_index].wBuildVersion,
+                                                                   xb_library_versions[library_index].wFlags.QFEVersion);
                     }
 
                     // Skip duplicate library finding.
@@ -615,9 +615,9 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
                 library_header->filters[count].flag = library_flag;
                 library_header->filters[count].build_version = xb_library_versions[library_index].wBuildVersion;
                 library_header->filters[count].qfe_version = xb_library_versions[library_index].wFlags.QFEVersion;
-                memcpy(library_header->filters[count].name, XbSymbolDatabase_LibraryToString(library_flag), 8);
+                memcpy(library_header->filters[count].name, XbSDB_LibraryToString(library_flag), 8);
 
-                if ((library_flag & (XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG)) > 0) {
+                if ((library_flag & (XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG)) > 0) {
 
                     // Functions in this library were updated by June 2003 XDK (5558) with Integrated Hotfixes,
                     // However August 2003 XDK (5659) still uses the old function.
@@ -640,12 +640,12 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
 
         // Manual check if DSOUND section do exist.
         if (!has_dsound_library) {
-            if (XbSymbolHasDSoundSection(xb_header_addr)) {
+            if (XbSDBi_HasDSoundSection(xb_header_addr)) {
                 if (library_header != NULL) {
-                    library_header->filters[count].flag = XbSymbolLib_DSOUND;
+                    library_header->filters[count].flag = XBSDBLIB_DSOUND;
                     library_header->filters[count].build_version = build_version;
                     library_header->filters[count].qfe_version = 0;
-                    (void)strncpy(library_header->filters[count].name, Lib_DSOUND, 8);
+                    (void)strncpy(library_header->filters[count].name, LIB_DSOUND, 8);
                 }
                 count++;
             }
@@ -654,10 +654,10 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
         // Manual check if Xbe type is debug or Chihiro
         if (XbeType != XB_XBE_TYPE_RETAIL) {
             if (library_header != NULL) {
-                library_header->filters[count].flag = XbSymbolLib_JVS;
+                library_header->filters[count].flag = XBSDBLIB_JVS;
                 library_header->filters[count].build_version = build_version;
                 library_header->filters[count].qfe_version = 0;
-                (void)strncpy(library_header->filters[count].name, Lib_JVS, 8);
+                (void)strncpy(library_header->filters[count].name, LIB_JVS, 8);
             }
             count++;
         }
@@ -666,7 +666,7 @@ uint32_t XbSymbolDatabase_GenerateLibraryFilter(const void* xb_header_addr, XbSD
     return count;
 }
 
-uint32_t XbSymbolDatabase_GenerateSectionFilter(const void* xb_header_addr, XbSDBSectionHeader* section_header, bool is_raw)
+uint32_t XbSDB_GenerateSectionFilter(const void* xb_header_addr, XbSDBSectionHeader* section_header, bool is_raw)
 {
     const xbe_header* pXbeHeader = xb_header_addr;
     const memptr_t xb_start_addr = (memptr_t)xb_header_addr - pXbeHeader->dwBaseAddr;
@@ -680,7 +680,7 @@ uint32_t XbSymbolDatabase_GenerateSectionFilter(const void* xb_header_addr, XbSD
 
     if (pXbeHeader->pSectionHeadersAddr != 0) {
 
-        kernel_thunk_addr = XbSymbolDatabase_GetKernelThunkAddress(xb_header_addr);
+        kernel_thunk_addr = XbSDB_GetKernelThunkAddress(xb_header_addr);
 
         for (unsigned section_index = 0; section_index < section_total; section_index++) {
 
@@ -737,7 +737,7 @@ uint32_t XbSymbolDatabase_GenerateSectionFilter(const void* xb_header_addr, XbSD
     return count;
 }
 
-xbaddr XbSymbolDatabase_GetKernelThunkAddress(const void* xb_header_addr)
+xbaddr XbSDB_GetKernelThunkAddress(const void* xb_header_addr)
 {
     xb_xbe_type xbe_type = GetXbeType(xb_header_addr);
 
@@ -748,7 +748,7 @@ xbaddr XbSymbolDatabase_GetKernelThunkAddress(const void* xb_header_addr)
 }
 
 #include "internal_db_version.h"
-unsigned int XbSymbolDatabase_LibraryVersion()
+unsigned int XbSDB_LibraryVersion()
 {
     // Calculate this just once
     static unsigned int CalculatedHash = 0;
@@ -759,23 +759,23 @@ unsigned int XbSymbolDatabase_LibraryVersion()
 }
 
 #include "internal_tests.h"
-unsigned int XbSymbolDatabase_TestOOVPAs()
+unsigned int XbSDB_TestOOVPAs()
 {
-    SymbolDatabaseVerifyContext context = { 0 };
+    XbSDBiVerifyContext context = { 0 };
     context.output.func = g_output_func;
     context.output.verbose_level = g_output_verbose_level;
-    return SymbolDatabaseVerifyContext_VerifyDatabaseList(&context);
+    return XbSDBiVerifyContext_VerifyDatabaseList(&context);
 }
 
 // ******************************************************************
-// * XbSymbolContextHandle manager functions
+// * XbSDBContextHandle manager functions
 // ******************************************************************
 
-bool XbSymbolDatabase_CreateXbSymbolContext(XbSymbolContextHandle* ppHandle,
-                                            xb_symbol_register_t register_func,
-                                            XbSDBLibraryHeader library_input,
-                                            XbSDBSectionHeader section_input,
-                                            xbaddr kernel_thunk)
+bool XbSDB_CreateContext(XbSDBContextHandle* ppHandle,
+                         xb_symbol_register_t register_func,
+                         XbSDBLibraryHeader library_input,
+                         XbSDBSectionHeader section_input,
+                         xbaddr kernel_thunk)
 {
     if (register_func == NULL) {
         goto EmptyCleanup;
@@ -791,13 +791,13 @@ bool XbSymbolDatabase_CreateXbSymbolContext(XbSymbolContextHandle* ppHandle,
         goto EmptyCleanup;
     }
 
-    *ppHandle = calloc(1, sizeof(iXbSymbolContext));
+    *ppHandle = calloc(1, sizeof(XbSDBiContext));
 
     if (*ppHandle == NULL) {
         goto EmptyCleanup;
     }
 
-    iXbSymbolContext* pContext = (iXbSymbolContext*)*ppHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)*ppHandle;
 
     pContext->scan_stage = SS_NONE;
 
@@ -849,7 +849,7 @@ bool XbSymbolDatabase_CreateXbSymbolContext(XbSymbolContextHandle* ppHandle,
                 unsigned int index = *kt & 0x7FFFFFFF;
                 // Check if the index is within range, then add to the xreference database.
                 if (index > 0 && index < XREF_KT_COUNT) {
-                    internal_SetXRefDatabase(pContext, LT_KERNEL, index, kt_addr);
+                    XbSDBi_SetXRefDatabase(pContext, LT_KERNEL, index, kt_addr);
                 }
                 else {
                     output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_WARN,
@@ -928,9 +928,9 @@ EmptyCleanup:
     return false;
 }
 
-void XbSymbolContext_Release(XbSymbolContextHandle pHandle)
+void XbSDBContext_Release(XbSDBContextHandle pHandle)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
     for (unsigned int i = 0; i < LT_COUNT; i++) {
         if (pContext->library_contexts[i].is_active) {
@@ -943,46 +943,46 @@ void XbSymbolContext_Release(XbSymbolContextHandle pHandle)
 
 
 // ******************************************************************
-// * XbSymbolContext API functions
+// * Context API functions
 // ******************************************************************
 
-void XbSymbolContext_SetBypassBuildVersionLimit(XbSymbolContextHandle pHandle, bool bypass_limit)
+void XbSDBContext_SetBypassBuildVersionLimit(XbSDBContextHandle pHandle, bool bypass_limit)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
-    if (iXbSymbolContext_AllowSetParameter(pContext)) {
+    if (XbSDBiContext_AllowSetParameter(pContext)) {
         pContext->strict_build_version_limit = !bypass_limit;
     }
 }
 
-void XbSymbolContext_SetContinuousSigScan(XbSymbolContextHandle pHandle, bool enable)
+void XbSDBContext_SetContinuousSigScan(XbSDBContextHandle pHandle, bool enable)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
-    if (iXbSymbolContext_AllowSetParameter(pContext)) {
+    if (XbSDBiContext_AllowSetParameter(pContext)) {
         pContext->one_time_scan = !enable;
     }
 }
 
-void XbSymbolContext_SetFirstDetectAddressOnly(XbSymbolContextHandle pHandle, bool enable)
+void XbSDBContext_SetFirstDetectAddressOnly(XbSDBContextHandle pHandle, bool enable)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
-    if (iXbSymbolContext_AllowSetParameter(pContext)) {
+    if (XbSDBiContext_AllowSetParameter(pContext)) {
         pContext->scan_first_detect = enable;
     }
 }
 
-bool XbSymbolContext_RegisterLibrary(XbSymbolContextHandle pHandle, uint32_t library_filter)
+bool XbSDBContext_RegisterLibrary(XbSDBContextHandle pHandle, uint32_t library_filter)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
-    if (!iXbSymbolContext_AllowSetParameter(pContext)) {
+    if (!XbSDBiContext_AllowSetParameter(pContext)) {
         return false;
     }
 
     // Check to make sure all flags are acceptable before set.
-    if ((library_filter & ~XbSymbolLib_ALL) > 0) {
+    if ((library_filter & ~XBSDBLIB_ALL) > 0) {
         return false;
     }
 
@@ -991,9 +991,9 @@ bool XbSymbolContext_RegisterLibrary(XbSymbolContextHandle pHandle, uint32_t lib
 }
 
 #include "manual_custom.h"
-void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle)
+void XbSDBContext_ScanManual(XbSDBContextHandle pHandle)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
     if (pContext->scan_stage >= SS_1_MANUAL) {
         output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "Manual rescan request is skip.");
@@ -1004,18 +1004,18 @@ void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle)
     for (unsigned int lv = 0; lv < pContext->library_input.count; lv++) {
 
         const XbSDBLibrary* pLibrary = pContext->library_input.filters + lv;
-        eLibraryType i_LibraryType = internal_GetLibraryType(pLibrary->flag);
+        eLibraryType i_LibraryType = XbSDBi_GetLibraryType(pLibrary->flag);
 
         if (i_LibraryType <= LT_UNKNOWN || LT_MAX <= i_LibraryType) {
             continue;
         }
 
-        iXbSymbolLibrarySession libSession = {
+        XbSDBiLibrarySession libSession = {
             .pLibrary = pLibrary,
             .iLibraryType = i_LibraryType
         };
 
-        if ((pLibrary->flag & (XbSymbolLib_D3D8 | XbSymbolLib_D3D8LTCG)) > 0) {
+        if ((pLibrary->flag & (XBSDBLIB_D3D8 | XBSDBLIB_D3D8LTCG)) > 0) {
             // TODO: Do we need to check twice?
             // Perform check twice, since sections can be in different order.
             for (unsigned int loop = 0; loop < 2; loop++) {
@@ -1027,7 +1027,7 @@ void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle)
                 break;
             }
         }
-        else if ((pLibrary->flag & XbSymbolLib_DSOUND) > 0) {
+        else if ((pLibrary->flag & XBSDBLIB_DSOUND) > 0) {
             // Perform check twice, since sections can be in different order.
             for (unsigned int loop = 0; loop < 2; loop++) {
                 // Initialize a matching specific section is currently pair with library in order to scan specific section only.
@@ -1038,7 +1038,7 @@ void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle)
                 break;
             }
         }
-        else if ((pLibrary->flag & XbSymbolLib_XAPILIB) > 0) {
+        else if ((pLibrary->flag & XBSDBLIB_XAPILIB) > 0) {
             manual_scan_library_custom(pContext, manual_scan_section_xapilib, &libSession);
         }
     }
@@ -1046,36 +1046,36 @@ void XbSymbolContext_ScanManual(XbSymbolContextHandle pHandle)
     pContext->scan_stage = SS_2_SCAN_LIBS;
 }
 
-unsigned int XbSymbolContext_ScanLibrary(XbSymbolContextHandle pHandle,
-                                         const XbSDBLibrary* pLibrary,
-                                         bool xref_first_pass)
+unsigned int XbSDBContext_ScanLibrary(XbSDBContextHandle pHandle,
+                                      const XbSDBLibrary* pLibrary,
+                                      bool xref_first_pass)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
-    eLibraryType iLibraryType = internal_GetLibraryType(pLibrary->flag);
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
+    eLibraryType iLibraryType = XbSDBi_GetLibraryType(pLibrary->flag);
 
     if (iLibraryType <= LT_UNKNOWN || LT_MAX <= iLibraryType) {
         return 0;
     }
 
-    iXbSymbolLibrarySession librarySession = {
+    XbSDBiLibrarySession librarySession = {
         .pLibrary = pLibrary,
         .iLibraryType = iLibraryType
     };
 
     unsigned int xref_count = pContext->library_contexts[iLibraryType].xref_registered;
 
-    if (!iXbSymbolContext_AllowScanLibrary(pContext)) {
+    if (!XbSDBiContext_AllowScanLibrary(pContext)) {
         return 0;
     }
 
     // If library type is active, do nothing.
-    if (!internal_SetLibraryTypeStart(pContext, iLibraryType)) {
+    if (!XbSDBi_SetLibraryTypeStart(pContext, iLibraryType)) {
         return 0;
     }
 
     SymbolDatabaseList* pSymbolDB;
     unsigned db_i = 0;
-    while ((pSymbolDB = internal_FindLibraryDB(pLibrary->flag, &db_i))) {
+    while ((pSymbolDB = XbSDBi_FindLibraryDB(pLibrary->flag, &db_i))) {
         db_i++;
         for (unsigned int s = 0; s < pContext->section_input.count; s++) {
 
@@ -1088,11 +1088,11 @@ unsigned int XbSymbolContext_ScanLibrary(XbSymbolContextHandle pHandle,
                     output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, "Scanning %.8s library in %.8s section",
                                           pLibrary->name, pSymbolDB->LibSec.section[d3]);
 
-                    internal_OOVPATableList_scan(pContext,
-                                                 &librarySession,
-                                                 pSymbolDB->Symbols,
-                                                 pContext->section_input.filters + s,
-                                                 xref_first_pass);
+                    XbSDBi_OOVPATableList_scan(pContext,
+                                               &librarySession,
+                                               pSymbolDB->Symbols,
+                                               pContext->section_input.filters + s,
+                                               xref_first_pass);
                     break;
                 }
             }
@@ -1110,16 +1110,16 @@ unsigned int XbSymbolContext_ScanLibrary(XbSymbolContextHandle pHandle,
 
     xref_count = pContext->library_contexts[iLibraryType].xref_registered - xref_count;
 
-    internal_SetLibraryTypeEnd(pContext, iLibraryType);
+    XbSDBi_SetLibraryTypeEnd(pContext, iLibraryType);
 
     return xref_count;
 }
 
-void XbSymbolContext_ScanAllLibraryFilter(XbSymbolContextHandle pHandle)
+void XbSDBContext_ScanAllLibraryFilter(XbSDBContextHandle pHandle)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
-    if (!iXbSymbolContext_AllowScanLibrary(pContext)) {
+    if (!XbSDBiContext_AllowScanLibrary(pContext)) {
         return;
     }
 
@@ -1135,8 +1135,8 @@ void XbSymbolContext_ScanAllLibraryFilter(XbSymbolContextHandle pHandle)
     // Get Library's dependency flag(s)
     for (unsigned int lv = 0; lv < pContext->library_input.count; lv++) {
         const XbSDBLibrary* library = pContext->library_input.filters + lv;
-        if (internal_LibraryFilterPermitScan(pContext, library->flag)) {
-            library_dependency[lv] = XbSymbolContext_GetLibraryDependencies(pHandle, library->flag);
+        if (XbSDBi_LibraryFilterPermitScan(pContext, library->flag)) {
+            library_dependency[lv] = XbSDBContext_GetLibraryDependencies(pHandle, library->flag);
             library_scan |= library->flag;
         }
     }
@@ -1151,27 +1151,27 @@ void XbSymbolContext_ScanAllLibraryFilter(XbSymbolContextHandle pHandle)
             do {
                 // Temporary placeholder until v2.0 API's section scan function is ready or may be permanent in here.
                 // Skip specific library if third-party set to specific library.
-                if (!internal_LibraryFilterPermitScan(pContext, library->flag)) {
+                if (!XbSDBi_LibraryFilterPermitScan(pContext, library->flag)) {
                     output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, "Skipping %.8s (%hu) scan.", library->name, library->build_version);
                 }
                 else {
                     // Check if we already completed library scan first.
-                    if (XbSymbolDatabase_CheckDependencyCompletion(library_completion, library->flag)) {
+                    if (XbSDB_CheckDependencyCompletion(library_completion, library->flag)) {
                         // Skip if already been scanned.
                         break;
                     }
 
                     // Check if any dependency is set and if they are completed
-                    if (library_dependency[lv] && !XbSymbolDatabase_CheckDependencyCompletion(library_completion, library_dependency[lv])) {
+                    if (library_dependency[lv] && !XbSDB_CheckDependencyCompletion(library_completion, library_dependency[lv])) {
                         // Skip if any dependency library isn't done yet.
                         break;
                     }
                     // Start library scan against symbol database we want to search for address of symbols and xreferences.
-                    unsigned counter = XbSymbolContext_ScanLibrary(pHandle, library, !not_first_pass[lv]);
+                    unsigned counter = XbSDBContext_ScanLibrary(pHandle, library, !not_first_pass[lv]);
 
                     // If no additional symbols found, then set as scan completed.
                     if (counter == 0) {
-                        XbSymbolDatabase_SetLibraryCompletion(library_completion, library->flag);
+                        XbSDB_SetLibraryCompletion(library_completion, library->flag);
                     }
                     // Once first pass is done, multiple passes may will occur for any xref dependency symbols haven't been found.
                     if (!not_first_pass[lv]) {
@@ -1181,14 +1181,14 @@ void XbSymbolContext_ScanAllLibraryFilter(XbSymbolContextHandle pHandle)
             } while (true);
         }
 
-    } while (!XbSymbolDatabase_CheckDependencyCompletion(library_completion, library_scan));
+    } while (!XbSDB_CheckDependencyCompletion(library_completion, library_scan));
 }
 
 // Does individual registration of derived XRef's that are useful but not yet registered.
 // Called after entire scan.
-void XbSymbolContext_RegisterXRefs(XbSymbolContextHandle pHandle)
+void XbSDBContext_RegisterXRefs(XbSDBContextHandle pHandle)
 {
-    iXbSymbolContext* pContext = (iXbSymbolContext*)pHandle;
+    XbSDBiContext* pContext = (XbSDBiContext*)pHandle;
 
     if (pContext->register_func == NULL) {
         return;
@@ -1205,19 +1205,19 @@ void XbSymbolContext_RegisterXRefs(XbSymbolContextHandle pHandle)
 // ******************************************************************
 
 // Aka the basic example to handle the scan process.
-bool XbSymbolScan(const void* xb_header_addr,
-                  xb_symbol_register_t register_func,
-                  bool is_raw)
+bool XbSDB_Scan(const void* xb_header_addr,
+                xb_symbol_register_t register_func,
+                bool is_raw)
 {
     bool bCheckJVS = false;
 
-    XbSymbolContextHandle pHandle;
-    iXbSymbolContext* iContext;
+    XbSDBContextHandle pHandle;
+    XbSDBiContext* iContext;
     XbSDBLibraryHeader library_input = { 0 };
     XbSDBSectionHeader section_input = { 0 };
 
     // Step 1, let's get the total sum of array to allocate library input.
-    library_input.count = XbSymbolDatabase_GenerateLibraryFilter(xb_header_addr, NULL);
+    library_input.count = XbSDB_GenerateLibraryFilter(xb_header_addr, NULL);
     // If total sum is zero, then the input is invalid.
     if (library_input.count == 0) {
         return false;
@@ -1229,10 +1229,10 @@ bool XbSymbolScan(const void* xb_header_addr,
         return false;
     }
     // Finally, obtain the information for internal scan process.
-    (void)XbSymbolDatabase_GenerateLibraryFilter(xb_header_addr, &library_input);
+    (void)XbSDB_GenerateLibraryFilter(xb_header_addr, &library_input);
 
     // Step 2, let's get the total sum of array to allocate section input.
-    section_input.count = XbSymbolDatabase_GenerateSectionFilter(xb_header_addr, NULL, is_raw);
+    section_input.count = XbSDB_GenerateSectionFilter(xb_header_addr, NULL, is_raw);
     // If total sum is zero, then the input is invalid.
     if (section_input.count == 0) {
         goto LibraryCleanup;
@@ -1244,37 +1244,37 @@ bool XbSymbolScan(const void* xb_header_addr,
         goto LibraryCleanup;
     }
     // Finally, obtain the information for internal scan process.
-    (void)XbSymbolDatabase_GenerateSectionFilter(xb_header_addr, &section_input, is_raw);
+    (void)XbSDB_GenerateSectionFilter(xb_header_addr, &section_input, is_raw);
 
     xb_xbe_type xbe_type = GetXbeType(xb_header_addr);
 
-    uint32_t kernel_thunk_addr = XbSymbolDatabase_GetKernelThunkAddress(xb_header_addr);
+    uint32_t kernel_thunk_addr = XbSDB_GetKernelThunkAddress(xb_header_addr);
 
     // Step 3, initialize context handle to pre-allocate the requirement.
     // However, calling global functions are recommended first for any customization.
-    if (!XbSymbolDatabase_CreateXbSymbolContext(&pHandle, register_func, library_input, section_input, kernel_thunk_addr)) {
+    if (!XbSDB_CreateContext(&pHandle, register_func, library_input, section_input, kernel_thunk_addr)) {
         goto FullCleanup;
     }
     // After initialize, we do not need to keep the allocated filter arrays in memory.
     free(section_input.filters);
     free(library_input.filters);
 
-    iContext = (iXbSymbolContext*)pHandle;
+    iContext = (XbSDBiContext*)pHandle;
 
     output_message_format(&iContext->output, XB_OUTPUT_MESSAGE_DEBUG, "xbe type is %s", xbe_type_str[xbe_type]);
 
     // Step 4, perform manual scan requirement to collect the necessary requirement
     // before perform general scan.
-    XbSymbolContext_ScanManual(pHandle);
+    XbSDBContext_ScanManual(pHandle);
 
     // Step 5, do a full scan process.
-    XbSymbolContext_ScanAllLibraryFilter(pHandle);
+    XbSDBContext_ScanAllLibraryFilter(pHandle);
 
     // Step 6, register any xrefs (which doesn't have its own OOVPA)
-    XbSymbolContext_RegisterXRefs(pHandle);
+    XbSDBContext_RegisterXRefs(pHandle);
 
     // Finally, after all the scan process is done, release the context handler.
-    XbSymbolContext_Release(pHandle);
+    XbSDBContext_Release(pHandle);
 
     return true;
 
@@ -1293,11 +1293,11 @@ LibraryCleanup:
 }
 
 // Require to be at end of various functions may use manual register calls in order to count properly.
-unsigned XbSymbolDatabase_GetTotalSymbols(uint32_t library_filter)
+unsigned XbSDB_GetTotalSymbols(uint32_t library_filter)
 {
     unsigned db_i = 0, total = SYMBOL_COUNTER_VALUE;
     SymbolDatabaseList* pLibraryDB;
-    while ((pLibraryDB = internal_FindLibraryDB(library_filter, &db_i))) {
+    while ((pLibraryDB = XbSDBi_FindLibraryDB(library_filter, &db_i))) {
         db_i++;
         total += pLibraryDB->Symbols->Count;
     }

--- a/src/lib/libXbSymbolDatabase.c
+++ b/src/lib/libXbSymbolDatabase.c
@@ -519,7 +519,7 @@ uint32_t XbSDBContext_GetLibraryDependencies(XbSDBContextHandle pHandle, uint32_
 }
 
 // TODO: Expose to third-party?
-bool XbSDBi_HasDSoundSection(const void* xb_header_addr)
+static bool XbSDBi_HasDSoundSection(const void* xb_header_addr)
 {
     const xbe_header* pXbeHeader = xb_header_addr;
     memptr_t xb_start_addr = (memptr_t)xb_header_addr - pXbeHeader->dwBaseAddr;

--- a/src/lib/manual_custom.h
+++ b/src/lib/manual_custom.h
@@ -6,7 +6,7 @@
 #pragma once
 
 // ******************************************************************
-// * Used for XbSymbolContext_ScanManual
+// * Used for XbSDBContext_ScanManual
 // ******************************************************************
 
 // Each include is base on library requirement to do by hand
@@ -15,9 +15,9 @@
 #include "manual_jvs.h"
 #include "manual_xapilib.h"
 
-static bool manual_scan_library_custom(iXbSymbolContext* pContext,
+static bool manual_scan_library_custom(XbSDBiContext* pContext,
                                        custom_scan_func_t custom_scan_func,
-                                       const iXbSymbolLibrarySession* pLibSession)
+                                       const XbSDBiLibrarySession* pLibSession)
 {
     bool scan_ret = false;
 
@@ -25,7 +25,7 @@ static bool manual_scan_library_custom(iXbSymbolContext* pContext,
 
     SymbolDatabaseList* pLibraryDB;
     unsigned db_i = 0;
-    while ((pLibraryDB = internal_FindLibraryDB(pLibSession->pLibrary->flag, &db_i))) {
+    while ((pLibraryDB = XbSDBi_FindLibraryDB(pLibSession->pLibrary->flag, &db_i))) {
         db_i++;
         for (unsigned int s = 0; s < pContext->section_input.count; s++) {
 
@@ -57,7 +57,7 @@ static bool manual_scan_library_custom(iXbSymbolContext* pContext,
     return scan_ret;
 }
 
-static inline void manual_register_symbols(iXbSymbolContext* pContext)
+static inline void manual_register_symbols(XbSDBiContext* pContext)
 {
     manual_register_d3d8__ltcg(pContext);
     manual_register_jvs(pContext);

--- a/src/lib/manual_d3d8__ltcg.h
+++ b/src/lib/manual_d3d8__ltcg.h
@@ -669,7 +669,6 @@ static bool manual_scan_section_dx8(iXbSymbolContext* pContext,
 {
     // Generic usage
     memptr_t pSymbolAddr = 0;
-    uintptr_t virt_start_relative = (uintptr_t)pSection->buffer_lower - pSection->xb_virt_addr;
     const XbSDBLibrary* pLibrary = pLibrarySession->pLibrary;
 
     // We need to mask boolean from each function's scan process if any return false.

--- a/src/lib/manual_d3d8__ltcg.h
+++ b/src/lib/manual_d3d8__ltcg.h
@@ -239,8 +239,8 @@ static int GetRenderStateOffsetByXRef(uint16_t xref,
     return -1;
 }
 
-static void manual_scan_section_dx8_VerifyRenderStateOffsets(iXbSymbolContext* pContext,
-                                                             const iXbSymbolLibrarySession* pLibrarySession)
+static void manual_scan_section_dx8_VerifyRenderStateOffsets(XbSDBiContext* pContext,
+                                                             const XbSDBiLibrarySession* pLibrarySession)
 {
     const XbSDBLibrary* pLibrary = pLibrarySession->pLibrary;
 
@@ -249,14 +249,14 @@ static void manual_scan_section_dx8_VerifyRenderStateOffsets(iXbSymbolContext* p
     // * Complex offset
     // Verify D3D_g_RenderState is set.
     xbaddr g_RenderState = pContext->xref_database[XREF_D3D_g_RenderState];
-    if (internal_IsXRefAddrUnset(g_RenderState)) {
+    if (XbSDBi_IsXRefAddrUnset(g_RenderState)) {
         output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "D3D_g_RenderState is not set!");
         return;
     }
 
     // Verify D3D_g_DeferredRenderState is set.
     xbaddr g_DeferredRenderState = pContext->xref_database[XREF_D3D_g_DeferredRenderState];
-    if (internal_IsXRefAddrUnset(g_DeferredRenderState)) {
+    if (XbSDBi_IsXRefAddrUnset(g_DeferredRenderState)) {
         output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "D3D_g_DeferredRenderState is not set!");
         return;
     }
@@ -272,7 +272,7 @@ static void manual_scan_section_dx8_VerifyRenderStateOffsets(iXbSymbolContext* p
 
     // Verify D3D_g_ComplexRenderState is set.
     xbaddr g_ComplexRenderState = pContext->xref_database[XREF_D3D_g_ComplexRenderState];
-    if (internal_IsXRefAddrUnset(g_ComplexRenderState)) {
+    if (XbSDBi_IsXRefAddrUnset(g_ComplexRenderState)) {
         output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, "D3D_g_ComplexRenderState is not set!");
         return;
     }
@@ -294,7 +294,7 @@ static void manual_scan_section_dx8_VerifyRenderStateOffsets(iXbSymbolContext* p
         if (IsRenderStateAvailableInCurrentXboxD3D8Lib(DxbxRenderStateInfo[i], pLibrary->build_version)) {
             if (DxbxRenderStateInfo[i].xref) {
                 xbaddr RenderState_iAddr = pContext->xref_database[DxbxRenderStateInfo[i].xref];
-                if (internal_IsXRefAddrUnset(RenderState_iAddr)) {
+                if (XbSDBi_IsXRefAddrUnset(RenderState_iAddr)) {
                     if (RenderState_iAddr != XREF_ADDR_DERIVE) {
                         snprintf(buffer_str, XBSDB_ARRAY_SIZE(buffer_str), "XbSymbolDatabase's %s symbol is not set!", DxbxRenderStateInfo[i].name);
                         output_message(&pContext->output, XB_OUTPUT_MESSAGE_ERROR, buffer_str);
@@ -316,8 +316,8 @@ static void manual_scan_section_dx8_VerifyRenderStateOffsets(iXbSymbolContext* p
     output_message(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, "Verify RenderState offsets is complete.");
 }
 
-static bool manual_scan_section_dx8_register_D3DRS_vars(iXbSymbolContext* pContext,
-                                                        const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8_register_D3DRS_vars(XbSDBiContext* pContext,
+                                                        const XbSDBiLibrarySession* pLibrarySession,
                                                         SymbolDatabaseList* pLibraryDB,
                                                         const XbSDBSection* pSection)
 {
@@ -331,50 +331,50 @@ static bool manual_scan_section_dx8_register_D3DRS_vars(iXbSymbolContext* pConte
             if (DxbxRenderStateInfo[i].xref) {
                 xbaddr RenderState_iAddr = pContext->xref_database[DxbxRenderStateInfo[i].xref];
                 // Check if D3DRS_ prefix variables are set.
-                if (internal_IsXRefAddrUnset(RenderState_iAddr)) {
+                if (XbSDBi_IsXRefAddrUnset(RenderState_iAddr)) {
                     if (RenderState_iAddr != XREF_ADDR_DERIVE) {
                         // If it is not derive address, then let's calculate base on DxbxRenderStateInfo table for accuracy.
-                        internal_SetXRefDatabase(pContext,
-                                                 pLibrarySession->iLibraryType,
-                                                 DxbxRenderStateInfo[i].xref,
-                                                 pContext->xref_database[XREF_D3D_g_RenderState] + RenderState_iLib * sizeof(xbaddr));
+                        XbSDBi_SetXRefDatabase(pContext,
+                                               pLibrarySession->iLibraryType,
+                                               DxbxRenderStateInfo[i].xref,
+                                               pContext->xref_database[XREF_D3D_g_RenderState] + RenderState_iLib * sizeof(xbaddr));
                         snprintf(buffer_str, XBSDB_ARRAY_SIZE(buffer_str), "%s symbol address is manually set to D3D_g_RenderState + %zd * %u.", DxbxRenderStateInfo[i].name, sizeof(xbaddr), RenderState_iLib);
                         output_message(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, buffer_str);
                     }
                 }
-                internal_RegisterValidXRefAddr(pContext, Lib_D3D8, XbSymbolLib_D3D8, render_state_i.xref, render_state_i.version, render_state_i.name, symbol_variable, call_none, 0, NULL);
+                XbSDBi_RegisterValidXRefAddr(pContext, LIB_D3D8, XBSDBLIB_D3D8, render_state_i.xref, render_state_i.version, render_state_i.name, symbol_variable, call_none, 0, NULL);
             }
             RenderState_iLib++;
         }
     }
 
     // Manual register RenderState sections.
-    internal_RegisterValidXRefAddr(pContext, Lib_D3D8, XbSymbolLib_D3D8, XREF_D3D_g_RenderState, 0, "D3D_g_RenderState", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_D3D8, XbSymbolLib_D3D8, XREF_D3D_g_ComplexRenderState, 0, "D3D_g_ComplexRenderState", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_D3D8, XbSymbolLib_D3D8, XREF_D3D_g_DeferredRenderState, 0, "D3D_g_DeferredRenderState", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_D3D8, XBSDBLIB_D3D8, XREF_D3D_g_RenderState, 0, "D3D_g_RenderState", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_D3D8, XBSDBLIB_D3D8, XREF_D3D_g_ComplexRenderState, 0, "D3D_g_ComplexRenderState", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_D3D8, XBSDBLIB_D3D8, XREF_D3D_g_DeferredRenderState, 0, "D3D_g_DeferredRenderState", symbol_variable, call_none, 0, NULL);
 
     return true;
 }
 
 // No dependency requirement
-static bool manual_scan_section_dx8_register_D3DRS(iXbSymbolContext* pContext,
-                                                   const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8_register_D3DRS(XbSDBiContext* pContext,
+                                                   const XbSDBiLibrarySession* pLibrarySession,
                                                    SymbolDatabaseList* pLibraryDB,
                                                    const XbSDBSection* pSection)
 {
     // First, we need to find D3DDevice_SetRenderState_Simple symbol.
     xbaddr D3DDevice_SetRenderState_Simple = pContext->xref_database[XREF_D3DDevice_SetRenderState_Simple];
-    if (internal_IsXRefAddrUnset(D3DDevice_SetRenderState_Simple)) {
-        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                            pLibrarySession,
-                                                                                            pLibraryDB,
-                                                                                            pSection,
-                                                                                            XREF_D3DDevice_SetRenderState_Simple,
-                                                                                            DB_ST_MANUAL,
-                                                                                            FIRSTPASS_YES,
-                                                                                            REGISTER_YES,
-                                                                                            NULL,
-                                                                                            NULL);
+    if (XbSDBi_IsXRefAddrUnset(D3DDevice_SetRenderState_Simple)) {
+        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                          pLibrarySession,
+                                                                                          pLibraryDB,
+                                                                                          pSection,
+                                                                                          XREF_D3DDevice_SetRenderState_Simple,
+                                                                                          DB_ST_MANUAL,
+                                                                                          FIRSTPASS_YES,
+                                                                                          REGISTER_YES,
+                                                                                          NULL,
+                                                                                          NULL);
         // If not found, skip the rest of the scan.
         if (xSymbolAddr == 0) {
             return false;
@@ -385,36 +385,36 @@ static bool manual_scan_section_dx8_register_D3DRS(iXbSymbolContext* pContext,
 
     // Then look up for D3D_g_RenderState
     xbaddr D3D_g_RenderState = pContext->xref_database[XREF_D3D_g_RenderState];
-    if (internal_IsXRefAddrUnset(D3D_g_RenderState)) {
+    if (XbSDBi_IsXRefAddrUnset(D3D_g_RenderState)) {
         // Below xref is used to obtain from D3DDevice_SetRenderState(Not)Inline signatures.
         pContext->xref_database[XREF_D3D_g_RenderState] = XREF_ADDR_DERIVE;
-        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                            pLibrarySession,
-                                                                                            pLibraryDB,
-                                                                                            pSection,
-                                                                                            XREF_D3DDevice_SetRenderStateNotInline,
-                                                                                            DB_ST_MANUAL,
-                                                                                            FIRSTPASS_YES,
-                                                                                            REGISTER_YES,
-                                                                                            NULL,
-                                                                                            NULL);
+        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                          pLibrarySession,
+                                                                                          pLibraryDB,
+                                                                                          pSection,
+                                                                                          XREF_D3DDevice_SetRenderStateNotInline,
+                                                                                          DB_ST_MANUAL,
+                                                                                          FIRSTPASS_YES,
+                                                                                          REGISTER_YES,
+                                                                                          NULL,
+                                                                                          NULL);
         if (xSymbolAddr == 0) {
             // If not found, then check if library is not LTCG.
-            if (pLibrarySession->pLibrary->flag == XbSymbolLib_D3D8) {
+            if (pLibrarySession->pLibrary->flag == XBSDBLIB_D3D8) {
                 pContext->xref_database[XREF_D3D_g_RenderState] = XREF_ADDR_UNDETERMINED;
                 return false;
             }
             // Otherwise, let's look up for D3DDevice_SetRenderStateInline__GenericFragment which is NOT a symbol.
-            xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                         pLibrarySession,
-                                                                                         pLibraryDB,
-                                                                                         pSection,
-                                                                                         XREF_D3DDevice_SetRenderStateInline__GenericFragment,
-                                                                                         DB_ST_MANUAL,
-                                                                                         FIRSTPASS_YES,
-                                                                                         REGISTER_NO,
-                                                                                         NULL,
-                                                                                         NULL);
+            xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                       pLibrarySession,
+                                                                                       pLibraryDB,
+                                                                                       pSection,
+                                                                                       XREF_D3DDevice_SetRenderStateInline__GenericFragment,
+                                                                                       DB_ST_MANUAL,
+                                                                                       FIRSTPASS_YES,
+                                                                                       REGISTER_NO,
+                                                                                       NULL,
+                                                                                       NULL);
 
             // If not found, skip the rest of the scan.
             if (xSymbolAddr == 0) {
@@ -422,13 +422,13 @@ static bool manual_scan_section_dx8_register_D3DRS(iXbSymbolContext* pContext,
                 return false;
             }
             // pointer to cmp opcode's value from D3DDevice_SetRenderStateInline__GenericFragment sig.
-            pD3D_g_DeferredRenderStateOffset = internal_section_VirtToHostAddress(pContext, xSymbolAddr + 0x02);
+            pD3D_g_DeferredRenderStateOffset = XbSDBi_section_VirtToHostAddress(pContext, xSymbolAddr + 0x02);
 
             // If it is found, don't register it.
         }
         else {
             // pointer to cmp opcode's value from D3DDevice_SetRenderStateNotInline sig.
-            pD3D_g_DeferredRenderStateOffset = internal_section_VirtToHostAddress(pContext, xSymbolAddr + 0x07);
+            pD3D_g_DeferredRenderStateOffset = XbSDBi_section_VirtToHostAddress(pContext, xSymbolAddr + 0x07);
 
             // Self register only D3DDevice_SetRenderStateNotInline symbol function.
             // NOTE: D3DDevice_SetRenderStateInline__GenericFragment is NOT a symbol but a generic method to find D3D_g_RenderState.
@@ -440,43 +440,43 @@ static bool manual_scan_section_dx8_register_D3DRS(iXbSymbolContext* pContext,
         // This is 100% accurate method than manual offset usage.
         if (pD3D_g_DeferredRenderStateOffset) {
             uint8_t D3D_g_DeferredRenderStateOffset = *(uint8_t*)pD3D_g_DeferredRenderStateOffset;
-            internal_SetXRefDatabase(pContext,
-                                     pLibrarySession->iLibraryType,
-                                     XREF_D3D_g_DeferredRenderState,
-                                     pContext->xref_database[XREF_D3D_g_RenderState] + D3D_g_DeferredRenderStateOffset * 4);
+            XbSDBi_SetXRefDatabase(pContext,
+                                   pLibrarySession->iLibraryType,
+                                   XREF_D3D_g_DeferredRenderState,
+                                   pContext->xref_database[XREF_D3D_g_RenderState] + D3D_g_DeferredRenderStateOffset * 4);
 
-            internal_SetXRefDatabase(pContext,
-                                     pLibrarySession->iLibraryType,
-                                     XREF_D3DRS_FogEnable,
-                                     pContext->xref_database[XREF_D3D_g_DeferredRenderState]);
+            XbSDBi_SetXRefDatabase(pContext,
+                                   pLibrarySession->iLibraryType,
+                                   XREF_D3DRS_FogEnable,
+                                   pContext->xref_database[XREF_D3D_g_DeferredRenderState]);
         }
     }
     return true;
 }
 
 // No dependency requirement
-static bool manual_scan_section_dx8_register_D3DCRS(iXbSymbolContext* pContext,
-                                                    const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8_register_D3DCRS(XbSDBiContext* pContext,
+                                                    const XbSDBiLibrarySession* pLibrarySession,
                                                     SymbolDatabaseList* pLibraryDB,
                                                     const XbSDBSection* pSection)
 {
     // First, we need to find D3DRS_FillMode symbol.
     xbaddr D3DRS_FillMode = pContext->xref_database[XREF_D3DRS_FillMode];
-    if (internal_IsXRefAddrUnset(D3DRS_FillMode)) {
+    if (XbSDBi_IsXRefAddrUnset(D3DRS_FillMode)) {
         // These xrefs are used to obtain from D3DDevice_SetRenderState_FillMode signature.
         pContext->xref_database[XREF_D3DRS_FillMode] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_BackFillMode] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_TwoSidedLighting] = XREF_ADDR_DERIVE;
-        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                            pLibrarySession,
-                                                                                            pLibraryDB,
-                                                                                            pSection,
-                                                                                            XREF_D3DDevice_SetRenderState_FillMode,
-                                                                                            DB_ST_MANUAL,
-                                                                                            FIRSTPASS_NO,
-                                                                                            REGISTER_YES,
-                                                                                            NULL,
-                                                                                            NULL);
+        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                          pLibrarySession,
+                                                                                          pLibraryDB,
+                                                                                          pSection,
+                                                                                          XREF_D3DDevice_SetRenderState_FillMode,
+                                                                                          DB_ST_MANUAL,
+                                                                                          FIRSTPASS_NO,
+                                                                                          REGISTER_YES,
+                                                                                          NULL,
+                                                                                          NULL);
         // If not found, skip the rest of the scan.
         if (xSymbolAddr == 0) {
             pContext->xref_database[XREF_D3DRS_FillMode] = XREF_ADDR_UNDETERMINED;
@@ -499,29 +499,29 @@ static bool manual_scan_section_dx8_register_D3DCRS(iXbSymbolContext* pContext,
 }
 
 // No dependency requirement
-static bool manual_scan_section_dx8_register_D3DRS_end_of_list(iXbSymbolContext* pContext,
-                                                               const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8_register_D3DRS_end_of_list(XbSDBiContext* pContext,
+                                                               const XbSDBiLibrarySession* pLibrarySession,
                                                                SymbolDatabaseList* pLibraryDB,
                                                                const XbSDBSection* pSection)
 {
     // First, we need to find D3DRS_DoNotCullUncompressed symbol.
     xbaddr D3DRS_DoNotCullUncompressed = pContext->xref_database[XREF_D3DRS_DoNotCullUncompressed];
-    if (internal_IsXRefAddrUnset(D3DRS_DoNotCullUncompressed)) {
+    if (XbSDBi_IsXRefAddrUnset(D3DRS_DoNotCullUncompressed)) {
         // These xrefs are used to obtain from D3D_CommonSetDebugRegisters signature.
         pContext->xref_database[XREF_D3D_g_pDevice] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_RopZCmpAlwaysRead] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_RopZRead] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_DoNotCullUncompressed] = XREF_ADDR_DERIVE;
-        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                            pLibrarySession,
-                                                                                            pLibraryDB,
-                                                                                            pSection,
-                                                                                            XREF_D3D_CommonSetDebugRegisters,
-                                                                                            DB_ST_MANUAL,
-                                                                                            FIRSTPASS_NO,
-                                                                                            REGISTER_YES,
-                                                                                            NULL,
-                                                                                            NULL);
+        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                          pLibrarySession,
+                                                                                          pLibraryDB,
+                                                                                          pSection,
+                                                                                          XREF_D3D_CommonSetDebugRegisters,
+                                                                                          DB_ST_MANUAL,
+                                                                                          FIRSTPASS_NO,
+                                                                                          REGISTER_YES,
+                                                                                          NULL,
+                                                                                          NULL);
         // If not found, skip the rest of the scan.
         if (xSymbolAddr == 0) {
             pContext->xref_database[XREF_D3D_g_pDevice] = XREF_ADDR_UNDETERMINED;
@@ -532,44 +532,44 @@ static bool manual_scan_section_dx8_register_D3DRS_end_of_list(iXbSymbolContext*
         }
 
         OOVPATable* pSymbolEntry = NULL;
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3D_g_pDevice);
-        internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3D_g_pDevice);
+        XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
 #if 0 // TODO: Fix this after #208 pull request is merged.
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DRS_RopZCmpAlwaysRead);
-        internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DRS_RopZRead);
-        internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DRS_DoNotCullUncompressed);
-        internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DRS_RopZCmpAlwaysRead);
+        XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DRS_RopZRead);
+        XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DRS_DoNotCullUncompressed);
+        XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
 #endif
     }
     return true;
 }
 
 // No dependency requirement
-static bool manual_scan_section_dx8_register_D3DRS_Stencils_and_Occlusion(iXbSymbolContext* pContext,
-                                                                          const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8_register_D3DRS_Stencils_and_Occlusion(XbSDBiContext* pContext,
+                                                                          const XbSDBiLibrarySession* pLibrarySession,
                                                                           SymbolDatabaseList* pLibraryDB,
                                                                           const XbSDBSection* pSection)
 {
     // First, we need to find D3DRS_StencilEnable symbol.
     xbaddr D3DRS_StencilEnable = pContext->xref_database[XREF_D3DRS_StencilEnable];
-    if (internal_IsXRefAddrUnset(D3DRS_StencilEnable)) {
+    if (XbSDBi_IsXRefAddrUnset(D3DRS_StencilEnable)) {
         // These xrefs are used to obtain from D3DRS_Stencils_and_Occlusion__GenericFragment signature.
         pContext->xref_database[XREF_D3DRS_StencilEnable] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_StencilFail] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_OcclusionCullEnable] = XREF_ADDR_DERIVE;
         pContext->xref_database[XREF_D3DRS_StencilCullEnable] = XREF_ADDR_DERIVE;
-        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                            pLibrarySession,
-                                                                                            pLibraryDB,
-                                                                                            pSection,
-                                                                                            XREF_D3DRS_Stencils_and_Occlusion__GenericFragment,
-                                                                                            DB_ST_MANUAL,
-                                                                                            FIRSTPASS_NO,
-                                                                                            REGISTER_NO,
-                                                                                            NULL,
-                                                                                            NULL);
+        xbaddr xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                          pLibrarySession,
+                                                                                          pLibraryDB,
+                                                                                          pSection,
+                                                                                          XREF_D3DRS_Stencils_and_Occlusion__GenericFragment,
+                                                                                          DB_ST_MANUAL,
+                                                                                          FIRSTPASS_NO,
+                                                                                          REGISTER_NO,
+                                                                                          NULL,
+                                                                                          NULL);
         // If not found, skip the rest of the scan.
         if (xSymbolAddr == 0) {
             pContext->xref_database[XREF_D3DRS_StencilEnable] = XREF_ADDR_UNDETERMINED;
@@ -584,8 +584,8 @@ static bool manual_scan_section_dx8_register_D3DRS_Stencils_and_Occlusion(iXbSym
     return true;
 }
 
-static void manual_scan_section_dx8_register_D3DTSS(iXbSymbolContext* pContext,
-                                                    const iXbSymbolLibrarySession* pLibrarySession)
+static void manual_scan_section_dx8_register_D3DTSS(XbSDBiContext* pContext,
+                                                    const XbSDBiLibrarySession* pLibrarySession)
 {
     const XbSDBLibrary* pLibrary = pLibrarySession->pLibrary;
     const eLibraryType iLibraryType = pLibrarySession->iLibraryType;
@@ -593,19 +593,19 @@ static void manual_scan_section_dx8_register_D3DTSS(iXbSymbolContext* pContext,
     xbaddr DerivedAddr_D3DTSS_TEXCOORDINDEX = pContext->xref_database[XREF_D3DTSS_TEXCOORDINDEX];
     int Decrement = 0x70; // TODO : Rename into something understandable
 
-    //internal_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_BUMPENV, DerivedAddr_D3DTSS_TEXCOORDINDEX - 28 * 4);
-    //internal_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_TEXCOORDINDEX, DerivedAddr_D3DTSS_TEXCOORDINDEX); // Already been set.
-    //internal_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_BORDERCOLOR, DerivedAddr_D3DTSS_TEXCOORDINDEX + 1 * 4);
-    //internal_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_COLORKEYCOLOR, DerivedAddr_D3DTSS_TEXCOORDINDEX + 2 * 4);
+    //XbSDBi_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_BUMPENV, DerivedAddr_D3DTSS_TEXCOORDINDEX - 28 * 4);
+    //XbSDBi_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_TEXCOORDINDEX, DerivedAddr_D3DTSS_TEXCOORDINDEX); // Already been set.
+    //XbSDBi_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_BORDERCOLOR, DerivedAddr_D3DTSS_TEXCOORDINDEX + 1 * 4);
+    //XbSDBi_SetXRefDatabase(pContext, iLibraryType, XREF_D3DTSS_COLORKEYCOLOR, DerivedAddr_D3DTSS_TEXCOORDINDEX + 2 * 4);
 
     uint32_t EmuD3DDeferredTextureState = DerivedAddr_D3DTSS_TEXCOORDINDEX - Decrement;
 
-    internal_RegisterXRef(pContext, pLibrarySession, XREF_D3D_g_DeferredTextureState, 0, "D3D_g_DeferredTextureState", EmuD3DDeferredTextureState, symbol_variable, call_none, 0, NULL, true);
+    XbSDBi_RegisterXRef(pContext, pLibrarySession, XREF_D3D_g_DeferredTextureState, 0, "D3D_g_DeferredTextureState", EmuD3DDeferredTextureState, symbol_variable, call_none, 0, NULL, true);
 }
 
 // Has dependency on D3D_g_pDevice xref.
-static bool manual_scan_section_dx8_register_callbacks(iXbSymbolContext* pContext,
-                                                       const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8_register_callbacks(XbSDBiContext* pContext,
+                                                       const XbSDBiLibrarySession* pLibrarySession,
                                                        SymbolDatabaseList* pLibraryDB,
                                                        const XbSDBSection* pSection)
 {
@@ -623,16 +623,16 @@ static bool manual_scan_section_dx8_register_callbacks(iXbSymbolContext* pContex
 
         // Scan if event handle variable is not yet derived.
         if (pContext->xref_database[XREF_D3DDevice__m_VerticalBlankEvent_OFFSET] == XREF_ADDR_DERIVE) {
-            xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                         pLibrarySession,
-                                                                                         pLibraryDB,
-                                                                                         pSection,
-                                                                                         XREF_D3DDevice__m_VerticalBlankEvent__GenericFragment,
-                                                                                         DB_ST_MANUAL,
-                                                                                         FIRSTPASS_YES,
-                                                                                         REGISTER_NO,
-                                                                                         NULL,
-                                                                                         NULL);
+            xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                       pLibrarySession,
+                                                                                       pLibraryDB,
+                                                                                       pSection,
+                                                                                       XREF_D3DDevice__m_VerticalBlankEvent__GenericFragment,
+                                                                                       DB_ST_MANUAL,
+                                                                                       FIRSTPASS_YES,
+                                                                                       REGISTER_NO,
+                                                                                       NULL,
+                                                                                       NULL);
         }
 
         // We are not registering D3DDevice__m_VerticalBlankEvent__GenericFragment itself, as it is NOT a symbol.
@@ -646,12 +646,12 @@ static bool manual_scan_section_dx8_register_callbacks(iXbSymbolContext* pContex
         // Finally, manual register the symbol variables.
         OOVPATable* pSymbolEntry = NULL;
         xSymbolAddr = pContext->xref_database[XREF_D3DDevice__m_VerticalBlankEvent_OFFSET];
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DDevice__m_VerticalBlankEvent_OFFSET);
-        internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DDevice__m_SwapCallback_OFFSET);
-        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, xSymbolAddr - 8);
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DDevice__m_VBlankCallback_OFFSET);
-        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, xSymbolAddr - 4);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DDevice__m_VerticalBlankEvent_OFFSET);
+        XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 0);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DDevice__m_SwapCallback_OFFSET);
+        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, xSymbolAddr - 8);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, D3DDevice__m_VBlankCallback_OFFSET);
+        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, xSymbolAddr - 4);
     }
     // If D3D_g_pDevice is not found, the scan is not complete
     // and will continue scan to next given section.
@@ -662,8 +662,8 @@ static bool manual_scan_section_dx8_register_callbacks(iXbSymbolContext* pContex
     return true;
 }
 
-static bool manual_scan_section_dx8(iXbSymbolContext* pContext,
-                                    const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dx8(XbSDBiContext* pContext,
+                                    const XbSDBiLibrarySession* pLibrarySession,
                                     SymbolDatabaseList* pLibraryDB,
                                     const XbSDBSection* pSection)
 {
@@ -709,15 +709,15 @@ static bool manual_scan_section_dx8(iXbSymbolContext* pContext,
     // then locate D3DDeferredTextureState
     OOVPATable* pSymbolEntry = NULL;
     OOVPARevision* pSymbolEntryRevision = NULL;
-    pSymbolAddr = internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                              pLibrarySession,
-                                                              pLibraryDB,
-                                                              pSection,
-                                                              XREF_D3DDevice_SetTextureState_TexCoordIndex, DB_ST_MANUAL,
-                                                              FIRSTPASS_YES,
-                                                              REGISTER_YES,
-                                                              &pSymbolEntry,
-                                                              &pSymbolEntryRevision);
+    pSymbolAddr = XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                            pLibrarySession,
+                                                            pLibraryDB,
+                                                            pSection,
+                                                            XREF_D3DDevice_SetTextureState_TexCoordIndex, DB_ST_MANUAL,
+                                                            FIRSTPASS_YES,
+                                                            REGISTER_YES,
+                                                            &pSymbolEntry,
+                                                            &pSymbolEntryRevision);
 
     if (pSymbolAddr != 0) {
         // Self register D3DDevice_SetTextureState_TexCoordIndex
@@ -727,16 +727,16 @@ static bool manual_scan_section_dx8(iXbSymbolContext* pContext,
 
     pSymbolEntry = NULL;
     pSymbolEntryRevision = NULL;
-    pSymbolAddr = internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                              pLibrarySession,
-                                                              pLibraryDB,
-                                                              pSection,
-                                                              XREF_D3DDevice_SetStreamSource,
-                                                              DB_ST_MANUAL,
-                                                              FIRSTPASS_YES,
-                                                              REGISTER_YES,
-                                                              &pSymbolEntry,
-                                                              &pSymbolEntryRevision);
+    pSymbolAddr = XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                            pLibrarySession,
+                                                            pLibraryDB,
+                                                            pSection,
+                                                            XREF_D3DDevice_SetStreamSource,
+                                                            DB_ST_MANUAL,
+                                                            FIRSTPASS_YES,
+                                                            REGISTER_YES,
+                                                            &pSymbolEntry,
+                                                            &pSymbolEntryRevision);
 
     if (pSymbolAddr != 0) {
         // Self register D3DDevice_SetStreamSource
@@ -751,8 +751,8 @@ static bool manual_scan_section_dx8(iXbSymbolContext* pContext,
             pContext->xref_database[XREF_D3D_g_Stream] = D3D_g_Stream_i_pVertexBuffer - 8;
         }
 
-        // TODO: Use internal_FindByReferenceHelper to get OOVPA revision. Or better yet, do self register.
-        internal_RegisterValidXRefAddr(pContext, pLibrary->name, pLibrary->flag, XREF_D3D_g_Stream, 0, "D3D_g_Stream", symbol_variable, call_none, 0, NULL);
+        // TODO: Use XbSDBi_FindByReferenceHelper to get OOVPA revision. Or better yet, do self register.
+        XbSDBi_RegisterValidXRefAddr(pContext, pLibrary->name, pLibrary->flag, XREF_D3D_g_Stream, 0, "D3D_g_Stream", symbol_variable, call_none, 0, NULL);
     }
 
     bComplete = manual_scan_section_dx8_register_callbacks(pContext, pLibrarySession, pLibraryDB, pSection);
@@ -760,9 +760,9 @@ static bool manual_scan_section_dx8(iXbSymbolContext* pContext,
     return bComplete;
 }
 
-static inline void manual_register_d3d8__ltcg(iXbSymbolContext* pContext)
+static inline void manual_register_d3d8__ltcg(XbSDBiContext* pContext)
 {
     // TODO: Require to be here until self register functionality is implement.
-    internal_RegisterValidXRefAddr(pContext, Lib_D3D8, XbSymbolLib_D3D8, XREF_D3DDevice__m_VertexShader_OFFSET, 0, "D3DDevice__m_VertexShader_OFFSET", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_D3D8, XBSDBLIB_D3D8, XREF_D3DDevice__m_VertexShader_OFFSET, 0, "D3DDevice__m_VertexShader_OFFSET", symbol_variable, call_none, 0, NULL);
     // NOTE: D3DDevice__m_PixelShader_OFFSET is not accessible to the user.
 }

--- a/src/lib/manual_dsound.h
+++ b/src/lib/manual_dsound.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-static bool manual_scan_section_dsound(iXbSymbolContext* pContext,
-                                       const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_dsound(XbSDBiContext* pContext,
+                                       const XbSDBiLibrarySession* pLibrarySession,
                                        SymbolDatabaseList* pLibraryDB,
                                        const XbSDBSection* pSection)
 {
@@ -24,16 +24,16 @@ static bool manual_scan_section_dsound(iXbSymbolContext* pContext,
 
     // Scan for DirectSoundStream's constructor function.
     if (pContext->xref_database[XREF_CDirectSoundStream_Constructor] == XREF_ADDR_UNDETERMINED) {
-        xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                     pLibrarySession,
-                                                                                     pLibraryDB,
-                                                                                     pSection,
-                                                                                     XREF_CDirectSoundStream_Constructor,
-                                                                                     DB_ST_MANUAL,
-                                                                                     FIRSTPASS_YES,
-                                                                                     REGISTER_YES,
-                                                                                     NULL,
-                                                                                     NULL);
+        xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                   pLibrarySession,
+                                                                                   pLibraryDB,
+                                                                                   pSection,
+                                                                                   XREF_CDirectSoundStream_Constructor,
+                                                                                   DB_ST_MANUAL,
+                                                                                   FIRSTPASS_YES,
+                                                                                   REGISTER_YES,
+                                                                                   NULL,
+                                                                                   NULL);
 
         // If not found, skip the rest of the scan.
         if (xSymbolAddr == 0) {
@@ -41,10 +41,10 @@ static bool manual_scan_section_dsound(iXbSymbolContext* pContext,
         }
 
         // TODO: If possible, integrate into the OOVPA structure.
-        internal_RegisterXRef(pContext, pLibrarySession, XREF_DSS_VOICE_VTABLE, 3911,
-                              NULL, *(xbaddr*)(virt_start_relative + xSymbolAddr + 0x14), symbol_variable, call_none, 0, NULL, false);
-        internal_RegisterXRef(pContext, pLibrarySession, XREF_DSS_STREAM_VTABLE, 3911,
-                              NULL, *(xbaddr*)(virt_start_relative + xSymbolAddr + 0x1B), symbol_variable, call_none, 0, NULL, false);
+        XbSDBi_RegisterXRef(pContext, pLibrarySession, XREF_DSS_VOICE_VTABLE, 3911,
+                            NULL, *(xbaddr*)(virt_start_relative + xSymbolAddr + 0x14), symbol_variable, call_none, 0, NULL, false);
+        XbSDBi_RegisterXRef(pContext, pLibrarySession, XREF_DSS_STREAM_VTABLE, 3911,
+                            NULL, *(xbaddr*)(virt_start_relative + xSymbolAddr + 0x1B), symbol_variable, call_none, 0, NULL, false);
     }
 
     // Verify both variables are already set from the scan function above.
@@ -62,33 +62,33 @@ static bool manual_scan_section_dsound(iXbSymbolContext* pContext,
         if (xblower <= vtable && vtable < xbupper) {
             pSymbolAddr = (memptr_t)virt_start_relative + vtable;
             OOVPATable* pSymbolEntry = NULL;
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_AddRef);
-            internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 0 * 4));
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_AddRef);
+            XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 0 * 4));
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Release);
-            internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 1 * 4));
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Release);
+            XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 1 * 4));
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_GetInfo);
-            internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 2 * 4));
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_GetInfo);
+            XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 2 * 4));
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_GetStatus);
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_GetStatus);
             // TODO: May need further investigation with Cxbx-Reloaded's source code for possible reasoning why this method is used.
             SYMBOL_COUNTER_VALUE; // Force increase by one symbol counter since we do not have both revisions difference in the OOVPA database.
             if (pLibrarySession->pLibrary->build_version < 4134) {
-                internal_RegisterSymbolHelper(pContext, pLibrarySession, pSymbolEntry, "CDirectSoundStream_GetStatus__r1", 3911, *(uint32_t*)(pSymbolAddr + 3 * 4));
+                XbSDBi_RegisterSymbolHelper(pContext, pLibrarySession, pSymbolEntry, "CDirectSoundStream_GetStatus__r1", 3911, *(uint32_t*)(pSymbolAddr + 3 * 4));
             }
             else {
-                internal_RegisterSymbolHelper(pContext, pLibrarySession, pSymbolEntry, "CDirectSoundStream_GetStatus__r2", 4134, *(uint32_t*)(pSymbolAddr + 3 * 4));
+                XbSDBi_RegisterSymbolHelper(pContext, pLibrarySession, pSymbolEntry, "CDirectSoundStream_GetStatus__r2", 4134, *(uint32_t*)(pSymbolAddr + 3 * 4));
             }
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Process);
-            internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 4 * 4));
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Process);
+            XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 4 * 4));
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Discontinuity);
-            internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 5 * 4));
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Discontinuity);
+            XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 5 * 4));
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Flush);
-            internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 6 * 4));
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, CDirectSoundStream_Flush);
+            XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 3911, *(uint32_t*)(pSymbolAddr + 6 * 4));
 
             // NOTE: it is possible to manual add GetInfo, GetStatus, Process, Discontinuity,
             // and Flush functions.

--- a/src/lib/manual_jvs.h
+++ b/src/lib/manual_jvs.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-static inline void manual_register_jvs(iXbSymbolContext* pContext)
+static inline void manual_register_jvs(XbSDBiContext* pContext)
 {
-    internal_RegisterValidXRefAddr(pContext, Lib_JVS, XbSymbolLib_JVS, XREF_JVS_g_pPINSA, 4831, "JVS_g_pPINSA", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_JVS, XbSymbolLib_JVS, XREF_JVS_g_pPINSB, 4831, "JVS_g_pPINSB", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_JVS, XBSDBLIB_JVS, XREF_JVS_g_pPINSA, 4831, "JVS_g_pPINSA", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_JVS, XBSDBLIB_JVS, XREF_JVS_g_pPINSB, 4831, "JVS_g_pPINSB", symbol_variable, call_none, 0, NULL);
 }

--- a/src/lib/manual_xapilib.h
+++ b/src/lib/manual_xapilib.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-static bool internal_xapi_find_XGetSectionSize(iXbSymbolContext* pContext,
-                                               const iXbSymbolLibrarySession* pLibrarySession,
+static bool internal_xapi_find_XGetSectionSize(XbSDBiContext* pContext,
+                                               const XbSDBiLibrarySession* pLibrarySession,
                                                SymbolDatabaseList* pLibraryDB,
                                                const XbSDBSection* pSection,
                                                uintptr_t virt_start_relative)
@@ -16,24 +16,24 @@ static bool internal_xapi_find_XGetSectionSize(iXbSymbolContext* pContext,
     OOVPATable* pSymbolEntry = NULL;
 
     // Find XapiMapLetterToDirectory function
-    if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_XapiMapLetterToDirectory])) {
+    if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_XapiMapLetterToDirectory])) {
         const char* xref_str = "XGetSectionSize";
 
-        xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                     pLibrarySession,
-                                                                                     pLibraryDB,
-                                                                                     pSection,
-                                                                                     XREF_XapiMapLetterToDirectory,
-                                                                                     DB_ST_MANUAL,
-                                                                                     FIRSTPASS_YES,
-                                                                                     REGISTER_YES,
-                                                                                     &pSymbolEntry,
-                                                                                     &pSymbolRevision);
+        xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                   pLibrarySession,
+                                                                                   pLibraryDB,
+                                                                                   pSection,
+                                                                                   XREF_XapiMapLetterToDirectory,
+                                                                                   DB_ST_MANUAL,
+                                                                                   FIRSTPASS_YES,
+                                                                                   REGISTER_YES,
+                                                                                   &pSymbolEntry,
+                                                                                   &pSymbolRevision);
 
         if (xSymbolAddr) {
 
             // Register XGetSectionSize function.
-            if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_XGetSectionSize])) {
+            if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_XGetSectionSize])) {
                 // If relative address is not recorded, then signature needs a fix.
                 output_message_format(&pContext->output,
                                       XB_OUTPUT_MESSAGE_ERROR,
@@ -42,7 +42,7 @@ static bool internal_xapi_find_XGetSectionSize(iXbSymbolContext* pContext,
                 return false;
             }
             // Manually translate to virtual address from relative address.
-            xSymbolAddr = internal_OOVPARevision_ConvertXRefRelativeAddrtToVirtAddr(pContext, pSymbolEntry, pSymbolRevision, xref_str, XREF_XGetSectionSize);
+            xSymbolAddr = XbSDBi_OOVPARevision_ConvertXRefRelativeAddrtToVirtAddr(pContext, pSymbolEntry, pSymbolRevision, xref_str, XREF_XGetSectionSize);
             if (!xSymbolAddr) {
                 // Error message is handled by above function. No extra message necessary here.
                 return false;
@@ -50,16 +50,16 @@ static bool internal_xapi_find_XGetSectionSize(iXbSymbolContext* pContext,
             // Update to use virtual address instead of relative address.
             pContext->xref_database[XREF_XGetSectionSize] = xSymbolAddr;
 
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, XGetSectionSize);
-            internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, pSymbolRevision->Version);
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, XGetSectionSize);
+            XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, pSymbolRevision->Version);
         }
     }
 
     return true;
 }
 
-static bool internal_xapi_find_DeviceType_MU(iXbSymbolContext* pContext,
-                                             const iXbSymbolLibrarySession* pLibrarySession,
+static bool internal_xapi_find_DeviceType_MU(XbSDBiContext* pContext,
+                                             const XbSDBiLibrarySession* pLibrarySession,
                                              SymbolDatabaseList* pLibraryDB,
                                              const XbSDBSection* pSection,
                                              uintptr_t virt_start_relative)
@@ -68,38 +68,38 @@ static bool internal_xapi_find_DeviceType_MU(iXbSymbolContext* pContext,
     memptr_t buffer_upper = (memptr_t)pSection->buffer_lower + pSection->buffer_size;
 
     // Find MU_Init function
-    if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_MU_Init])) {
+    if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_MU_Init])) {
 
-        xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                     pLibrarySession,
-                                                                                     pLibraryDB,
-                                                                                     pSection,
-                                                                                     XREF_MU_Init,
-                                                                                     DB_ST_MANUAL,
-                                                                                     FIRSTPASS_YES,
-                                                                                     REGISTER_YES,
-                                                                                     NULL,
-                                                                                     NULL);
+        xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                   pLibrarySession,
+                                                                                   pLibraryDB,
+                                                                                   pSection,
+                                                                                   XREF_MU_Init,
+                                                                                   DB_ST_MANUAL,
+                                                                                   FIRSTPASS_YES,
+                                                                                   REGISTER_YES,
+                                                                                   NULL,
+                                                                                   NULL);
     }
 
-    if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_MU_Init])) {
+    if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_MU_Init])) {
         // If not found, skip the rest of the scan.
         return false;
     }
 
 
     // Scan for IUsbInit::GetMaxDeviceTypeCount function.
-    if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_IUsbInit_GetMaxDeviceTypeCount])) {
-        xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                     pLibrarySession,
-                                                                                     pLibraryDB,
-                                                                                     pSection,
-                                                                                     XREF_IUsbInit_GetMaxDeviceTypeCount,
-                                                                                     DB_ST_MANUAL,
-                                                                                     FIRSTPASS_YES,
-                                                                                     REGISTER_YES,
-                                                                                     NULL,
-                                                                                     NULL);
+    if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_IUsbInit_GetMaxDeviceTypeCount])) {
+        xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                   pLibrarySession,
+                                                                                   pLibraryDB,
+                                                                                   pSection,
+                                                                                   XREF_IUsbInit_GetMaxDeviceTypeCount,
+                                                                                   DB_ST_MANUAL,
+                                                                                   FIRSTPASS_YES,
+                                                                                   REGISTER_YES,
+                                                                                   NULL,
+                                                                                   NULL);
 
         // If not found, skip the rest of the scan.
         if (xSymbolAddr == 0) {
@@ -122,7 +122,7 @@ static bool internal_xapi_find_DeviceType_MU(iXbSymbolContext* pContext,
 
             // check if call is linked to IUsbInit_GetMaxDeviceTypeCount function.
             xbaddr ActualAddr = *(xbaddr*)(cur + 6);
-            if (MatchXRefAddr(cur + 6, virt_start_relative, pContext->xref_database[XREF_IUsbInit_GetMaxDeviceTypeCount])) {
+            if (XbSDBi_MatchXRefAddr(cur + 6, virt_start_relative, pContext->xref_database[XREF_IUsbInit_GetMaxDeviceTypeCount])) {
                 // this is where g_DeviceType_MU hardcode address reside in.
                 xSymbolAddr = *(xbaddr*)(cur + 1);
                 break;
@@ -131,19 +131,19 @@ static bool internal_xapi_find_DeviceType_MU(iXbSymbolContext* pContext,
     }
 
     // register if g_DeviceType_MU is not valid.
-    if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_g_DeviceType_MU])) {
+    if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_g_DeviceType_MU])) {
 
         // Register g_DeviceType_MU
         OOVPATable* pSymbolEntry = NULL;
-        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_MU);
-        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, pSymbolEntry->revisions[0].Version, xSymbolAddr);
+        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_MU);
+        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, pSymbolEntry->revisions[0].Version, xSymbolAddr);
     }
 
     return true;
 }
 
-static bool internal_xapi_find_device_types(iXbSymbolContext* pContext,
-                                            const iXbSymbolLibrarySession* pLibrarySession,
+static bool internal_xapi_find_device_types(XbSDBiContext* pContext,
+                                            const XbSDBiLibrarySession* pLibrarySession,
                                             SymbolDatabaseList* pLibraryDB,
                                             const XbSDBSection* pSection,
                                             uintptr_t virt_start_relative)
@@ -151,30 +151,30 @@ static bool internal_xapi_find_device_types(iXbSymbolContext* pContext,
     xbaddr xSymbolAddr = 0;
 
     // Find GetTypeInformation_4 function
-    if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_GetTypeInformation_4])) {
-        xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                     pLibrarySession,
-                                                                                     pLibraryDB,
-                                                                                     pSection,
-                                                                                     XREF_GetTypeInformation_4,
-                                                                                     DB_ST_MANUAL,
-                                                                                     FIRSTPASS_YES,
-                                                                                     REGISTER_YES,
-                                                                                     NULL,
-                                                                                     NULL);
+    if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_GetTypeInformation_4])) {
+        xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                   pLibrarySession,
+                                                                                   pLibraryDB,
+                                                                                   pSection,
+                                                                                   XREF_GetTypeInformation_4,
+                                                                                   DB_ST_MANUAL,
+                                                                                   FIRSTPASS_YES,
+                                                                                   REGISTER_YES,
+                                                                                   NULL,
+                                                                                   NULL);
 
         // If GetTypeInformation_4 is not found, then try find GetTypeInformation_8
         if (!xSymbolAddr) {
-            xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                         pLibrarySession,
-                                                                                         pLibraryDB,
-                                                                                         pSection,
-                                                                                         XREF_GetTypeInformation_8,
-                                                                                         DB_ST_MANUAL,
-                                                                                         FIRSTPASS_YES,
-                                                                                         REGISTER_YES,
-                                                                                         NULL,
-                                                                                         NULL);
+            xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                       pLibrarySession,
+                                                                                       pLibraryDB,
+                                                                                       pSection,
+                                                                                       XREF_GetTypeInformation_8,
+                                                                                       DB_ST_MANUAL,
+                                                                                       FIRSTPASS_YES,
+                                                                                       REGISTER_YES,
+                                                                                       NULL,
+                                                                                       NULL);
         }
 
         // If either GetTypeInformation overload is found, start look up in DeviceTypeInfo table's entries.
@@ -182,13 +182,13 @@ static bool internal_xapi_find_device_types(iXbSymbolContext* pContext,
 
             // TODO: Make below as self-register
             OOVPATable* pSymbolEntry = NULL;
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceTypeInfoTableBegin);
-            internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 4242);
-            internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceTypeInfoTableEnd);
-            internal_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 4242);
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceTypeInfoTableBegin);
+            XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 4242);
+            XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceTypeInfoTableEnd);
+            XbSDBi_RegisterSelfValidXRefAddr(pContext, pLibrarySession, pSymbolEntry, 4242);
 
-            uint32_t* table_i = (uint32_t*)internal_section_VirtToHostAddress(pContext, pContext->xref_database[XREF_g_DeviceTypeInfoTableBegin]);
-            uint32_t* table_end = (uint32_t*)internal_section_VirtToHostAddress(pContext, pContext->xref_database[XREF_g_DeviceTypeInfoTableEnd]);
+            uint32_t* table_i = (uint32_t*)XbSDBi_section_VirtToHostAddress(pContext, pContext->xref_database[XREF_g_DeviceTypeInfoTableBegin]);
+            uint32_t* table_end = (uint32_t*)XbSDBi_section_VirtToHostAddress(pContext, pContext->xref_database[XREF_g_DeviceTypeInfoTableEnd]);
             size_t type_description_table_count = ((memptr_t)table_end - (memptr_t)table_i) / sizeof(uint32_t);
 
             output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_DEBUG, "DeviceTypeInfoTable Entries: %u", type_description_table_count);
@@ -204,32 +204,32 @@ static bool internal_xapi_find_device_types(iXbSymbolContext* pContext,
             // Iterate through the table until we find known device types.
             int i = 0;
             for (; table_i < table_end; table_i++, i++) {
-                PXID_TYPE_INFORMATION DeviceTypeInfo = (PXID_TYPE_INFORMATION)internal_section_VirtToHostAddress(pContext, *table_i);
+                PXID_TYPE_INFORMATION DeviceTypeInfo = (PXID_TYPE_INFORMATION)XbSDBi_section_VirtToHostAddress(pContext, *table_i);
                 if (!DeviceTypeInfo) {
                     // if address is nullptr, then skip it.
                     continue;
                 }
                 switch (DeviceTypeInfo->ucType) {
                     case 1: // Gamepad (Generic)
-                        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_Gamepad);
-                        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
+                        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_Gamepad);
+                        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
                         break;
                     case 2: // Keyboard
-                        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_Keyboard);
-                        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
+                        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_Keyboard);
+                        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
                         break;
                     case 3: // IR Dongle
-                        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_IRDongle);
-                        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
+                        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_IRDongle);
+                        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
                         break;
                     case 4: // Mouse
                         // NOTE: Possibly introduced when Phantasy Star Online (b4831) added keyboard support.
-                        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_Mouse);
-                        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
+                        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_Mouse);
+                        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 0, DeviceTypeInfo->XppType);
                         break;
                     case 128: // Steel Battalion
-                        internal_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_SBC);
-                        internal_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 4242, DeviceTypeInfo->XppType);
+                        XbSDBi_FindByReferenceHelper(pContext, pLibraryDB, pSymbolEntry, g_DeviceType_SBC);
+                        XbSDBi_RegisterSymbol(pContext, pLibrarySession, pSymbolEntry, 4242, DeviceTypeInfo->XppType);
                         break;
                     default: // Unknown
                         output_message_format(&pContext->output, XB_OUTPUT_MESSAGE_WARN, "Unknown device type, DeviceTypeInfoTable[%hhu]:  ucType = %hhu, XppType = %08X", i, DeviceTypeInfo->ucType, DeviceTypeInfo->XppType);
@@ -239,17 +239,17 @@ static bool internal_xapi_find_device_types(iXbSymbolContext* pContext,
         }
         else {
             // Find XInputOpen function
-            if (!internal_IsXRefAddrValid(pContext->xref_database[XREF_XInputOpen])) {
-                xSymbolAddr = (xbaddr)(uintptr_t)internal_SymbolDatabaseList_ScanByReference(pContext,
-                                                                                             pLibrarySession,
-                                                                                             pLibraryDB,
-                                                                                             pSection,
-                                                                                             XREF_XInputOpen,
-                                                                                             DB_ST_MANUAL,
-                                                                                             FIRSTPASS_YES,
-                                                                                             REGISTER_YES,
-                                                                                             NULL,
-                                                                                             NULL);
+            if (!XbSDBi_IsXRefAddrValid(pContext->xref_database[XREF_XInputOpen])) {
+                xSymbolAddr = (xbaddr)(uintptr_t)XbSDBi_SymbolDatabaseList_ScanByReference(pContext,
+                                                                                           pLibrarySession,
+                                                                                           pLibraryDB,
+                                                                                           pSection,
+                                                                                           XREF_XInputOpen,
+                                                                                           DB_ST_MANUAL,
+                                                                                           FIRSTPASS_YES,
+                                                                                           REGISTER_YES,
+                                                                                           NULL,
+                                                                                           NULL);
                 // No further manual action require.
             }
         }
@@ -262,8 +262,8 @@ static bool internal_xapi_find_device_types(iXbSymbolContext* pContext,
     return true;
 };
 
-static bool manual_scan_section_xapilib(iXbSymbolContext* pContext,
-                                        const iXbSymbolLibrarySession* pLibrarySession,
+static bool manual_scan_section_xapilib(XbSDBiContext* pContext,
+                                        const XbSDBiLibrarySession* pLibrarySession,
                                         SymbolDatabaseList* pLibraryDB,
                                         const XbSDBSection* pSection)
 {
@@ -279,26 +279,26 @@ static bool manual_scan_section_xapilib(iXbSymbolContext* pContext,
     return foundXGetSectionSize && foundMURefs && foundDeviceTypes;
 }
 
-static inline void manual_register_xapilib(iXbSymbolContext* pContext)
+static inline void manual_register_xapilib(XbSDBiContext* pContext)
 {
     // TODO: Make everything below have ability to perform self-register. (but we need difference between virtual and relative address.... can it be built-in support?)
     //       Actually, let's make a separate pull request for this...
     // NOTE: These device types can be self-register according to XInputOpen signature. But newer implementation require manual search.
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceType_Gamepad, 0, "g_DeviceType_Gamepad", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceType_IRDongle, 0, "g_DeviceType_IRDongle", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceType_Keyboard, 0, "g_DeviceType_Keyboard", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceType_Mouse, 0, "g_DeviceType_Mouse", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceType_SBC, 4242, "g_DeviceType_SBC", symbol_variable, call_none, 0, NULL);
-    //internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceTypeInfoTableBegin, 4242, "g_DeviceTypeInfoTableBegin", symbol_variable, call_none, 0, NULL);
-    //internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_DeviceTypeInfoTableEnd, 4242, "g_DeviceTypeInfoTableEnd", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceType_Gamepad, 0, "g_DeviceType_Gamepad", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceType_IRDongle, 0, "g_DeviceType_IRDongle", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceType_Keyboard, 0, "g_DeviceType_Keyboard", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceType_Mouse, 0, "g_DeviceType_Mouse", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceType_SBC, 4242, "g_DeviceType_SBC", symbol_variable, call_none, 0, NULL);
+    //XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceTypeInfoTableBegin, 4242, "g_DeviceTypeInfoTableBegin", symbol_variable, call_none, 0, NULL);
+    //XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_DeviceTypeInfoTableEnd, 4242, "g_DeviceTypeInfoTableEnd", symbol_variable, call_none, 0, NULL);
     // TODO: The above could actually do self-register but... do we need to?
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_XapiAltLett_MU, 0, "g_XapiAltLett_MU", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_XapiMountedMUs, 0, "g_XapiMountedMUs", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_g_XapiCurrentTopLevelFilter, 0, "g_XapiCurrentTopLevelFilter", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF__tls_array, 0, "_tls_array", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF__tls_index, 0, "_tls_index", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_XapiCurrentFiber_OFFSET, 0, "XapiCurrentFiber_OFFSET", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_XapiLastErrorCode_OFFSET, 0, "XapiLastErrorCode_OFFSET", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_XapiThreadFiberData_OFFSET, 0, "XapiThreadFiberData_OFFSET", symbol_variable, call_none, 0, NULL);
-    internal_RegisterValidXRefAddr(pContext, Lib_XAPILIB, XbSymbolLib_XAPILIB, XREF_XapiThreadNotifyRoutineList, 0, "XapiThreadNotifyRoutineList", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_XapiAltLett_MU, 0, "g_XapiAltLett_MU", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_XapiMountedMUs, 0, "g_XapiMountedMUs", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_g_XapiCurrentTopLevelFilter, 0, "g_XapiCurrentTopLevelFilter", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF__tls_array, 0, "_tls_array", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF__tls_index, 0, "_tls_index", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_XapiCurrentFiber_OFFSET, 0, "XapiCurrentFiber_OFFSET", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_XapiLastErrorCode_OFFSET, 0, "XapiLastErrorCode_OFFSET", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_XapiThreadFiberData_OFFSET, 0, "XapiThreadFiberData_OFFSET", symbol_variable, call_none, 0, NULL);
+    XbSDBi_RegisterValidXRefAddr(pContext, LIB_XAPILIB, XBSDBLIB_XAPILIB, XREF_XapiThreadNotifyRoutineList, 0, "XapiThreadNotifyRoutineList", symbol_variable, call_none, 0, NULL);
 }

--- a/src/test/libverify.cpp
+++ b/src/test/libverify.cpp
@@ -130,7 +130,7 @@ bool match_library_db(std::map<uint32_t, symbol_result>& list,
         // If a match is not found, then we need to push the generic symbol
         // name into missing list.
         if (found_xref == list.end()) {
-            missing.push_back(XbSymbolDatabase_SymbolReferenceToString(xref->first));
+            missing.push_back(XbSDB_SymbolReferenceToString(xref->first));
             continue;
         }
 
@@ -461,28 +461,28 @@ bool run_test_verify_libraries()
     size_t error_count = 0;
     library_db lib_db;
     getLibraryD3D8(lib_db);
-    run_test_verify_library(Lib_D3D8, lib_db, error_count);
+    run_test_verify_library(LIB_D3D8, lib_db, error_count);
 
     getLibraryDSOUND(lib_db);
-    run_test_verify_library(Lib_DSOUND, lib_db, error_count);
+    run_test_verify_library(LIB_DSOUND, lib_db, error_count);
 
     getLibraryJVS(lib_db);
-    run_test_verify_library(Lib_JVS, lib_db, error_count);
+    run_test_verify_library(LIB_JVS, lib_db, error_count);
 
     getLibraryXACTENG(lib_db);
-    run_test_verify_library(Lib_XACTENG, lib_db, error_count);
+    run_test_verify_library(LIB_XACTENG, lib_db, error_count);
 
     getLibraryXAPILIB(lib_db);
-    run_test_verify_library(Lib_XAPILIB, lib_db, error_count);
+    run_test_verify_library(LIB_XAPILIB, lib_db, error_count);
 
     getLibraryXGRAPHIC(lib_db);
-    run_test_verify_library(Lib_XGRAPHC, lib_db, error_count);
+    run_test_verify_library(LIB_XGRAPHC, lib_db, error_count);
 
     getLibraryXNET(lib_db);
-    run_test_verify_library(Lib_XNET, lib_db, error_count);
+    run_test_verify_library(LIB_XNET, lib_db, error_count);
 
     getLibraryXONLINE(lib_db);
-    run_test_verify_library(Lib_XONLINE, lib_db, error_count);
+    run_test_verify_library(LIB_XONLINE, lib_db, error_count);
 
     if (error_count) {
         return false;
@@ -597,37 +597,37 @@ void run_test_verify_symbols(lib_versions& lib_vers,
 
     getLibraryD3D8(lib_db);
     if (lib_vers.d3d8ltcg) {
-        constexpr auto XbSymbolLib_D3D8LTCG_flags =
-            XbSymbolLib_D3D8LTCG | XbSymbolLib_D3D8;
-        run_test_verify_symbol(symbols_list, Lib_D3D8LTCG, lib_vers.d3d8ltcg, XbSymbolLib_D3D8LTCG_flags, lib_db, full_lib_count, error_count);
+        constexpr auto XBSDBLIB_D3D8LTCG_flags =
+            XBSDBLIB_D3D8LTCG | XBSDBLIB_D3D8;
+        run_test_verify_symbol(symbols_list, LIB_D3D8LTCG, lib_vers.d3d8ltcg, XBSDBLIB_D3D8LTCG_flags, lib_db, full_lib_count, error_count);
     }
     else {
-        run_test_verify_symbol(symbols_list, Lib_D3D8, lib_vers.d3d8, XbSymbolLib_D3D8, lib_db, full_lib_count, error_count);
+        run_test_verify_symbol(symbols_list, LIB_D3D8, lib_vers.d3d8, XBSDBLIB_D3D8, lib_db, full_lib_count, error_count);
     }
 
     getLibraryDSOUND(lib_db);
-    run_test_verify_symbol(symbols_list, Lib_DSOUND, lib_vers.dsound, XbSymbolLib_DSOUND, lib_db, full_lib_count, error_count);
+    run_test_verify_symbol(symbols_list, LIB_DSOUND, lib_vers.dsound, XBSDBLIB_DSOUND, lib_db, full_lib_count, error_count);
 
     getLibraryJVS(lib_db);
-    run_test_verify_symbol(symbols_list, Lib_JVS, lib_vers.jvs, XbSymbolLib_JVS, lib_db, full_lib_count, error_count);
+    run_test_verify_symbol(symbols_list, LIB_JVS, lib_vers.jvs, XBSDBLIB_JVS, lib_db, full_lib_count, error_count);
 
     getLibraryXACTENG(lib_db);
-    run_test_verify_symbol(symbols_list, Lib_XACTENG, lib_vers.xacteng, XbSymbolLib_XACTENG, lib_db, full_lib_count, error_count);
+    run_test_verify_symbol(symbols_list, LIB_XACTENG, lib_vers.xacteng, XBSDBLIB_XACTENG, lib_db, full_lib_count, error_count);
 
     getLibraryXAPILIB(lib_db);
-    run_test_verify_symbol(symbols_list, Lib_XAPILIB, lib_vers.xapilib, XbSymbolLib_XAPILIB, lib_db, full_lib_count, error_count);
+    run_test_verify_symbol(symbols_list, LIB_XAPILIB, lib_vers.xapilib, XBSDBLIB_XAPILIB, lib_db, full_lib_count, error_count);
 
     getLibraryXGRAPHIC(lib_db);
-    run_test_verify_symbol(symbols_list, Lib_XGRAPHC, lib_vers.xgraphic, XbSymbolLib_XGRAPHC, lib_db, full_lib_count, error_count);
+    run_test_verify_symbol(symbols_list, LIB_XGRAPHC, lib_vers.xgraphic, XBSDBLIB_XGRAPHC, lib_db, full_lib_count, error_count);
 
     getLibraryXNET(lib_db);
-    constexpr auto XbSymbolLib_XNET_flags =
-        XbSymbolLib_XNET | XbSymbolLib_XNETS | XbSymbolLib_XNETN |
-        XbSymbolLib_XONLINE | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS;
-    run_test_verify_symbol(symbols_list, Lib_XNET, lib_vers.xnet, XbSymbolLib_XNET_flags, lib_db, full_lib_count, error_count);
+    constexpr auto XBSDBLIB_XNET_flags =
+        XBSDBLIB_XNET | XBSDBLIB_XNETS | XBSDBLIB_XNETN |
+        XBSDBLIB_XONLINE | XBSDBLIB_XONLINES | XBSDBLIB_XONLINLS;
+    run_test_verify_symbol(symbols_list, LIB_XNET, lib_vers.xnet, XBSDBLIB_XNET_flags, lib_db, full_lib_count, error_count);
 
     getLibraryXONLINE(lib_db);
-    constexpr auto XbSymbolLib_XONLINE_flags =
-        XbSymbolLib_XONLINE | XbSymbolLib_XONLINES | XbSymbolLib_XONLINLS;
-    run_test_verify_symbol(symbols_list, Lib_XONLINE, lib_vers.xonline, XbSymbolLib_XONLINE_flags, lib_db, full_lib_count, error_count);
+    constexpr auto XBSDBLIB_XONLINE_flags =
+        XBSDBLIB_XONLINE | XBSDBLIB_XONLINES | XBSDBLIB_XONLINLS;
+    run_test_verify_symbol(symbols_list, LIB_XONLINE, lib_vers.xonline, XBSDBLIB_XONLINE_flags, lib_db, full_lib_count, error_count);
 }

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -308,7 +308,7 @@ static void EmuRegisterSymbol(const char* library_str,
     if (xref_index == -1) {
         std::stringstream gen_str;
         gen_str << "Symbol could not be register due to xref index is -1: "
-            << XbSymbolDatabase_LibraryToString(library_flag) << " (b"
+            << XbSDB_LibraryToString(library_flag) << " (b"
             << std::dec << std::setfill('0') << std::setw(4) << build << ") 0x"
             << std::setfill('0') << std::setw(8) << std::hex << symbol_addr
             << " -> " << symbol_str;
@@ -336,12 +336,12 @@ static void EmuRegisterSymbol(const char* library_str,
 
             std::stringstream gen_str;
             gen_str << "Symbol names returned for same xref index: \n"
-                << XbSymbolDatabase_LibraryToString(hasSymbol.library_flag)
+                << XbSDB_LibraryToString(hasSymbol.library_flag)
                 << " (b" << std::dec << std::setfill('0') << std::setw(4)
                 << hasSymbol.build << ") 0x" << std::setfill('0')
                 << std::setw(8) << std::hex << hasSymbol.addr << " -> "
                 << hasSymbol.symbol << "\nvs\n"
-                << XbSymbolDatabase_LibraryToString(library_flag) << " (b"
+                << XbSDB_LibraryToString(library_flag) << " (b"
                 << std::dec << std::setfill('0') << std::setw(4) << build
                 << ") 0x" << std::setfill('0') << std::setw(8) << std::hex
                 << symbol_addr << " -> " << symbol_str;
@@ -355,7 +355,7 @@ static void EmuRegisterSymbol(const char* library_str,
 
     std::stringstream gen_str;
     gen_str << "Symbol Detected: "
-              << std::setw(8) << XbSymbolDatabase_LibraryToString(library_flag) << " (b"
+              << std::setw(8) << XbSDB_LibraryToString(library_flag) << " (b"
               << std::dec << std::setw(4) << std::setfill('0') << build
               << ") 0x" << std::setw(8) << std::hex
               << symbol_addr << " -> " << symbol_str;
@@ -436,7 +436,7 @@ static bool VerifyXbeIsBuiltWithXDK(const xbe_header* pXbeHeader,
     const char* section_str;
 
     // Output Symbol Database version
-    XbSUT_OutputMessage<false>(XB_OUTPUT_MESSAGE_INFO, "XbSymbolDatabase_LibraryVersion: " + std::to_string(XbSymbolDatabase_LibraryVersion()));;
+    XbSUT_OutputMessage<false>(XB_OUTPUT_MESSAGE_INFO, "XbSDB_LibraryVersion: " + std::to_string(XbSDB_LibraryVersion()));;
 
     // Store Certificate Details
     const auto& title_name = getXbeTitle(pXbeHeader);
@@ -475,34 +475,34 @@ static bool VerifyXbeIsBuiltWithXDK(const xbe_header* pXbeHeader,
         }
 
         // Translate string to flag for quicker assignment.
-        uint32_t lib_flag = XbSymbolDatabase_LibraryToFlag(LibraryName.c_str());
+        uint32_t lib_flag = XbSDB_LibraryToFlag(LibraryName.c_str());
         switch (lib_flag) {
-            case XbSymbolLib_D3D8:
+            case XBSDBLIB_D3D8:
                 lib_vers.d3d8 = pLibraryVersion[i].wBuildVersion;
                 break;
-            case XbSymbolLib_D3D8LTCG:
+            case XBSDBLIB_D3D8LTCG:
                 lib_vers.d3d8ltcg = pLibraryVersion[i].wBuildVersion;
                 break;
 #if 0
-            case XbSymbolLib_D3DX8:
+            case XBSDBLIB_D3DX8:
                 lib_vers.d3dx8 = pLibraryVersion[i].wBuildVersion;
                 break;
 #endif
-            case XbSymbolLib_DSOUND:
+            case XBSDBLIB_DSOUND:
                 lib_vers.dsound = pLibraryVersion[i].wBuildVersion;
                 break;
-            case XbSymbolLib_XACTENG:
+            case XBSDBLIB_XACTENG:
                 lib_vers.xacteng = pLibraryVersion[i].wBuildVersion;
                 break;
-            case XbSymbolLib_XAPILIB:
+            case XBSDBLIB_XAPILIB:
                 lib_vers.xapilib = pLibraryVersion[i].wBuildVersion;
                 break;
-            case XbSymbolLib_XGRAPHC:
+            case XBSDBLIB_XGRAPHC:
                 lib_vers.xgraphic = pLibraryVersion[i].wBuildVersion;
                 break;
-            case XbSymbolLib_XNET:
-            case XbSymbolLib_XNETN:
-            case XbSymbolLib_XNETS:
+            case XBSDBLIB_XNET:
+            case XBSDBLIB_XNETN:
+            case XBSDBLIB_XNETS:
                 lib_vers.xnet = pLibraryVersion[i].wBuildVersion;
                 // Technically, it is combined with XONLINE library. So, check
                 // if XONLINE doesn't exist then force check.
@@ -510,9 +510,9 @@ static bool VerifyXbeIsBuiltWithXDK(const xbe_header* pXbeHeader,
                     lib_vers.xonline = pLibraryVersion[i].wBuildVersion;
                 }
                 break;
-            case XbSymbolLib_XONLINE:
-            case XbSymbolLib_XONLINES:
-            case XbSymbolLib_XONLINLS:
+            case XBSDBLIB_XONLINE:
+            case XBSDBLIB_XONLINES:
+            case XBSDBLIB_XONLINLS:
                 lib_vers.xonline = pLibraryVersion[i].wBuildVersion;
                 // Technically, it is combined with XNET library. So, check if
                 // XNET doesn't exist then force check.
@@ -531,7 +531,7 @@ static bool VerifyXbeIsBuiltWithXDK(const xbe_header* pXbeHeader,
             section_str = reinterpret_cast<const char*>(
                 xb_start_addr + pSections[i].SectionNameAddr);
 
-            if (std::strncmp(section_str, Lib_DSOUND, 8) == 0) {
+            if (std::strncmp(section_str, LIB_DSOUND, 8) == 0) {
                 lib_vers.dsound = buildVersion;
                 XbSUT_OutputMessage<false>(XB_OUTPUT_MESSAGE_INFO, "Library Name[ ?]      : DSOUND   (b" + std::to_string(buildVersion) + ")");
                 gen_result.SetLongValue(section_libs, sect_libs.DSOUND, buildVersion);
@@ -564,7 +564,7 @@ static bool GetXbSymbolDatabaseFilters(const xbe_header* pXbeHeader,
     std::string error_msg = "unknown";
 
     library_output.count =
-        XbSymbolDatabase_GenerateLibraryFilter(pXbeHeader, nullptr);
+        XbSDB_GenerateLibraryFilter(pXbeHeader, nullptr);
 
     if (library_output.count != 0) {
         library_output.filters = new XbSDBLibrary[library_output.count];
@@ -580,10 +580,10 @@ static bool GetXbSymbolDatabaseFilters(const xbe_header* pXbeHeader,
         goto scanError;
     }
 
-    (void)XbSymbolDatabase_GenerateLibraryFilter(pXbeHeader, &library_output);
+    (void)XbSDB_GenerateLibraryFilter(pXbeHeader, &library_output);
 
     section_output.count =
-        XbSymbolDatabase_GenerateSectionFilter(pXbeHeader, nullptr, is_raw);
+        XbSDB_GenerateSectionFilter(pXbeHeader, nullptr, is_raw);
 
     if (section_output.count != 0) {
         section_output.filters = new XbSDBSection[section_output.count];
@@ -599,7 +599,7 @@ static bool GetXbSymbolDatabaseFilters(const xbe_header* pXbeHeader,
         goto scanError;
     }
 
-    (void)XbSymbolDatabase_GenerateSectionFilter(pXbeHeader, &section_output, is_raw);
+    (void)XbSDB_GenerateSectionFilter(pXbeHeader, &section_output, is_raw);
     return true;
 
 scanError:
@@ -673,7 +673,7 @@ static void ScanXbe(const xbe_header* pXbeHeader, bool is_raw)
     // start.
     g_SymbolAddresses.clear();
 
-    XbSymbolContextHandle pHandle;
+    XbSDBContextHandle pHandle;
     XbSDBLibraryHeader library_input = {};
     XbSDBSectionHeader section_input = {};
 
@@ -681,39 +681,39 @@ static void ScanXbe(const xbe_header* pXbeHeader, bool is_raw)
         return;
     }
 
-    xbaddr kt_addr = XbSymbolDatabase_GetKernelThunkAddress(pXbeHeader);
+    xbaddr kt_addr = XbSDB_GetKernelThunkAddress(pXbeHeader);
 
-    if (!XbSymbolDatabase_CreateXbSymbolContext(&pHandle, EmuRegisterSymbol, library_input, section_input, kt_addr)) {
-        error_msg = "Unable to create XbSymbolContext handle.";
+    if (!XbSDB_CreateContext(&pHandle, EmuRegisterSymbol, library_input, section_input, kt_addr)) {
+        error_msg = "Unable to create XbSDBContext handle.";
     }
     else {
 
         // delete[] library_input.filters;
         // library_input.filters = nullptr;
-        // We no longer need section_input variable as XbSymbolDatabase_CreateXbSymbolContext will store it internally.
+        // We no longer need section_input variable as XbSDB_CreateContext will store it internally.
         delete[] section_input.filters;
         section_input.filters = nullptr;
 
         // For output various false detection messages.
-        XbSymbolContext_SetBypassBuildVersionLimit(pHandle, true);
-        XbSymbolContext_SetContinuousSigScan(pHandle, true);
-        XbSymbolContext_SetFirstDetectAddressOnly(pHandle, true);
+        XbSDBContext_SetBypassBuildVersionLimit(pHandle, true);
+        XbSDBContext_SetContinuousSigScan(pHandle, true);
+        XbSDBContext_SetFirstDetectAddressOnly(pHandle, true);
 
-        XbSymbolContext_ScanManual(pHandle);
+        XbSDBContext_ScanManual(pHandle);
 
 #ifdef DISABLE_MULTI_THREAD
-        XbSymbolContext_ScanAllLibraryFilter(pHandle);
+        XbSDBContext_ScanAllLibraryFilter(pHandle);
 #else
         std::vector<std::thread> threads;
         uint32_t library_completion = 0;
-        auto ScanLibraryFunc = [&library_completion](XbSymbolContextHandle pHandle,
+        auto ScanLibraryFunc = [&library_completion](XbSDBContextHandle pHandle,
                                   const XbSDBLibrary* library) -> void {
-            uint32_t dependency_flags = XbSymbolContext_GetLibraryDependencies(pHandle, library->flag);
+            uint32_t dependency_flags = XbSDBContext_GetLibraryDependencies(pHandle, library->flag);
             if (dependency_flags) {
                 do {
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     std::lock_guard lck(mtx_context);
-                    if (XbSymbolDatabase_CheckDependencyCompletion(library_completion, dependency_flags)) {
+                    if (XbSDB_CheckDependencyCompletion(library_completion, dependency_flags)) {
                         break;
                     }
                 } while (true);
@@ -728,13 +728,13 @@ static void ScanXbe(const xbe_header* pXbeHeader, bool is_raw)
                 // Start library scan against symbol database we want to
                 // search for address of symbols and xreferences.
                 CurrentUnResolvedXRefs +=
-                    XbSymbolContext_ScanLibrary(pHandle, library, xref_first_pass);
+                    XbSDBContext_ScanLibrary(pHandle, library, xref_first_pass);
 
                 xref_first_pass = false;
             } while (LastUnResolvedXRefs < CurrentUnResolvedXRefs);
 
             std::lock_guard lck(mtx_context);
-            XbSymbolDatabase_SetLibraryCompletion(library_completion, library->flag);
+            XbSDB_SetLibraryCompletion(library_completion, library->flag);
         };
 
         for (unsigned i = 0; i < library_input.count; i++) {
@@ -749,9 +749,9 @@ static void ScanXbe(const xbe_header* pXbeHeader, bool is_raw)
         delete[] library_input.filters;
         library_input.filters = nullptr;
 
-        XbSymbolContext_RegisterXRefs(pHandle);
+        XbSDBContext_RegisterXRefs(pHandle);
 
-        XbSymbolContext_Release(pHandle);
+        XbSDBContext_Release(pHandle);
 
         std::cout << "\n";
 
@@ -912,13 +912,13 @@ int main(int argc, char** argv)
         g_verbose_mode = true;
     }
 
-    XbSymbolDatabase_SetOutputVerbosity(xbsdb_output);
-    XbSymbolDatabase_SetOutputMessage(XbSDb_OutputMessage);
-    XbSDB_test_error = XbSymbolDatabase_TestOOVPAs();
+    XbSDB_SetOutputVerbosity(xbsdb_output);
+    XbSDB_SetOutputMessage(XbSDb_OutputMessage);
+    XbSDB_test_error = XbSDB_TestOOVPAs();
 
     XbSUT_OutputMessage<false>(XB_OUTPUT_MESSAGE_INFO,
                                "Total symbols in XbSymbolDatabase: " +
-                                   std::to_string(XbSymbolDatabase_GetTotalSymbols(XbSymbolLib_ALL)));
+                                   std::to_string(XbSDB_GetTotalSymbols(XBSDBLIB_ALL)));
 
     // Perform self test to verify all symbol registers are validated.
     if (!run_test_verify_libraries()) {
@@ -1032,7 +1032,7 @@ int main(int argc, char** argv)
         // Now report what's missing compared to other.
         for (const auto& xref : g_SymbolAddresses) {
             std::cout << "ERROR  : g_SymbolAddressesRaw is missing "
-                      << XbSymbolDatabase_LibraryToString(xref.second.library_flag)
+                      << XbSDB_LibraryToString(xref.second.library_flag)
                       << " (b" << std::dec << std::setfill('0') << std::setw(4)
                       << xref.second.build
                       << ") 0x" << std::hex << std::setfill('0') << std::setw(8)
@@ -1041,7 +1041,7 @@ int main(int argc, char** argv)
         }
         for (const auto& xref : g_SymbolAddressesRaw) {
             std::cout << "ERROR  : g_SymbolAddresses is missing "
-                      << XbSymbolDatabase_LibraryToString(xref.second.library_flag)
+                      << XbSDB_LibraryToString(xref.second.library_flag)
                       << " (b" << std::dec << std::setfill('0') << std::setw(4)
                       << xref.second.build
                       << ") 0x" << std::hex << std::setfill('0') << std::setw(8)


### PR DESCRIPTION
close #78 

Changes were made to standardize the prefix of `XbSDB` for public APIs and `XbSDBi` for internal use only. The only prefix that does not have `XbSDBi` is `manual_` prefix functions.

I noticed some definitions that were not in full caps have also been updated. And missing static to one of the internal functions.