### PR TITLE
Minor fixes to unittest and future internal oovpa signatures conflict

### DIFF
--- a/src/OOVPADatabase/OOVPA.h
+++ b/src/OOVPADatabase/OOVPA.h
@@ -162,10 +162,10 @@ typedef struct _LOOVPA {
 // clang-format on
 
 #define OOVPA_SIG_HEADER_XREF_EXTEND(Name, Version, XRefCount, DetectSelect) \
-    LOOVPA Name##_##Version = { VARPADSET, XRefCount, DetectSelect,
+    static LOOVPA Name##_##Version = { VARPADSET, XRefCount, DetectSelect,
 
 #define OOVPA_XREF_EXTEND(Name, Version, Count, XRefCount, DetectSelect) \
-    LOOVPA Name##_##Version = { VARPADSET, XRefCount, DetectSelect, Count,
+    static LOOVPA Name##_##Version = { VARPADSET, XRefCount, DetectSelect, Count,
 
 #define OOVPA_SIG_HEADER_XREF_DETECT OOVPA_SIG_HEADER_XREF_EXTEND
 

--- a/src/test/libverify/D3D8.cpp
+++ b/src/test/libverify/D3D8.cpp
@@ -363,7 +363,7 @@ static const library_list database_full = {
     REGISTER_SYMBOL_INLINE(D3DDevice_SetVertexShaderConstant4, VER_RANGE(4627)),
     REGISTER_SYMBOLS(D3DDevice_SetVertexShaderConstantNotInline,
                      REGISTER_SYMBOL(D3DDevice_SetVertexShaderConstantNotInline, VER_RANGE(4627)),
-                     REGISTER_SYMBOL(D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_eax2_edx3, VER_RANGE(4627))),
+                     REGISTER_SYMBOL(D3DDevice_SetVertexShaderConstantNotInline_0__LTCG_ebx1_edx2_eax3, VER_RANGE(4627))),
     REGISTER_SYMBOL_INLINE(D3DDevice_SetVertexShaderConstantNotInlineFast, VER_RANGE(4627)),
     REGISTER_SYMBOL_INLINE(D3DDevice_SetVertexShaderInput, VER_RANGE(3911)),
     REGISTER_SYMBOL_INLINE(D3DDevice_SetVertexShaderInputDirect, VER_RANGE(4361)),


### PR DESCRIPTION
One commit is forgotten to add to the #221 pull request with the unittest's symbol renamed.

The other commit is mainly to keep OOVPA signatures local only to OOVPA's group files. I am not entirely sure how this was missed duration of untangling from the manual scan process needs to access the OOVPA signatures directly. Relative to #218 pull request.